### PR TITLE
Fix #250: Ignore query parameters to build payload for Keto engine

### DIFF
--- a/pipeline/authz/keto_engine_acp_ory.go
+++ b/pipeline/authz/keto_engine_acp_ory.go
@@ -125,9 +125,10 @@ func (a *AuthorizerKetoEngineACPORY) Authorize(r *http.Request, session *authn.A
 	}
 
 	var b bytes.Buffer
+	u := fmt.Sprintf("%s://%s%s", r.URL.Scheme, r.URL.Host, r.URL.Path)
 	if err := json.NewEncoder(&b).Encode(&AuthorizerKetoEngineACPORYRequestBody{
-		Action:   compiled.ReplaceAllString(r.URL.String(), cf.RequiredAction),
-		Resource: compiled.ReplaceAllString(r.URL.String(), cf.RequiredResource),
+		Action:   compiled.ReplaceAllString(u, cf.RequiredAction),
+		Resource: compiled.ReplaceAllString(u, cf.RequiredResource),
 		Context:  a.contextCreator(r),
 		Subject:  subject,
 	}); err != nil {


### PR DESCRIPTION
## Related issue
#250 

## Proposed changes
Ignore query parameters to build the payload for Keto engine like oathkeeper do to match rules:
https://github.com/ory/oathkeeper/blob/d21179dd25543662075be402f6e24e1ee20d2754/rule/rule.go#L137

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have read the [security policy](../security/policy)
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation within the code base (if appropriate)
- [X] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)
