### PR TITLE
Log subject and method

### DIFF
--- a/api/decision.go
+++ b/api/decision.go
@@ -88,16 +88,20 @@ func (h *DecisionHandler) decisions(w http.ResponseWriter, r *http.Request) {
 		h.r.Logger().WithError(err).
 			WithField("granted", false).
 			WithField("access_url", r.URL.String()).
+			WithField("method", r.Method).
+			WithField("subject", "").
 			Warn("Access request denied")
 		h.r.Writer().WriteError(w, r, err)
 		return
 	}
 
-	headers, err := h.r.ProxyRequestHandler().HandleRequest(r, rl)
+	headers, subject, err := h.r.ProxyRequestHandler().HandleRequest(r, rl)
 	if err != nil {
 		h.r.Logger().WithError(err).
 			WithField("granted", false).
 			WithField("access_url", r.URL.String()).
+			WithField("method", r.Method).
+			WithField("subject", subject).
 			Warn("Access request denied")
 		h.r.Writer().WriteError(w, r, err)
 		return
@@ -106,6 +110,8 @@ func (h *DecisionHandler) decisions(w http.ResponseWriter, r *http.Request) {
 	h.r.Logger().
 		WithField("granted", true).
 		WithField("access_url", r.URL.String()).
+		WithField("method", r.Method).
+		WithField("subject", subject).
 		Warn("Access request granted")
 
 	for k := range headers {

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -131,7 +131,7 @@ func (d *RequestHandler) HandleRequest(r *http.Request, rl *rule.Rule) (http.Hea
 			WithField("access_url", r.URL.String()).
 			WithField("authorization_handler", rl.Authorizer.Handler).
 			WithField("reason_id", "unknown_authorization_handler").
-			Warn("Unknown authentication handler requested")
+			Warn("Unknown authorization handler requested")
 		return nil, session.Subject, err
 	}
 

--- a/proxy/request_handler_test.go
+++ b/proxy/request_handler_test.go
@@ -218,7 +218,7 @@ func TestRequestHandler(t *testing.T) {
 				tc.setup()
 			}
 
-			_, err := reg.ProxyRequestHandler().HandleRequest(tc.r, &tc.rule)
+			_, _, err := reg.ProxyRequestHandler().HandleRequest(tc.r, &tc.rule)
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Related issue

#242 @aeneasr 

## Proposed changes

This change adds the two fields "method" and "subject" as fields to the Logger in the decisions API endpoint as well as the proxy implementation.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments