### PR TITLE
issue #149 - Update README building-from-source part with the gomodul…

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ ec91228cb105db315553499c81918258f52cee9636ea2a4821bdb8226872f54b
 
 ### Building from source
 
-If you wish to compile ORY Oathkeeper yourself, you need to install and set up [Go 1.10+](https://golang.org/) and add `$GOPATH/bin`
-to your `$PATH` as well as [golang/dep](http://github.com/golang/dep).
+If you wish to compile ORY Oathkeeper yourself, you need to install and set up [Go 1.11+](https://golang.org/).
 
 The following commands will check out the latest release tag of ORY Oathkeeper and compile it and set up flags so that `oathkeeper version`
 works as expected. Please note that this will only work with a linux shell like bash or sh.
@@ -97,12 +96,11 @@ go get -d -u github.com/ory/oathkeeper
 cd $(go env GOPATH)/src/github.com/ory/oathkeeper
 OATHKEEPER_LATEST=$(git describe --abbrev=0 --tags)
 git checkout $OATHKEEPER_LATEST
-dep ensure -vendor-only
-go install \
+GO111MODULE=on go install \
     -ldflags "-X github.com/ory/oathkeeper/cmd.Version=$OATHKEEPER_LATEST -X github.com/ory/oathkeeper/cmd.BuildTime=`TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ'` -X github.com/ory/oathkeeper/cmd.GitHash=`git rev-parse HEAD`" \
     github.com/ory/oathkeeper
 git checkout master
-oathkeeper help
+$GOPATH/bin/oathkeeper help
 ```
 
 ## Ecosystem


### PR DESCRIPTION
please help review the pr, thanks a lot!

## Related issue #149 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

Additionally, tested the change offside...

```
user@hostname:~/go/src/github.com/ory$ go version 
go version go1.11.4 linux/amd64
user@hostname:~/go/src/github.com/ory$ go get -d -u github.com/ory/oathkeeper
user@hostname:~/go/src/github.com/ory$ cd $(go env GOPATH)/src/github.com/ory/oathkeeper
user@hostname:~/go/src/github.com/ory/oathkeeper$
user@hostname:~/go/src/github.com/ory/oathkeeper$ OATHKEEPER_LATEST=$(git describe --abbrev=0 --tags)
user@hostname:~/go/src/github.com/ory/oathkeeper$ echo ${OATHKEEPER_LATEST}
v0.14.2+oryOS.10
user@hostname:~/go/src/github.com/ory/oathkeeper$ git checkout $OATHKEEPER_LATEST
Note: checking out 'v0.14.2+oryOS.10'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 62415a1 ci: Fix docker push arguments in publish task
user@hostname:~/go/src/github.com/ory/oathkeeper$ GO111MODULE=on go install \
>     -ldflags "-X github.com/ory/oathkeeper/cmd.Version=$OATHKEEPER_LATEST -X github.com/ory/oathkeeper/cmd.BuildTime=`TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ'` -X github.com/ory/oathkeeper/cmd.GitHash=`git rev-parse HEAD`" \
>     github.com/ory/oathkeeper
user@hostname:~/go/src/github.com/ory/oathkeeper$ git checkout master
Previous HEAD position was 62415a1 ci: Fix docker push arguments in publish task
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
user@hostname:~/go/src/github.com/ory/oathkeeper$ $GOPATH/bin/oathkeeper help
A cloud native Access and Identity Proxy

Usage:
  oathkeeper [command]

Available Commands:
  help        Help about any command
  migrate     
  rules       Commands for managing rules
  serve       
  version     Display this binary's version, build time and git hash of this build

Flags:
  -h, --help     help for oathkeeper
  -t, --toggle   Help message for toggle

Use "oathkeeper [command] --help" for more information about a command.
user@hostname:~/go/src/github.com/ory/oathkeeper$ $GOPATH/bin/oathkeeper version
Version:    v0.14.2+oryOS.10
Git Hash:   62415a1c36f6a335f02adf272cb0e50eb1691f89
Build Time: 2019-01-22 15:24:32.839090877 +0800 CST m=+0.004459638
user@hostname:~/go/src/github.com/ory/oathkeeper$ 
```
