### PR TITLE
Extend available transports for tokens: authorizers "jwt" and "oauth2_introspection"

### DIFF
--- a/helper/bearer.go
+++ b/helper/bearer.go
@@ -21,15 +21,116 @@
 package helper
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"mime"
 	"net/http"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
-func BearerTokenFromRequest(r *http.Request) string {
+const accessToken = "access_token"
+
+// ErrInvalidCookieFormat indicates a malformed configuration
+var ErrInvalidCookieFormat = errors.New("invalid cookie format specified. Supported values are: 'rawstd-base64-json' (default), 'rawurl-base64-json'")
+
+// BearerTokenFromRequest retrieves an access token from request according
+// to RFC6750
+func BearerTokenFromRequest(r *http.Request) (token string) {
 	auth := r.Header.Get("Authorization")
 	split := strings.SplitN(auth, " ", 2)
-	if len(split) != 2 || !strings.EqualFold(split[0], "bearer") {
-		return ""
+	if len(split) == 2 && strings.EqualFold(split[0], "bearer") {
+		token = split[1]
 	}
-	return split[1]
+
+	if token == "" && r.URL != nil {
+		qs := r.URL.Query()
+		token = qs.Get(accessToken)
+	}
+
+	if token == "" {
+		ct := r.Header.Get("Content-Type")
+		if ct != "" {
+			contentType, _, _ := mime.ParseMediaType(ct)
+			if contentType == "application/x-www-form-urlencoded" || contentType == "multipart/form-data" {
+				token = r.FormValue(accessToken)
+			}
+		}
+	}
+	return
+}
+
+// CookieTokenConfig configures how a token may be stored in a cookie.
+type CookieTokenConfig struct {
+	// ValueFormat indicates how the value is parsed. At the moment, we assume base64 encoded JSON.
+	ValueFormat string `json:"value_format"`
+
+	// TokenKey indicates the key of the token value in the decoded cookie value. By default, we use key accessToken
+	TokenKey string `json:"token_key"`
+}
+
+// BearerTokenFromCookie extracts a bearer token (e.g. access token, JWT) from a cookie container
+func BearerTokenFromCookie(configCookies map[string]CookieTokenConfig, r *http.Request) (string, error) {
+	// we have configured cookies: let's check if a token is contained in one of the recognized cookies.
+	// We assume only one such cookie arrives. If several are in the request, any one containing a token
+	// may be selected, in any order. Cookies with no token are skipped.
+	var token string
+
+	for k, v := range configCookies {
+		ck, err := r.Cookie(k)
+		if err == http.ErrNoCookie {
+			continue
+		}
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+
+		var (
+			buf     []byte
+			erd     error
+			decoded bool
+		)
+		switch v.ValueFormat {
+		case "rawurl-base64-json":
+			buf, erd = base64.RawURLEncoding.DecodeString(ck.Value)
+			if erd != nil {
+				return "", errors.WithStack(errors.WithMessage(err, "cookie value expected as unpadded url base64"))
+			}
+			decoded = true
+		case "rawstd-base64-json":
+			fallthrough
+		case "":
+			buf, erd = base64.RawStdEncoding.DecodeString(ck.Value)
+			if erd != nil {
+				return "", errors.WithStack(errors.WithMessage(err, "cookie value expected as unpadded standard base64"))
+			}
+			decoded = true
+		default:
+			return "", errors.WithStack(ErrInvalidCookieFormat)
+		}
+		if decoded {
+			var body map[string]json.RawMessage
+			if erd := json.Unmarshal(buf, &body); erd != nil {
+				return "", errors.WithStack(errors.WithMessage(erd, "cookie does not contain valid json value"))
+			}
+			var key string
+			if v.TokenKey == "" {
+				// default key in JSON cookie
+				key = accessToken
+			} else {
+				key = v.TokenKey
+			}
+			str := body[key]
+			if len(str) > 0 {
+				if eru := json.Unmarshal(str, &token); eru != nil {
+					return "", errors.WithStack(errors.WithMessage(eru, "token in cookie is not a json string"))
+				}
+			}
+			if token != "" {
+				break
+			}
+		}
+	}
+	return token, nil
 }

--- a/helper/bearer_test.go
+++ b/helper/bearer_test.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author       Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @copyright  2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license  	   Apache-2.0
+ */
+
+package helper
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBearerToken(t *testing.T) {
+	r := httptest.NewRequest("GET", "https://a.b.c/xyz", nil)
+	token := BearerTokenFromRequest(r)
+	assert.Equal(t, "", token)
+
+	r.Header.Add("Authorization", "Bearer |token|")
+	token = BearerTokenFromRequest(r)
+	assert.Equal(t, "|token|", token)
+
+	u, _ := url.Parse("https://a.b.c/xyz")
+	e := u.Query()
+	e.Add("access_token", "|token|")
+	u.RawQuery = e.Encode()
+
+	r = httptest.NewRequest("GET", u.RequestURI(), nil)
+	token = BearerTokenFromRequest(r)
+	assert.Equal(t, "|token|", token)
+
+	body := strings.NewReader(e.Encode())
+	r = httptest.NewRequest("POST", "https://a.b.c/xyz", body)
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	token = BearerTokenFromRequest(r)
+	assert.Equal(t, "|token|", token)
+}
+
+func TestBearerTokenFromCookie(t *testing.T) {
+	//configCookies map[string]CookieTokenConfig, r *http.Request) (string, error) {
+	confMap := map[string]CookieTokenConfig{
+		"_cookie1": {},
+		"_cookie2": {
+			ValueFormat: "rawstd-base64-json",
+			TokenKey:    "token",
+		},
+		"_cookie3": {
+			ValueFormat: "garbled",
+			TokenKey:    "absent",
+		},
+		"_cookie4": {
+			ValueFormat: "",
+			TokenKey:    "absent",
+		},
+		"_cookie5": {
+			ValueFormat: "rawurl-base64-json",
+		},
+	}
+	r := httptest.NewRequest("POST", "https://a.b.c/xyz", nil)
+	r.AddCookie(&http.Cookie{
+		Name:  "irrelevant",
+		Value: "123",
+	})
+	token, err := BearerTokenFromCookie(confMap, r)
+	assert.Empty(t, token)
+	assert.NoError(t, err)
+
+	jazon := []byte(`{"access_token": "123456789","other": "abcd"}`)
+	value := base64.RawStdEncoding.EncodeToString(jazon)
+	r.AddCookie(&http.Cookie{
+		Name:  "_cookie1",
+		Value: value,
+	})
+	token, err = BearerTokenFromCookie(confMap, r)
+	assert.NoError(t, err)
+	assert.Equal(t, "123456789", token)
+
+	r = httptest.NewRequest("POST", "https://a.b.c/xyz", nil)
+	jazon = []byte(`{"token": "123456789","other": "abcd"}`)
+	value = base64.RawStdEncoding.EncodeToString(jazon)
+	r.AddCookie(&http.Cookie{
+		Name:  "_cookie2",
+		Value: value,
+	})
+	token, err = BearerTokenFromCookie(confMap, r)
+	assert.NoError(t, err)
+	assert.Equal(t, "123456789", token)
+
+	r = httptest.NewRequest("POST", "https://a.b.c/xyz", nil)
+	jazon = []byte(`{"token": "123456789","other": "abcd"}`)
+	value = base64.RawStdEncoding.EncodeToString(jazon)
+	r.AddCookie(&http.Cookie{
+		Name:  "_cookie3",
+		Value: value,
+	})
+	token, err = BearerTokenFromCookie(confMap, r)
+	assert.Empty(t, token)
+	assert.Error(t, err)
+
+	r = httptest.NewRequest("POST", "https://a.b.c/xyz", nil)
+	jazon = []byte(`{"token": "123456789","other": "abcd"}`)
+	value = base64.RawStdEncoding.EncodeToString(jazon)
+	r.AddCookie(&http.Cookie{
+		Name:  "_cookie4",
+		Value: value,
+	})
+	token, err = BearerTokenFromCookie(confMap, r)
+	assert.Empty(t, token)
+	assert.NoError(t, err)
+
+	r = httptest.NewRequest("POST", "https://a.b.c/xyz", nil)
+	jazon = []byte(`{"access_token": "123456789","other": "abcd"}`)
+	value = base64.RawURLEncoding.EncodeToString(jazon)
+	r.AddCookie(&http.Cookie{
+		Name:  "_cookie5",
+		Value: value,
+	})
+	token, err = BearerTokenFromCookie(confMap, r)
+	assert.NoError(t, err)
+	assert.Equal(t, "123456789", token)
+}


### PR DESCRIPTION
now support tokens coming under other forms than the "Authorization Bearer" header.

* RFC6750 bearer tokens: as query param (?access_token=...) or form param
* token in cookie (atm, support is provided for base64 encoded JSON values for cookies)

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>