### PR TITLE
(fix) Typo in checkResponse function

### DIFF
--- a/cmd/helper_response.go
+++ b/cmd/helper_response.go
@@ -32,7 +32,7 @@ func checkResponse(response *swagger.APIResponse, err error, expectedStatusCode 
 	must(err, "A network error occurred: %s", err)
 
 	if response.StatusCode != expectedStatusCode {
-		fmt.Printf("Command failed because status code %d was expeceted but code %d was received", expectedStatusCode, response.StatusCode)
+		fmt.Printf("Command failed because status code %d was expected but code %d was received", expectedStatusCode, response.StatusCode)
 		os.Exit(1)
 		return
 	}


### PR DESCRIPTION
Message goes "Command failed because status code %d was expeceted.." but should be "Command failed because status code %d was expected.."