### PR TITLE
judge: copy all request headers

### DIFF
--- a/judge/handler.go
+++ b/judge/handler.go
@@ -113,6 +113,8 @@ func (h *Handler) judge(w http.ResponseWriter, r *http.Request) {
 		WithField("access_url", r.URL.String()).
 		Warn("Access request granted")
 
-	w.Header().Set("Authorization", r.Header.Get("Authorization"))
+	for hdrName, _ := range r.Header {
+		w.Header().Set(hdrName, r.Header.Get(hdrName))
+	}
 	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Signed-off-by: Lars Sjöström <lars@radicore.se>

## Related issue
When running oathkeeper in judge mode, it should pass on all request headers. Especially useful when using credential issuer `header` module for passing headers down stream. 

## Proposed changes
Not just copy the Authorization header but copy all request headers.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x ] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)


