### PR TITLE
rules: Properly handle conflicts on PUT and POST

### DIFF
--- a/cmd/rules_import.go
+++ b/cmd/rules_import.go
@@ -71,9 +71,10 @@ Usage example:
 		for _, r := range rules {
 			fmt.Printf("Importing rule %s...\n", r.ID)
 			client := oathkeeper.NewSDK(endpoint)
-			out, response, err := client.GetRule(r.ID)
-			if err == nil {
-				response.Body.Close()
+
+			shouldUpdate := false
+			if _, response, _ := client.GetRule(r.ID); err == nil && response.StatusCode == http.StatusOK {
+				shouldUpdate = true
 			}
 
 			rh := make([]swagger.RuleHandler, len(r.Authenticators))
@@ -104,7 +105,7 @@ Usage example:
 				},
 			}
 
-			if out != nil {
+			if shouldUpdate {
 				out, response, err := client.UpdateRule(r.ID, sr)
 				checkResponse(response, err, http.StatusOK)
 				fmt.Printf("Successfully imported rule %s...\n", out.Id)

--- a/helper/errors.go
+++ b/helper/errors.go
@@ -52,4 +52,9 @@ var (
 		CodeField:   http.StatusNotFound,
 		StatusField: http.StatusText(http.StatusNotFound),
 	}
+	ErrResourceConflict = &herodot.DefaultError{
+		ErrorField:  "The request could not be completed due to a conflict with the current state of the target resource",
+		CodeField:   http.StatusConflict,
+		StatusField: http.StatusText(http.StatusConflict),
+	}
 )

--- a/rule/manager_memory.go
+++ b/rule/manager_memory.go
@@ -54,10 +54,19 @@ func (m *MemoryManager) GetRule(id string) (*Rule, error) {
 }
 
 func (m *MemoryManager) CreateRule(rule *Rule) error {
-	return m.UpdateRule(rule)
+	if _, ok := m.Rules[rule.ID]; ok {
+		return errors.WithStack(helper.ErrResourceConflict)
+	}
+
+	m.Rules[rule.ID] = *rule
+	return nil
 }
 
 func (m *MemoryManager) UpdateRule(rule *Rule) error {
+	if _, ok := m.Rules[rule.ID]; !ok {
+		return errors.WithStack(helper.ErrResourceConflict)
+	}
+
 	m.Rules[rule.ID] = *rule
 	return nil
 }

--- a/rule/manager_test.go
+++ b/rule/manager_test.go
@@ -25,6 +25,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
+	"github.com/ory/oathkeeper/helper"
 	"github.com/ory/oathkeeper/pkg"
 	"github.com/ory/sqlcon/dockertest"
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,9 @@ func TestManagers(t *testing.T) {
 		t.Run("case="+k, func(t *testing.T) {
 			_, err := manager.GetRule("1")
 			require.Error(t, err)
+
+			// Updating of a non-existent rule should throw 409
+			require.EqualError(t, manager.UpdateRule(&r3), helper.ErrResourceConflict.Error())
 
 			require.NoError(t, manager.CreateRule(&r1))
 			require.NoError(t, manager.CreateRule(&r2))


### PR DESCRIPTION
Previously, PUT and POST did not result in errors (409) when non-existing
resources were modified, or existing resources were created.
This patch resolves that.

Closes #38