### PR TITLE
cmd: Enables TLS option on serve api

### DIFF
--- a/cmd/helper_server_test.go
+++ b/cmd/helper_server_test.go
@@ -127,6 +127,10 @@ RHMZNMoDTRhmhQhj8M7N+FMtZAUOMddZ/1cvREtFW7+66w+XZvj9CQ/uectp/qb+
 	defer func() {
 		_ = os.Remove(tmpCert)
 		_ = os.Remove(tmpKey)
+		os.Setenv("HTTP_TLS_KEY_PATH", "")
+		os.Setenv("HTTP_TLS_CERT_PATH", "")
+		os.Setenv("HTTP_TLS_KEY", "")
+		os.Setenv("HTTP_TLS_CERT", "")
 	}()
 	_ = ioutil.WriteFile(tmpCert, []byte(certFileContent), 0600)
 	_ = ioutil.WriteFile(tmpKey, []byte(keyFileContent), 0600)

--- a/cmd/serve_proxy.go
+++ b/cmd/serve_proxy.go
@@ -254,7 +254,7 @@ OTHER CONTROLS
 			logger.Printf("Listening on http://%s.\n", addr)
 			return server.ListenAndServe()
 		}, server.Shutdown); err != nil {
-			logger.Fatalf("Unable to gracefully shutdown HTTP(s) server because %s.\n", err)
+			logger.Fatalf("Unable to gracefully shutdown HTTP(s) server because %v.\n", err)
 			return
 		}
 		logger.Println("HTTP(s) server was shutdown gracefully")

--- a/rule/doc.go
+++ b/rule/doc.go
@@ -26,7 +26,6 @@
 //
 // ORY Oathkeeper stores as many rules as required and iterates through them on every request. Rules are essential
 // to the way ORY Oathkeeper works. To read more on rules, please refer to the developer guide: https://ory.gitbooks.io/oathkeeper/content/concepts.html#rules
-
 package rule
 
 // A rule


### PR DESCRIPTION
Signed-off-by: Frederic BIDON <frederic@oneconcern.com>

NOTE: now hydra, keto and oathkeeper follow a homogeneous set of options regarding TLS setup

Nice to have next: factorize between repos