### PR TITLE
Extend ID_TOKEN mutator with custom claims

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -44,6 +44,33 @@ before finalizing the upgrade process.
 1. ORY Oathkeeper now supports multiple mutators. Mutations are performed in the provided order and must all succeed in order for the HTTP request to be forwarded.
 2. The `mutator` property was renamed to `mutators` to reflect its true nature (see previous item).
 
+#### id_token mutator
+
+The id_token mutator now allows to specify custom claims via the `claims` field of the mutator's `config` field. The keys represent names of claims and the values are strings which will be parsed by the Go [text/template](https://golang.org/pkg/text/template/) package for value substitution, receiving the `AuthenticationSession` struct. You must now specify
+the audience of the ID token directly via the `aud` claim. If you use `id_token` mutators with defined audience, please update them as follows:
+
+deprecated config:
+```json
+{
+  "handler": "id_token",
+  "config": {
+    "aud": ["https://my-backend-service/some/endpoint"]
+  }
+}
+```
+
+new config:
+```json
+{
+  "handler": "id_token",
+  "config": {
+    "claims": {
+      "aud": ["https://my-backend-service/some/endpoint"]
+    }
+  }
+}
+```
+
 ### Access Rule Changes
 
 As already noted, the `mutator` property was renamed to `mutators` and now represents a list of mutation handlers. If you have


### PR DESCRIPTION
## Related issue

#228 

## Proposed changes

- Mutator ID_TOKEN now supports go templates
- Users can define custom claims in rule configuration

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
