### PR TITLE
database: Add support for mysql as a database backend.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -108,6 +108,12 @@
   version = "v1.0"
 
 [[projects]]
+  name = "github.com/go-sql-driver/mysql"
+  packages = ["."]
+  revision = "a0583e0143b1624142adab07e0e97fe106d99561"
+  version = "v1.3"
+
+[[projects]]
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
@@ -481,6 +487,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3d72836aaa7e41e0968c4df01bd51d25d7a1b4d669d55fd3e9bb7037d748dcdb"
+  inputs-digest = "0dc63ca4dddbaf0a29762940c30a3867fe151de236167863c956f4979e924924"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -120,3 +120,7 @@
 [[constraint]]
   name = "gopkg.in/square/go-jose.v2"
   version = "2.1.3"
+
+[[constraint]]
+  name = "github.com/go-sql-driver/mysql"
+  version = "1.3.0"

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -22,6 +22,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 
 	"os"
 
@@ -39,7 +40,14 @@ var migrateCmd = &cobra.Command{
 			return
 		}
 
-		db, err := connectToSql(args[0])
+		url, err := url.Parse(args[0])
+		if err != nil {
+			fmt.Printf("Could not parse database url because %s.\n", err)
+			os.Exit(1)
+			return
+		}
+
+		db, err := connectToSql(url)
 		if err != nil {
 			fmt.Printf("Could not connect to database because %s.\n", err)
 			os.Exit(1)

--- a/rule/manager_sql.go
+++ b/rule/manager_sql.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"strings"
 
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"github.com/ory/ladon/compiler"


### PR DESCRIPTION
This uses the same basic code as I found in github.com/ory/hydra:
https://github.com/ory/hydra/blob/366ed57d9c39d7601a40b5545f91361e6a2b9f5a/config/backend_sql.go#L44

Signed-off-by: Michael Goff <thephred@gmail.com>