### PR TITLE
Support "scope" claim as a string in jwt authenticator

### DIFF
--- a/proxy/authenticator_jwt.go
+++ b/proxy/authenticator_jwt.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/ory/fosite"
@@ -125,6 +126,16 @@ func (a *AuthenticatorJWT) Authenticate(r *http.Request, config json.RawMessage,
 		if !stringslice.Has(cf.Issuers, parsedClaims.Issuer) {
 			return nil, errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Token issuer does not match any trusted issuer.")))
 		}
+	}
+
+	if scopeClaim, err := mapx.GetString(map[interface{}]interface{}{"scope": claims["scope"]}, "scope"); err == nil {
+		scopeStrings := strings.Split(scopeClaim, " ")
+		scopeInterfaces := make([]interface{}, len(scopeStrings))
+
+		for i := range scopeStrings {
+			scopeInterfaces[i] = scopeStrings[i]
+		}
+		claims["scope"] = scopeInterfaces
 	}
 
 	if a.scopeStrategy != nil {

--- a/proxy/authenticator_jwt_test.go
+++ b/proxy/authenticator_jwt_test.go
@@ -149,6 +149,28 @@ func TestAuthenticatorJWT(t *testing.T) {
 			},
 		},
 		{
+			d: "should pass because JWT scope can be a string",
+			r: &http.Request{Header: http.Header{"Authorization": []string{"bearer " + generateJWT(t, jwt.MapClaims{
+				"sub":   "sub",
+				"exp":   now.Add(time.Hour).Unix(),
+				"aud":   []string{"aud-1", "aud-2"},
+				"iss":   "iss-2",
+				"scope": "scope-3 scope-2 scope-1",
+			}, "RS256")}}},
+			config:    `{"target_audience": ["aud-1", "aud-2"], "trusted_issuers": ["iss-1", "iss-2"], "required_scope": ["scope-1", "scope-2"]}`,
+			expectErr: false,
+			expectSess: &AuthenticationSession{
+				Subject: "sub",
+				Extra: map[string]interface{}{
+					"sub":   "sub",
+					"exp":   float64(now.Add(time.Hour).Unix()),
+					"aud":   []interface{}{"aud-1", "aud-2"},
+					"iss":   "iss-2",
+					"scope": []interface{}{"scope-3", "scope-2", "scope-1"},
+				},
+			},
+		},
+		{
 			d: "should pass because JWT is valid and HS256 is allowed",
 			r: &http.Request{Header: http.Header{"Authorization": []string{"bearer " + generateJWT(t, jwt.MapClaims{
 				"sub": "sub",


### PR DESCRIPTION
We want to use oathkeeper to validate jwt generated by auth0 but it seems that "required_scope" option for jwt authenticator only works when "scope" claim is encoded as json array. Meanwhile rfc [mentions](https://tools.ietf.org/html/rfc6749#section-3.3)  
> a list of space-delimited, case-sensitive strings

and some identity providers (including auth0) use that format with no option to switch it to an array.

For example,  a rule
```
...
"authenticators": [{
  "handler": "jwt",
  "config": {
    "target_audience": ["..."],
    "required_scope": ["read:reports"],
    "allowed_algorithms": ["RS256"]
   }
}]
...
```

checked against token with claims
```
{
    "aud": "...",
    "azp": "...",
    "exp": 1542289232,
    "gty": "client-credentials",
    "iat": 1542202832,
    "iss": "...",
    "scope": "read:reports",
    "sub": "..."
}
```

gives an error
```
{
    "error": {
        "code": 403,
        "message": "Access credentials are not sufficient to access this resource",
        "reason": "Token is missing required scope read:reports.",
        "request": "00460c98dd6af2efbfceac7a3d133a1f",
        "status": "Forbidden"
    }
}
```

## Proposed changes

I added some code to convert "scope" claim to a an array of interfaces if it's a string and added a test for it.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x ] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
