### PR TITLE
Replace MatchesPath with MatchesURL

### DIFF
--- a/director/director_test.go
+++ b/director/director_test.go
@@ -40,14 +40,14 @@ func TestProxy(t *testing.T) {
 	proxy := httptest.NewServer(&httputil.ReverseProxy{Director: d.Director, Transport: d})
 	defer proxy.Close()
 
-	publicRule := rule.Rule{MatchesMethods: []string{"GET"}, MatchesPathCompiled: mustCompileRegex(t, "/users/[0-9]+"), AllowAnonymous: true}
-	disabledRule := rule.Rule{MatchesMethods: []string{"GET"}, MatchesPathCompiled: mustCompileRegex(t, "/users/[0-9]+"), BypassAuthorization: true}
+	publicRule := rule.Rule{MatchesMethods: []string{"GET"}, MatchesURLCompiled: mustCompileRegex(t, "/users/[0-9]+"), AllowAnonymous: true}
+	disabledRule := rule.Rule{MatchesMethods: []string{"GET"}, MatchesURLCompiled: mustCompileRegex(t, "/users/[0-9]+"), BypassAuthorization: true}
 	privateRule := rule.Rule{
-		MatchesMethods:      []string{"GET"},
-		MatchesPathCompiled: mustCompileRegex(t, "/users/([0-9]+)"),
-		RequiredResource:    "users:$1",
-		RequiredAction:      "get:$1",
-		RequiredScopes:      []string{"users.create"},
+		MatchesMethods:     []string{"GET"},
+		MatchesURLCompiled: mustCompileRegex(t, "/users/([0-9]+)"),
+		RequiredResource:   "users:$1",
+		RequiredAction:     "get:$1",
+		RequiredScopes:     []string{"users.create"},
 	}
 
 	for k, tc := range []struct {

--- a/docs/api.swagger.json
+++ b/docs/api.swagger.json
@@ -272,10 +272,10 @@
           },
           "x-go-name": "MatchesMethods"
         },
