### PR TITLE
Ignore query parameters when matching url in rules.

### DIFF
--- a/rule/rule.go
+++ b/rule/rule.go
@@ -22,6 +22,7 @@ package rule
 
 import (
 	"encoding/json"
+	"fmt"
 	"hash/crc32"
 	"net/url"
 	"regexp"
@@ -124,7 +125,7 @@ func (r *Rule) IsMatching(method string, u *url.URL) error {
 		return errors.WithStack(err)
 	}
 
-	if !c.MatchString(u.String()) {
+	if !c.MatchString(fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Path)) {
 		return errors.Errorf("rule %s does not match URL %s", r.ID, u)
 	}
 

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -43,5 +43,6 @@ func TestRule(t *testing.T) {
 	}
 
 	assert.NoError(t, r.IsMatching("DELETE", mustParse(t, "https://localhost/users/1234")))
+	assert.NoError(t, r.IsMatching("DELETE", mustParse(t, "https://localhost/users/1234?key=value&key1=value1")))
 	assert.Error(t, r.IsMatching("DELETE", mustParse(t, "https://localhost/users/abcd")))
 }


### PR DESCRIPTION
It seems that oathkeeper compares urls without stripping GET parameters. For example, a rule with
```
    "match": {
        "url": "http://test.com/test/",
        "methods": ["GET"]
    }
```
matches `http://test.com/test/` but doesn't match `http://test.com/test/?param=value`. [Comments](https://github.com/ory/oathkeeper/blob/master/rule/rule.go#L43) say:

> it compares the full request URL (e.g. https://mydomain.com/api/resource) **without query parameters** of the incoming request

So I guess it's a bug? According to [the docs](https://golang.org/pkg/net/url/#URL.String) .String() method uses `scheme://userinfo@host/path?query#fragment` pattern so I tried to fix it by simple Sprintf() and added a test.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

