### PR TITLE
cmd: Disable cors per default

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,13 @@ before finalizing the upgrade process.
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## 1.0.0-rc.1
+
+### CORS is disabled by default
+
+A new environment variable `CORS_ENABLED` was introduced. It sets whether CORS is enabled ("true") or not ("false")".
+Default is disabled.
+
 ## 1.0.0-beta.8
 
 ### `noop` authenticator no longer bypasses authorizers/credentials issuers

--- a/cmd/helper_messages.go
+++ b/cmd/helper_messages.go
@@ -27,6 +27,9 @@ import (
 
 var corsMessage = `CORS CONTROLS
 ==============
+- CORS_ENABLED: Switch CORS support on (true) or off (false). Default is off (false).
+	Example: CORS_ENABLED=true
+
 - CORS_ALLOWED_ORIGINS: A list of origins (comma separated values) a cross-domain request can be executed from.
 	If the special * value is present in the list, all origins will be allowed. An origin may contain a wildcard (*)
 	to replace 0 or more characters (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penality.

--- a/cmd/serve_api.go
+++ b/cmd/serve_api.go
@@ -122,7 +122,10 @@ HTTP CONTROLS
 		}
 
 		n.UseHandler(judgeHandler)
-		ch := cors.New(corsx.ParseOptions()).Handler(n)
+		var h http.Handler = n
+		if viper.GetString("CORS_ENABLED") == "true" {
+			h = cors.New(corsx.ParseOptions()).Handler(n)
+		}
 
 		go refreshKeys(keyManager, 0)
 		go refreshRules(matcher, 0)
@@ -130,7 +133,7 @@ HTTP CONTROLS
 		addr := fmt.Sprintf("%s:%s", viper.GetString("HOST"), viper.GetString("PORT"))
 		server := graceful.WithDefaults(&http.Server{
 			Addr:    addr,
-			Handler: ch,
+			Handler: h,
 		})
 
 		logger.Printf("Listening on %s", addr)

--- a/cmd/serve_proxy.go
+++ b/cmd/serve_proxy.go
@@ -205,7 +205,10 @@ OTHER CONTROLS
 		}
 
 		n.UseHandler(handler)
-		ch := cors.New(corsx.ParseOptions()).Handler(n)
+		var h http.Handler = n
+		if viper.GetString("CORS_ENABLED") == "true" {
+			h = cors.New(corsx.ParseOptions()).Handler(n)
+		}
 
 		var cert tls.Certificate
 		tlsCert := viper.GetString("HTTP_TLS_CERT")
@@ -223,7 +226,7 @@ OTHER CONTROLS
 		addr := fmt.Sprintf("%s:%s", viper.GetString("HOST"), viper.GetString("PORT"))
 		server := graceful.WithDefaults(&http.Server{
 			Addr:    addr,
-			Handler: ch,
+			Handler: h,
 			TLSConfig: &tls.Config{
 				Certificates: []tls.Certificate{cert},
 			},


### PR DESCRIPTION
This patch introduces CORS_ENABLED which defaults to "false".
