### PR TITLE
Add environment parameters (and description) to configure proxy server timeout settings

### DIFF
--- a/cmd/serve_proxy.go
+++ b/cmd/serve_proxy.go
@@ -160,6 +160,24 @@ OTHER CONTROLS
 	Default: RULES_REFRESH_INTERVAL=5s
 	--------------------------------------------------------------
 
+- PROXY_SERVER_READ_TIMEOUT: The maximum duration for reading the entire request, including the body.
+	Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	--------------------------------------------------------------
+	Default: PROXY_SERVER_READ_TIMEOUT=5s
+	--------------------------------------------------------------
+
+- PROXY_SERVER_WRITE_TIMEOUT: The maximum duration before timing out writes of the response.
+	Increase this parameter to prevent unexpected closing a client connection if an upstream request is executing more than 5 seconds. 
+	Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	--------------------------------------------------------------
+	Default: PROXY_SERVER_WRITE_TIMEOUT=10s
+	--------------------------------------------------------------
+
+- PROXY_SERVER_IDLE_TIMEOUT: The maximum amount of time to wait for any action of a request session, reading data or writing the response.
+	Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	--------------------------------------------------------------
+	Default: PROXY_SERVER_IDLE_TIMEOUT=120s
+	--------------------------------------------------------------
 
 ` + corsMessage,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -243,6 +261,9 @@ OTHER CONTROLS
 			TLSConfig: &tls.Config{
 				Certificates: certs,
 			},
+			ReadTimeout:  viper.GetDuration("PROXY_SERVER_READ_TIMEOUT"),
+			WriteTimeout: viper.GetDuration("PROXY_SERVER_WRITE_TIMEOUT"),
+			IdleTimeout:  viper.GetDuration("PROXY_SERVER_IDLE_TIMEOUT"),
 		})
 
 		if err := graceful.Graceful(func() error {

--- a/cmd/serve_proxy.go
+++ b/cmd/serve_proxy.go
@@ -167,7 +167,7 @@ OTHER CONTROLS
 	--------------------------------------------------------------
 
 - PROXY_SERVER_WRITE_TIMEOUT: The maximum duration before timing out writes of the response.
-	Increase this parameter to prevent unexpected closing a client connection if an upstream request is executing more than 5 seconds. 
+	Increase this parameter to prevent unexpected closing a client connection if an upstream request is executing more than 10 seconds. 
 	Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	--------------------------------------------------------------
 	Default: PROXY_SERVER_WRITE_TIMEOUT=10s


### PR DESCRIPTION
Add environment parameters (and description) to configure timeout settings

It will help prevent a case of unexpected closing a client connection if an upstream request is executing more than default timeout.

Signed-off-by: Aleksei Piianin <piyanin@gmail.com>

#64 @aeneasr 

I have a deployed ORY infrastructure (Hydra, OathKeeper, Keto) and have a case: clients connection "unexpected" closing if an upstream request was executing more than write timeout (10 seconds):

The case:
1. A client sends a request.
2. Oathkeeper processing it and make an upstream request.
3. A client and Oathkeeper are waiting a response - just about 20-30 seconds.
4. Oathkeeper successful processing a request.
5. But the client got a closing connection.

Has different cases when the timeout of the proxy server should configuring in different durations and offered changings would helping to solve them.

- [X ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [X] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [X] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
