### PR TITLE
feat: Add /auth_forward endpoint for Traefik

### DIFF
--- a/api/auth_forward.go
+++ b/api/auth_forward.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author       Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @copyright  2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license  	   Apache-2.0
+ */
+
+package api
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/ory/oathkeeper/x"
+
+	"github.com/ory/oathkeeper/proxy"
+	"github.com/ory/oathkeeper/rule"
+)
+
+const (
+	AuthForwardPath   = "/auth_forward"
+	xForwardedURI     = "X-Forwarded-Uri"
+	xForwardedMethod  = "X-Forwarded-Method"
+)
+
+type authForwardHandlerRegistry interface {
+	x.RegistryWriter
+	x.RegistryLogger
+
+	RuleMatcher() rule.Matcher
+	ProxyRequestHandler() *proxy.RequestHandler
+}
+
+type AuthForwardHandler struct {
+	r authForwardHandlerRegistry
+}
+
+func NewAuthForwarderHandler(r authForwardHandlerRegistry) *AuthForwardHandler {
+	return &AuthForwardHandler{r: r}
+}
+
+func (h *AuthForwardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if len(r.URL.Path) >= len(AuthForwardPath) && r.URL.Path[:len(AuthForwardPath)] == AuthForwardPath {
+		r.URL.Scheme = "http"
+		r.URL.Host = r.Host
+		if r.TLS != nil {
+			r.URL.Scheme = "https"
+		}
+		r.URL.Path = r.URL.Path[len(AuthForwardPath):]
+
+		h.authForwards(w, r)
+	} else {
+		next(w, r)
+	}
+}
+
+// swagger:route GET /authForwards api authForwards
+//
+// Access Control AuthForward API
+//
+// > This endpoint works with all HTTP Methods (GET, POST, PUT, ...) and matches every path prefixed with /authForward.
+//
+// This endpoint mirrors the proxy capability of ORY Oathkeeper's proxy functionality but instead of forwarding the
+// request to the upstream server, returns 200 (request should be allowed), 401 (unauthorized), or 403 (forbidden)
+// status codes. This endpoint can be used to integrate with other API Proxies like Ambassador, Kong, Envoy, and many more.
+//
+//     Schemes: http, https
+//
+//     Responses:
+//       200: emptyResponse
+//       401: genericError
+//       403: genericError
+//       404: genericError
+//       500: genericError
+func (h *AuthForwardHandler) authForwards(w http.ResponseWriter, r *http.Request) {
+	uriToMatch, err := url.Parse(r.Header.Get(xForwardedURI))
+	methodToMatch := r.Header.Get(xForwardedMethod)
+
+	rl, err := h.r.RuleMatcher().Match(r.Context(), methodToMatch, uriToMatch)
+	if err != nil {
+		h.r.Logger().WithError(err).
+			WithField("granted", false).
+			WithField("access_url", uriToMatch.String()).
+			Warn("Access request denied")
+		h.r.Writer().WriteError(w, r, err)
+		return
+	}
+
+	headers, err := h.r.ProxyRequestHandler().HandleRequest(r, rl)
+	if err != nil {
+		h.r.Logger().WithError(err).
+			WithField("granted", false).
+			WithField("access_url", uriToMatch.String()).
+			Warn("Access request denied")
+		h.r.Writer().WriteError(w, r, err)
+		return
+	}
+
+	h.r.Logger().
+		WithField("granted", true).
+		WithField("access_url", uriToMatch.String()).
+		Warn("Access request granted")
+
+	for k := range headers {
+		w.Header().Set(k, headers.Get(k))
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -79,6 +79,7 @@ func runAPI(d driver.Driver, n *negroni.Negroni, logger *logrus.Logger) func() {
 		d.Registry().CredentialHandler().SetRoutes(router)
 
 		n.Use(negronilogrus.NewMiddlewareFromLogger(logger, "oathkeeper-api"))
+		n.Use(d.Registry().AuthForwardHandler())
 		n.Use(d.Registry().DecisionHandler()) // This needs to be the last entry, otherwise the judge API won't work
 
 		n.UseHandler(router)
@@ -165,6 +166,7 @@ func RunServe(version, build, date string) func(cmd *cobra.Command, args []strin
 				WriteKey:      "MSx9A6YQ1qodnkzEFOv22cxOmOCJXMFa",
 				WhitelistedPaths: []string{
 					"/",
+					api.AuthForwardPath,
 					api.CredentialsPath,
 					api.DecisionPath,
 					api.RulesPath,

--- a/driver/registry.go
+++ b/driver/registry.go
@@ -30,6 +30,7 @@ type Registry interface {
 	HealthHandler() *healthx.Handler
 	RuleHandler() *api.RuleHandler
 	DecisionHandler() *api.DecisionHandler
+	AuthForwardHandler() *api.AuthForwardHandler
 	CredentialHandler() *api.CredentialsHandler
 
 	Proxy() *proxy.Proxy

--- a/driver/registry_memory.go
+++ b/driver/registry_memory.go
@@ -39,18 +39,19 @@ type RegistryMemory struct {
 
 	ch *api.CredentialsHandler
 
-	credentialsFetcher  credentials.Fetcher
-	credentialsVerifier credentials.Verifier
-	credentialsSigner   credentials.Signer
-	ruleValidator       rule.Validator
-	ruleRepository      *rule.RepositoryMemory
-	apiRuleHandler      *api.RuleHandler
-	apiJudgeHandler     *api.DecisionHandler
-	healthxHandler      *healthx.Handler
+	credentialsFetcher  	credentials.Fetcher
+	credentialsVerifier 	credentials.Verifier
+	credentialsSigner   	credentials.Signer
+	ruleValidator       	rule.Validator
+	ruleRepository      	*rule.RepositoryMemory
+	apiRuleHandler      	*api.RuleHandler
+	apiJudgeHandler     	*api.DecisionHandler
+	apiAuthForwarderHandler	*api.AuthForwardHandler
+	healthxHandler      	*healthx.Handler
 
-	proxyRequestHandler *proxy.RequestHandler
-	proxyProxy          *proxy.Proxy
-	ruleFetcher         rule.Fetcher
+	proxyRequestHandler 	*proxy.RequestHandler
+	proxyProxy          	*proxy.Proxy
+	ruleFetcher         	rule.Fetcher
 
 	authenticators map[string]authn.Authenticator
 	authorizers    map[string]authz.Authorizer
@@ -175,6 +176,13 @@ func (r *RegistryMemory) DecisionHandler() *api.DecisionHandler {
 		r.apiJudgeHandler = api.NewJudgeHandler(r)
 	}
 	return r.apiJudgeHandler
+}
+
+func (r *RegistryMemory) AuthForwardHandler() *api.AuthForwardHandler {
+	if r.apiAuthForwarderHandler == nil {
+		r.apiAuthForwarderHandler = api.NewAuthForwarderHandler(r)
+	}
+	return r.apiAuthForwarderHandler
 }
 
 func (r *RegistryMemory) CredentialsFetcher() credentials.Fetcher {


### PR DESCRIPTION
Behaves identical to /decisions except that it gets the url and method from the headers.
This allows integration with Traefik's ForwardAuth middleware.

## Related issue

#263 

## Proposed changes

Add integration with Traefik by adding a new `/auth_forward` endpoint that behaves identical to `/decisions` except that it gets the url and method from the following headers:

- `X-Forwarded-Uri`
- `X-Forwarded-Method`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

I've copied the `decision.go` file, renamed where appropriate, and changed the rule matcher input. Found references to `DecisionHandler` and added the new `AuthForwardHandler` accordingly.
I've tested locally with this config https://gist.github.com/MichielVanderlee/2dba10f1ed6c869630eab27847bc2d12

The endpoint only has to support GET but wasn't sure how that's achieved. 

Please review carefully as I'm not familiar with GoLang.