### PR TITLE
rules: Resolves an issue with cached matchers

### DIFF
--- a/rule/matcher_cached.go
+++ b/rule/matcher_cached.go
@@ -71,8 +71,17 @@ func (m *CachedMatcher) Refresh() error {
 		return errors.WithStack(err)
 	}
 
+	inserted := map[string]bool{}
 	for _, rule := range rules {
+		inserted[rule.ID] = true
 		m.Rules[rule.ID] = rule
 	}
+
+	for _, rule := range m.Rules {
+		if _, ok := inserted[rule.ID]; !ok {
+			delete(m.Rules, rule.ID)
+		}
+	}
+
 	return nil
 }

--- a/rule/matcher_cached_http.go
+++ b/rule/matcher_cached_http.go
@@ -51,6 +51,7 @@ func (m *HTTPMatcher) Refresh() error {
 		return errors.Errorf("Unable to fetch rules from backend, got status code %d but expected %s", response.StatusCode, http.StatusOK)
 	}
 
+	inserted := map[string]bool{}
 	for _, r := range rules {
 		if len(r.Match.Methods) == 0 {
 			r.Match.Methods = []string{}
@@ -64,6 +65,7 @@ func (m *HTTPMatcher) Refresh() error {
 			}
 		}
 
+		inserted[r.Id] = true
 		m.Rules[r.Id] = Rule{
 			ID:          r.Id,
 			Description: r.Description,
@@ -82,6 +84,12 @@ func (m *HTTPMatcher) Refresh() error {
 				PreserveHost: r.Upstream.PreserveHost,
 				StripPath:    r.Upstream.StripPath,
 			},
+		}
+	}
+
+	for _, rule := range m.Rules {
+		if _, ok := inserted[rule.ID]; !ok {
+			delete(m.Rules, rule.ID)
 		}
 	}
 


### PR DESCRIPTION
This patch resolves an issue where updates would not properly propagate. This caused deleted rules to still be available in the proxy.

Closes #73