-        "matchesPath": {
-          "description": "MatchesPathCompiled is a regular expression of paths this rule matches.",
+        "matchesUrl": {
+          "description": "MatchesURL is a regular expression of paths this rule matches.",
           "type": "string",
-          "x-go-name": "MatchesPath"
+          "x-go-name": "MatchesURL"
         },
         "requiredAction": {
           "description": "RequiredScopes is the action this rule requires.",

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -31,28 +31,28 @@ func mustGenerateURL(t *testing.T, u string) *url.URL {
 
 func TestEvaluator(t *testing.T) {
 	we := NewWardenEvaluator(nil, nil, nil)
-	publicRule := rule.Rule{MatchesMethods: []string{"GET"}, MatchesPathCompiled: mustCompileRegex(t, "/users/<[0-9]+>"), AllowAnonymous: true}
-	bypassACPRule := rule.Rule{MatchesMethods: []string{"GET"}, MatchesPathCompiled: mustCompileRegex(t, "/users/<[0-9]+>"), BypassAccessControlPolicies: true}
+	publicRule := rule.Rule{MatchesMethods: []string{"GET"}, MatchesURLCompiled: mustCompileRegex(t, "https://localhost/users/<[0-9]+>"), AllowAnonymous: true}
+	bypassACPRule := rule.Rule{MatchesMethods: []string{"GET"}, MatchesURLCompiled: mustCompileRegex(t, "https://localhost/users/<[0-9]+>"), BypassAccessControlPolicies: true}
 	privateRuleWithSubstitution := rule.Rule{
-		MatchesMethods:      []string{"POST"},
-		MatchesPathCompiled: mustCompileRegex(t, "/users/<[0-9]+>"),
-		RequiredResource:    "users:$1",
-		RequiredAction:      "get:$1",
-		RequiredScopes:      []string{"users.create"},
+		MatchesMethods:     []string{"POST"},
+		MatchesURLCompiled: mustCompileRegex(t, "https://localhost/users/<[0-9]+>"),
+		RequiredResource:   "users:$1",
+		RequiredAction:     "get:$1",
+		RequiredScopes:     []string{"users.create"},
 	}
 	privateRuleWithoutSubstitution := rule.Rule{
-		MatchesMethods:      []string{"POST"},
-		MatchesPathCompiled: mustCompileRegex(t, "/users<$|/([0-9]+)>"),
-		RequiredResource:    "users",
-		RequiredAction:      "get",
-		RequiredScopes:      []string{"users.create"},
+		MatchesMethods:     []string{"POST"},
+		MatchesURLCompiled: mustCompileRegex(t, "https://localhost/users<$|/([0-9]+)>"),
+		RequiredResource:   "users",
+		RequiredAction:     "get",
+		RequiredScopes:     []string{"users.create"},
 	}
 	privateRuleWithPartialSubstitution := rule.Rule{
-		MatchesMethods:      []string{"POST"},
-		MatchesPathCompiled: mustCompileRegex(t, "/users<$|/([0-9]+)>"),
-		RequiredResource:    "users:$2",
-		RequiredAction:      "get",
-		RequiredScopes:      []string{"users.create"},
+		MatchesMethods:     []string{"POST"},
+		MatchesURLCompiled: mustCompileRegex(t, "https://localhost/users<$|/([0-9]+)>"),
+		RequiredResource:   "users:$2",
+		RequiredAction:     "get",
+		RequiredScopes:     []string{"users.create"},
 	}
 
 	for k, tc := range []struct {
@@ -366,15 +366,4 @@ func TestEvaluator(t *testing.T) {
 			tc.e(t, s, err)
 		})
 	}
-}
-
-func TestSubstitution(t *testing.T) {
-	reg, err := compiler.CompileRegex("/rules<$|/([^/]+)>", '<', '>')
-	fmt.Println(reg.String())
-	fmt.Printf("Found: %s\n", reg.FindAllString("/rules", -1))
-	fmt.Printf("Found: %s\n", reg.FindAllString("/rules/", -1))
-	fmt.Printf("Found: %s\n", reg.FindAllString("/rules/2423", -1))
-	fmt.Printf("Found: %s\n", reg.ReplaceAllString("/rules/2423", "read:$2"))
-	require.NoError(t, err)
-
 }

--- a/evaluator/evaluator_warden.go
+++ b/evaluator/evaluator_warden.go
@@ -132,8 +132,8 @@ func (d *WardenEvaluator) EvaluateAccessRequest(r *http.Request) (*Session, erro
 func (d *WardenEvaluator) prepareAccessRequests(r *http.Request, token string, rl *rule.Rule) swagger.WardenTokenAccessRequest {
 	return swagger.WardenTokenAccessRequest{
 		Scopes:   rl.RequiredScopes,
-		Action:   rl.MatchesPathCompiled.ReplaceAllString(r.URL.Path, rl.RequiredAction),
-		Resource: rl.MatchesPathCompiled.ReplaceAllString(r.URL.Path, rl.RequiredResource),
+		Action:   rl.MatchesURLCompiled.ReplaceAllString(r.URL.String(), rl.RequiredAction),
+		Resource: rl.MatchesURLCompiled.ReplaceAllString(r.URL.String(), rl.RequiredResource),
 		Token:    token,
 		Context: map[string]interface{}{
 			"remoteIpAddress": realip.RealIP(r),

--- a/rule/doc.go
+++ b/rule/doc.go
@@ -50,8 +50,8 @@ type jsonRule struct {
 	// MatchesMethods is a list of HTTP methods that this rule matches.
 	MatchesMethods []string `json:"matchesMethods"`
 
-	// MatchesPathCompiled is a regular expression of paths this rule matches.
-	MatchesPath string `json:"matchesPath"`
+	// MatchesURL is a regular expression of paths this rule matches.
+	MatchesURL string `json:"matchesUrl"`
 
 	// RequiredScopes is a list of scopes that are required by this rule.
 	RequiredScopes []string `json:"requiredScopes"`

--- a/rule/handler.go
+++ b/rule/handler.go
@@ -198,15 +198,15 @@ func decodeRule(w http.ResponseWriter, r *http.Request) (*Rule, error) {
 }
 
 func toRule(rule *jsonRule) (*Rule, error) {
-	exp, err := compiler.CompileRegex(rule.MatchesPath, '<', '>')
+	exp, err := compiler.CompileRegex(rule.MatchesURL, '<', '>')
 	if err != nil {
 		return nil, err
 	}
 
 	return &Rule{
 		ID:                          rule.ID,
-		MatchesPathCompiled:         exp,
-		MatchesPath:                 rule.MatchesPath,
+		MatchesURLCompiled:          exp,
+		MatchesURL:                  rule.MatchesURL,
 		MatchesMethods:              rule.MatchesMethods,
 		RequiredScopes:              rule.RequiredScopes,
 		RequiredAction:              rule.RequiredAction,
@@ -221,7 +221,7 @@ func toRule(rule *jsonRule) (*Rule, error) {
 func encodeRule(r *Rule) *jsonRule {
 	return &jsonRule{
 		ID:                          r.ID,
-		MatchesPath:                 r.MatchesPath,
+		MatchesURL:                  r.MatchesURL,
 		MatchesMethods:              r.MatchesMethods,
 		RequiredScopes:              r.RequiredScopes,
 		RequiredAction:              r.RequiredAction,

--- a/rule/handler_test.go
+++ b/rule/handler_test.go
@@ -26,7 +26,7 @@ func TestHandler(t *testing.T) {
 	r1 := swagger.Rule{
 		Id:               "foo1",
 		Description:      "Create users rule",
-		MatchesPath:      "/users/([0-9]+)",
+		MatchesUrl:       server.URL + "/users/([0-9]+)",
 		MatchesMethods:   []string{"POST"},
 		RequiredResource: "users:$1",
 		RequiredAction:   "create:$1",
@@ -34,7 +34,7 @@ func TestHandler(t *testing.T) {
 	}
 	r2 := swagger.Rule{
 		Description:                 "Get users rule",
-		MatchesPath:                 "/users/([0-9]+)",
+		MatchesUrl:                  server.URL + "/users/([0-9]+)",
 		MatchesMethods:              []string{"GET"},
 		RequiredScopes:              []string{},
 		AllowAnonymous:              true,

--- a/rule/manager_sql.go
+++ b/rule/manager_sql.go
@@ -16,7 +16,7 @@ import (
 type sqlRule struct {
 	ID                          string `db:"id"`
 	MatchesMethods              string `db:"matches_methods"`
-	MatchesPath                 string `db:"matches_path"`
+	MatchesURL                  string `db:"matches_url"`
 	RequiredScopes              string `db:"required_scopes"`
 	RequiredAction              string `db:"required_action"`
 	RequiredResource            string `db:"required_resource"`
@@ -27,7 +27,7 @@ type sqlRule struct {
 }
 
 func (r *sqlRule) toRule() (*Rule, error) {
-	exp, err := compiler.CompileRegex(r.MatchesPath, '<', '>')
+	exp, err := compiler.CompileRegex(r.MatchesURL, '<', '>')
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -44,8 +44,8 @@ func (r *sqlRule) toRule() (*Rule, error) {
 	return &Rule{
 		ID:                          r.ID,
 		MatchesMethods:              methods,
-		MatchesPathCompiled:         exp,
-		MatchesPath:                 r.MatchesPath,
+		MatchesURLCompiled:          exp,
+		MatchesURL:                  r.MatchesURL,
 		RequiredScopes:              scopes,
 		RequiredAction:              r.RequiredAction,
 		RequiredResource:            r.RequiredResource,
@@ -60,7 +60,7 @@ func toSqlRule(r *Rule) *sqlRule {
 	return &sqlRule{
 		ID:                          r.ID,
 		MatchesMethods:              strings.Join(r.MatchesMethods, " "),
-		MatchesPath:                 r.MatchesPath,
+		MatchesURL:                  r.MatchesURL,
 		RequiredScopes:              strings.Join(r.RequiredScopes, " "),
 		RequiredAction:              r.RequiredAction,
 		RequiredResource:            r.RequiredResource,
@@ -78,7 +78,7 @@ var migrations = &migrate.MemoryMigrationSource{
 			Up: []string{`CREATE TABLE IF NOT EXISTS oathkeeper_rule (
 	id      			varchar(64) NOT NULL PRIMARY KEY,
 	matches_methods		varchar(64) NOT NULL,
-	matches_path		text NOT NULL,
+	matches_url		text NOT NULL,
 	required_scopes		text NOT NULL,
 	required_action		text NOT NULL,
 	required_resource	text NOT NULL,
@@ -97,7 +97,7 @@ var migrations = &migrate.MemoryMigrationSource{
 var sqlParams = []string{
 	"id",
 	"matches_methods",
-	"matches_path",
+	"matches_url",
 	"required_scopes",
 	"required_action",
 	"required_resource",

--- a/rule/manager_test.go
+++ b/rule/manager_test.go
@@ -50,20 +50,20 @@ func TestManagers(t *testing.T) {
 	for k, manager := range managers {
 
 		r1 := Rule{
-			ID:                  "foo1",
-			Description:         "Create users rule",
-			MatchesPathCompiled: mustCompileRegex(t, "/users/([0-9]+)"),
-			MatchesPath:         "/users/([0-9]+)",
-			MatchesMethods:      []string{"POST"},
-			RequiredResource:    "users:$1",
-			RequiredAction:      "create:$1",
-			RequiredScopes:      []string{"users.create"},
+			ID:                 "foo1",
+			Description:        "Create users rule",
+			MatchesURLCompiled: mustCompileRegex(t, "/users/([0-9]+)"),
+			MatchesURL:         "/users/([0-9]+)",
+			MatchesMethods:     []string{"POST"},
+			RequiredResource:   "users:$1",
+			RequiredAction:     "create:$1",
+			RequiredScopes:     []string{"users.create"},
 		}
 		r2 := Rule{
 			ID:                          "foo2",
 			Description:                 "Get users rule",
-			MatchesPathCompiled:         mustCompileRegex(t, "/users/([0-9]+)"),
-			MatchesPath:                 "/users/([0-9]+)",
+			MatchesURLCompiled:          mustCompileRegex(t, "/users/([0-9]+)"),
+			MatchesURL:                  "/users/([0-9]+)",
 			MatchesMethods:              []string{"GET"},
 			AllowAnonymous:              true,
 			RequiredScopes:              []string{},

--- a/rule/matcher_cached.go
+++ b/rule/matcher_cached.go
@@ -15,7 +15,7 @@ type CachedMatcher struct {
 func (m *CachedMatcher) MatchRule(method string, u *url.URL) (*Rule, error) {
 	var rules []Rule
 	for _, rule := range m.Rules {
-		if err := rule.MatchesURL(method, u); err == nil {
+		if err := rule.IsMatching(method, u); err == nil {
 			rules = append(rules, rule)
 		}
 	}

--- a/rule/matcher_test.go
+++ b/rule/matcher_test.go
@@ -21,12 +21,12 @@ func generateDummyRules(amount int) []Rule {
 	for i := 0; i < amount; i++ {
 		exp, _ := compiler.CompileRegex(expressions[(i%(len(expressions)))]+"([0-"+strconv.Itoa(i)+"]+)", '<', '>')
 		rules[i] = Rule{
-			ID:                  strconv.Itoa(i),
-			MatchesMethods:      methods[:i%(len(methods))],
-			RequiredScopes:      scopes[:i%(len(scopes))],
-			RequiredAction:      actions[i%(len(actions))],
-			RequiredResource:    resources[i%(len(resources))],
-			MatchesPathCompiled: exp,
+			ID:                 strconv.Itoa(i),
+			MatchesMethods:     methods[:i%(len(methods))],
+			RequiredScopes:     scopes[:i%(len(scopes))],
+			RequiredAction:     actions[i%(len(actions))],
+			RequiredResource:   resources[i%(len(resources))],
+			MatchesURLCompiled: exp,
 		}
 	}
 	return rules

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -16,11 +16,11 @@ type Rule struct {
 	// MatchesMethods is a list of HTTP methods that this rule matches.
 	MatchesMethods []string
 
-	// MatchesPathCompiled is a regular expression of paths this rule matches.
-	MatchesPathCompiled *regexp.Regexp
+	// MatchesURLCompiled is a regular expression of paths this rule matches.
+	MatchesURLCompiled *regexp.Regexp
 
-	// MatchesPath is a regular expression of paths this rule matches.
-	MatchesPath string
+	// MatchesURL is a regular expression of paths this rule matches.
+	MatchesURL string
 
 	// RequiredScopes is a list of scopes that are required by this rule.
 	RequiredScopes []string
@@ -44,13 +44,13 @@ type Rule struct {
 	Description string
 }
 
-func (r *Rule) MatchesURL(method string, u *url.URL) error {
+func (r *Rule) IsMatching(method string, u *url.URL) error {
 	if !stringInSlice(method, r.MatchesMethods) {
 		return errors.Errorf("Method %s does not match any of %v", method, r.MatchesMethods)
 	}
 
-	if !r.MatchesPathCompiled.MatchString(u.Path) {
-		return errors.Errorf("Path %s does not match %s", u.Path, r.MatchesPath)
+	if !r.MatchesURLCompiled.MatchString(u.String()) {
+		return errors.Errorf("Path %s does not match %s", u.String(), r.MatchesURL)
 	}
 
 	return nil

--- a/sdk/swagger/docs/Rule.md
+++ b/sdk/swagger/docs/Rule.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **Description** | **string** | Description describes the rule. | [optional] [default to null]
 **Id** | **string** | ID the a unique id of a rule. | [optional] [default to null]
 **MatchesMethods** | **[]string** | MatchesMethods is a list of HTTP methods that this rule matches. | [optional] [default to null]
-**MatchesPath** | **string** | MatchesPathCompiled is a regular expression of paths this rule matches. | [optional] [default to null]
+**MatchesUrl** | **string** | MatchesURL is a regular expression of paths this rule matches. | [optional] [default to null]
 **RequiredAction** | **string** | RequiredScopes is the action this rule requires. | [optional] [default to null]
 **RequiredResource** | **string** | RequiredScopes is the resource this rule requires. | [optional] [default to null]
 **RequiredScopes** | **[]string** | RequiredScopes is a list of scopes that are required by this rule. | [optional] [default to null]

--- a/sdk/swagger/rule.go
+++ b/sdk/swagger/rule.go
@@ -31,8 +31,8 @@ type Rule struct {
 	// MatchesMethods is a list of HTTP methods that this rule matches.
 	MatchesMethods []string `json:"matchesMethods,omitempty"`
 
-	// MatchesPathCompiled is a regular expression of paths this rule matches.
-	MatchesPath string `json:"matchesPath,omitempty"`
+	// MatchesURL is a regular expression of paths this rule matches.
+	MatchesUrl string `json:"matchesUrl,omitempty"`
 
 	// RequiredScopes is the action this rule requires.
 	RequiredAction string `json:"requiredAction,omitempty"`


### PR DESCRIPTION
ping @zepatrik `matchesPath` was replaced with `matchesUrl`, which matches a full URL such as `https://my-domain/some/path/some/<.*regex>`