### PR TITLE
cmd: correct logging typo

### DIFF
--- a/cmd/serve_proxy.go
+++ b/cmd/serve_proxy.go
@@ -157,7 +157,7 @@ func runProxy(c *proxyConfig) {
 	}
 
 	n := negroni.New()
-	n.Use(negronilogrus.NewMiddlewareFromLogger(logger, "oahtkeeper-proxy"))
+	n.Use(negronilogrus.NewMiddlewareFromLogger(logger, "oathkeeper-proxy"))
 	n.Use(segmentMiddleware)
 	n.UseHandler(proxy)
 


### PR DESCRIPTION
This corrects logging from 'oahtkeeper-proxy' to 'oathkeeper-proxy' in,
e.g., the proxy latency logline.