### PR TITLE
Add support for rules in YAML format

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -233,13 +233,13 @@ serve:
 # Configures Access Rules
 access_rules:
   # Locations (list of URLs) where access rules should be fetched from on boot.
-  # It is expected that the documents at those locations return a JSON Array containing ORY Oathkeeper Access Rules.
+  # It is expected that the documents at those locations return a JSON or YAML Array containing ORY Oathkeeper Access Rules.
   repositories:
     # If the URL Scheme is `file://`, the access rules (an array of access rules is expected) will be
     # fetched from the local file system.
     - file://path/to/rules.json
     # If the URL Scheme is `inline://`, the access rules (an array of access rules is expected)
-    # are expected to be a base64 encoded (with padding!) JSON string (base64_encode(`[{"id":"foo-rule","authenticators":[....]}]`)):
+    # are expected to be a base64 encoded (with padding!) JSON/YAML string (base64_encode(`[{"id":"foo-rule","authenticators":[....]}]`)):
     - inline://W3siaWQiOiJmb28tcnVsZSIsImF1dGhlbnRpY2F0b3JzIjpbXX1d
     # If the URL Scheme is `http://` or `https://`, the access rules (an array of access rules is expected) will be
     # fetched from the provided HTTP(s) location.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bxcodec/faker v2.0.1+incompatible
 	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-errors/errors v1.0.1
 	github.com/go-openapi/analysis v0.19.0 // indirect
 	github.com/go-openapi/errors v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/rule/fetcher_default_test.go
+++ b/rule/fetcher_default_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/internal"
+	"github.com/ory/oathkeeper/rule"
 )
 
 const testRule = `[{"id":"test-rule-5","upstream":{"preserve_host":true,"strip_path":"/api","url":"mybackend.com/api"},"match":{"url":"myproxy.com/api","methods":["GET","POST"]},"authenticators":[{"handler":"noop"},{"handler":"anonymous"}],"authorizer":{"handler":"allow"},"mutator":{"handler":"noop"}}]`
@@ -64,6 +65,61 @@ func TestFetcher(t *testing.T) {
 				tc.expectIDs = []string{}
 			}
 			assert.EqualValues(t, ids, tc.expectIDs)
+		})
+	}
+}
+
+func TestFetcherDefaultFetchFormats(t *testing.T) {
+	expected := []rule.Rule{
+		{
+			ID: "test-rule-1",
+			Match: rule.RuleMatch{
+				Methods: []string{"GET", "POST"},
+				URL:     "myproxy.com/api",
+			},
+			Authenticators: []rule.RuleHandler{
+				{
+					Handler: "noop",
+				},
+				{
+					Handler: "anonymous",
+				},
+			},
+			Authorizer: rule.RuleHandler{
+				Handler: "allow",
+			},
+			Mutator: rule.RuleHandler{
+				Handler: "noop",
+			},
+			Upstream: rule.Upstream{
+				PreserveHost: true,
+				StripPath:    "/api",
+				URL:          "mybackend.com/api",
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		fpath string
+	}{
+		"json file": {
+			fpath: "testdata/rules.json",
+		},
+		"yaml file": {
+			fpath: "testdata/rules.yaml",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			conf := internal.NewConfigurationWithDefaults()
+			viper.Set(configuration.ViperKeyAccessRuleRepositories, []string{"file://" + tc.fpath})
+
+			r := internal.NewRegistry(conf)
+			rules, err := r.RuleFetcher().Fetch()
+			require.NoError(t, err)
+
+			assert.Equal(t, expected, rules)
 		})
 	}
 }

--- a/rule/testdata/rules.json
+++ b/rule/testdata/rules.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "test-rule-1",
+    "upstream": {
+      "preserve_host": true,
+      "strip_path": "/api",
+      "url": "mybackend.com/api"
+    },
+    "match": {
+      "url": "myproxy.com/api",
+      "methods": [
+        "GET",
+        "POST"
+      ]
+    },
+    "authenticators": [
+      {
+        "handler": "noop"
+      },
+      {
+        "handler": "anonymous"
+      }
+    ],
+    "authorizer": {
+      "handler": "allow"
+    },
+    "mutator": {
+      "handler": "noop"
+    }
+  }
+]

--- a/rule/testdata/rules.yaml
+++ b/rule/testdata/rules.yaml
@@ -1,0 +1,17 @@
+- id: test-rule-1
+  upstream:
+    preserve_host: true
+    strip_path: /api
+    url: mybackend.com/api
+  match:
+    url: myproxy.com/api
+    methods:
+      - GET
+      - POST
+  authenticators:
+    - handler: noop
+    - handler: anonymous
+  authorizer:
+    handler: allow
+  mutator:
+    handler: noop


### PR DESCRIPTION
## Proposed changes

This commit adds support for defining access rules in YAML format, in
addition to existing JSON format.

YAML is known as a superset of JSON.

This is useful in some cases, where YAML manipulation is preferable over JSON.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [security policy](SECURITY.md)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)
