### PR TITLE
Ensure rule matcher is locked before updating

### DIFF
--- a/rule/matcher_cached_http.go
+++ b/rule/matcher_cached_http.go
@@ -52,6 +52,8 @@ func (m *HTTPMatcher) Refresh() error {
 		return errors.Errorf("unable to fetch rules from backend, got status code %d but expected %d", response.StatusCode, http.StatusOK)
 	}
 
+	m.Lock()
+	defer m.Unlock()
 	inserted := map[string]bool{}
 	for _, r := range rules {
 		if len(r.Match.Methods) == 0 {


### PR DESCRIPTION
## Proposed changes

Lock CachedMatcher before rules are updated when HTTPMatcher refreshes to avoid concurrent map iteration and map write errors.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)