### PR TITLE
Traefik auth forward

### DIFF
--- a/api/auth_forward.go
+++ b/api/auth_forward.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	AuthForwardPath   = "/auth_forward"
-	xForwardedURI     = "X-Forwarded-Uri"
-	xForwardedMethod  = "X-Forwarded-Method"
+	AuthForwardPath  = "/auth_forward"
+	xForwardedURI    = "X-Forwarded-Uri"
+	xForwardedMethod = "X-Forwarded-Method"
 )
 
 type authForwardHandlerRegistry interface {

--- a/api/auth_forward.go
+++ b/api/auth_forward.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author       Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @copyright  2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license  	   Apache-2.0
+ */
+
+package api
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/ory/oathkeeper/x"
+
+	"github.com/ory/oathkeeper/proxy"
+	"github.com/ory/oathkeeper/rule"
+)
+
+const (
+	AuthForwardPath   = "/auth_forward"
+	xForwardedURI     = "X-Forwarded-Uri"
+	xForwardedMethod  = "X-Forwarded-Method"
+)
+
+type authForwardHandlerRegistry interface {
+	x.RegistryWriter
+	x.RegistryLogger
+
+	RuleMatcher() rule.Matcher
+	ProxyRequestHandler() *proxy.RequestHandler
+}
+
+type AuthForwardHandler struct {
+	r authForwardHandlerRegistry
+}
+
+func NewAuthForwarderHandler(r authForwardHandlerRegistry) *AuthForwardHandler {
+	return &AuthForwardHandler{r: r}
+}
+
+func (h *AuthForwardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if len(r.URL.Path) >= len(AuthForwardPath) && r.URL.Path[:len(AuthForwardPath)] == AuthForwardPath {
+		r.URL.Scheme = "http"
+		r.URL.Host = r.Host
+		if r.TLS != nil {
+			r.URL.Scheme = "https"
+		}
+		r.URL.Path = r.URL.Path[len(AuthForwardPath):]
+
+		h.authForwards(w, r)
+	} else {
+		next(w, r)
+	}
+}
+
+// swagger:route GET /authForwards api authForwards
+//
+// Access Control AuthForward API
+//
+// > This endpoint works with all HTTP Methods (GET, POST, PUT, ...) and matches every path prefixed with /authForward.
+//
+// This endpoint mirrors the proxy capability of ORY Oathkeeper's proxy functionality but instead of forwarding the
+// request to the upstream server, returns 200 (request should be allowed), 401 (unauthorized), or 403 (forbidden)
+// status codes. This endpoint can be used to integrate with other API Proxies like Ambassador, Kong, Envoy, and many more.
+//
+//     Schemes: http, https
+//
+//     Responses:
+//       200: emptyResponse
+//       401: genericError
+//       403: genericError
+//       404: genericError
+//       500: genericError
+func (h *AuthForwardHandler) authForwards(w http.ResponseWriter, r *http.Request) {
+	uriToMatch, err := url.Parse(r.Header.Get(xForwardedURI))
+	methodToMatch := r.Header.Get(xForwardedMethod)
+
+	rl, err := h.r.RuleMatcher().Match(r.Context(), methodToMatch, uriToMatch)
+	if err != nil {
+		h.r.Logger().WithError(err).
+			WithField("granted", false).
+			WithField("access_url", uriToMatch.String()).
+			Warn("Access request denied")
+		h.r.Writer().WriteError(w, r, err)
+		return
+	}
+
+	headers, err := h.r.ProxyRequestHandler().HandleRequest(r, rl)
+	if err != nil {
+		h.r.Logger().WithError(err).
+			WithField("granted", false).
+			WithField("access_url", uriToMatch.String()).
+			Warn("Access request denied")
+		h.r.Writer().WriteError(w, r, err)
+		return
+	}
+
+	h.r.Logger().
+		WithField("granted", true).
+		WithField("access_url", uriToMatch.String()).
+		Warn("Access request granted")
+
+	for k := range headers {
+		w.Header().Set(k, headers.Get(k))
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/api/decision.go
+++ b/api/decision.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	DecisionPath 				= "/decisions/generic"
-	LegacyDecisionPath 	= "/decisions"
+	DecisionPath       = "/decisions/generic"
+	LegacyDecisionPath = "/decisions"
 )
 
 type decisionHandlerRegistry interface {

--- a/api/decision.go
+++ b/api/decision.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	DecisionPath = "/decisions"
+	DecisionPath = "/decisions/generic"
 )
 
 type decisionHandlerRegistry interface {

--- a/api/decision_traefik.go
+++ b/api/decision_traefik.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	DecisionTraefikPath = "/decisions/traefik"
-	xForwardedProto  	= "X-Forwarded-Proto"
-	xForwardedHost   	= "X-Forwarded-Host"
-	xForwardedURI    	= "X-Forwarded-Uri"
-	xForwardedMethod 	= "X-Forwarded-Method"
+	xForwardedProto     = "X-Forwarded-Proto"
+	xForwardedHost      = "X-Forwarded-Host"
+	xForwardedURI       = "X-Forwarded-Uri"
+	xForwardedMethod    = "X-Forwarded-Method"
 )
 
 type decisionTraefikHandlerRegistry interface {
@@ -87,8 +87,8 @@ func (h *DecisionTraefikHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 func (h *DecisionTraefikHandler) decisionTraefiks(w http.ResponseWriter, r *http.Request) {
 	urlToMatch := url.URL{
 		Scheme: r.Header.Get(xForwardedProto),
-		Host: r.Header.Get(xForwardedHost),
-		Path: r.Header.Get(xForwardedURI),
+		Host:   r.Header.Get(xForwardedHost),
+		Path:   r.Header.Get(xForwardedURI),
 	}
 	methodToMatch := r.Header.Get(xForwardedMethod)
 
@@ -117,7 +117,7 @@ func (h *DecisionTraefikHandler) decisionTraefiks(w http.ResponseWriter, r *http
 		WithField("access_url", urlToMatch.String()).
 		Warn("Access request granted")
 
-	for k := range s.Header  {
+	for k := range s.Header {
 		w.Header().Set(k, s.Header.Get(k))
 	}
 

--- a/api/decision_traefik.go
+++ b/api/decision_traefik.go
@@ -102,7 +102,7 @@ func (h *DecisionTraefikHandler) decisionTraefiks(w http.ResponseWriter, r *http
 		return
 	}
 
-	headers, err := h.r.ProxyRequestHandler().HandleRequest(r, rl)
+	s, err := h.r.ProxyRequestHandler().HandleRequest(r, rl)
 	if err != nil {
 		h.r.Logger().WithError(err).
 			WithField("granted", false).
@@ -117,8 +117,8 @@ func (h *DecisionTraefikHandler) decisionTraefiks(w http.ResponseWriter, r *http
 		WithField("access_url", urlToMatch.String()).
 		Warn("Access request granted")
 
-	for k := range headers {
-		w.Header().Set(k, headers.Get(k))
+	for k := range s.Header  {
+		w.Header().Set(k, s.Header.Get(k))
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/api/decision_traefik.go
+++ b/api/decision_traefik.go
@@ -31,11 +31,11 @@ import (
 )
 
 const (
-	DecisionTraefikPath  = "/decisions/traefik"
-	xForwardedProto  = "X-Forwarded-Proto"
-	xForwardedHost   = "X-Forwarded-Host"
-	xForwardedURI    = "X-Forwarded-Uri"
-	xForwardedMethod = "X-Forwarded-Method"
+	DecisionTraefikPath = "/decisions/traefik"
+	xForwardedProto  	= "X-Forwarded-Proto"
+	xForwardedHost   	= "X-Forwarded-Host"
+	xForwardedURI    	= "X-Forwarded-Uri"
+	xForwardedMethod 	= "X-Forwarded-Method"
 )
 
 type decisionTraefikHandlerRegistry interface {
@@ -68,15 +68,13 @@ func (h *DecisionTraefikHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-// swagger:route GET /decisionTraefiks api decisionTraefiks
+// swagger:route GET /decisions/traefik api decisionTraefiks
 //
 // Access Control DecisionTraefik API
 //
-// > This endpoint works with all HTTP Methods (GET, POST, PUT, ...) and matches every path prefixed with /decisionTraefik.
-//
 // This endpoint mirrors the proxy capability of ORY Oathkeeper's proxy functionality but instead of forwarding the
 // request to the upstream server, returns 200 (request should be allowed), 401 (unauthorized), or 403 (forbidden)
-// status codes. This endpoint can be used to integrate with other API Proxies like Ambassador, Kong, Envoy, and many more.
+// status codes. This endpoint can be used to integrate with the Traefik proxy.
 //
 //     Schemes: http, https
 //

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -83,6 +83,7 @@ func runAPI(d driver.Driver, n *negroni.Negroni, logger *logrus.Logger) func() {
 		d.Registry().CredentialHandler().SetRoutes(router)
 
 		n.Use(reqlog.NewMiddlewareFromLogger(logger, "oathkeeper-api").ExcludePaths(healthx.ReadyCheckPath, healthx.AliveCheckPath))
+		n.Use(d.Registry().AuthForwardHandler())
 		n.Use(d.Registry().DecisionHandler()) // This needs to be the last entry, otherwise the judge API won't work
 
 		n.UseHandler(router)
@@ -169,6 +170,7 @@ func RunServe(version, build, date string) func(cmd *cobra.Command, args []strin
 				WriteKey:      "xRVRP48SAKw6ViJEnvB0u2PY8bVlsO6O",
 				WhitelistedPaths: []string{
 					"/",
+					api.AuthForwardPath,
 					api.CredentialsPath,
 					api.DecisionPath,
 					api.RulesPath,

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -83,7 +83,7 @@ func runAPI(d driver.Driver, n *negroni.Negroni, logger *logrus.Logger) func() {
 		d.Registry().CredentialHandler().SetRoutes(router)
 
 		n.Use(reqlog.NewMiddlewareFromLogger(logger, "oathkeeper-api").ExcludePaths(healthx.ReadyCheckPath, healthx.AliveCheckPath))
-		n.Use(d.Registry().AuthForwardHandler())
+		n.Use(d.Registry().DecisionTraefikHandler())
 		n.Use(d.Registry().DecisionHandler()) // This needs to be the last entry, otherwise the judge API won't work
 
 		n.UseHandler(router)
@@ -170,7 +170,7 @@ func RunServe(version, build, date string) func(cmd *cobra.Command, args []strin
 				WriteKey:      "xRVRP48SAKw6ViJEnvB0u2PY8bVlsO6O",
 				WhitelistedPaths: []string{
 					"/",
-					api.AuthForwardPath,
+					api.DecisionTraefikPath,
 					api.CredentialsPath,
 					api.DecisionPath,
 					api.RulesPath,

--- a/driver/registry.go
+++ b/driver/registry.go
@@ -32,6 +32,7 @@ type Registry interface {
 	HealthHandler() *healthx.Handler
 	RuleHandler() *api.RuleHandler
 	DecisionHandler() *api.DecisionHandler
+	AuthForwardHandler() *api.AuthForwardHandler
 	CredentialHandler() *api.CredentialsHandler
 
 	Proxy() *proxy.Proxy

--- a/driver/registry.go
+++ b/driver/registry.go
@@ -32,7 +32,7 @@ type Registry interface {
 	HealthHandler() *healthx.Handler
 	RuleHandler() *api.RuleHandler
 	DecisionHandler() *api.DecisionHandler
-	AuthForwardHandler() *api.AuthForwardHandler
+	DecisionTraefikHandler() *api.DecisionTraefikHandler
 	CredentialHandler() *api.CredentialsHandler
 
 	Proxy() *proxy.Proxy

--- a/driver/registry_memory.go
+++ b/driver/registry_memory.go
@@ -43,15 +43,15 @@ type RegistryMemory struct {
 
 	ch *api.CredentialsHandler
 
-	credentialsFetcher  		credentials.Fetcher
-	credentialsVerifier 		credentials.Verifier
-	credentialsSigner   		credentials.Signer
-	ruleValidator       		rule.Validator
-	ruleRepository      		*rule.RepositoryMemory
-	apiRuleHandler      		*api.RuleHandler
-	apiJudgeHandler     		*api.DecisionHandler
-	apiDecisionTraefikerHandler	*api.DecisionTraefikHandler
-	healthxHandler      		*healthx.Handler
+	credentialsFetcher          credentials.Fetcher
+	credentialsVerifier         credentials.Verifier
+	credentialsSigner           credentials.Signer
+	ruleValidator               rule.Validator
+	ruleRepository              *rule.RepositoryMemory
+	apiRuleHandler              *api.RuleHandler
+	apiJudgeHandler             *api.DecisionHandler
+	apiDecisionTraefikerHandler *api.DecisionTraefikHandler
+	healthxHandler              *healthx.Handler
 
 	proxyRequestHandler *proxy.RequestHandler
 	proxyProxy          *proxy.Proxy

--- a/driver/registry_memory.go
+++ b/driver/registry_memory.go
@@ -43,18 +43,19 @@ type RegistryMemory struct {
 
 	ch *api.CredentialsHandler
 
-	credentialsFetcher  credentials.Fetcher
-	credentialsVerifier credentials.Verifier
-	credentialsSigner   credentials.Signer
-	ruleValidator       rule.Validator
-	ruleRepository      *rule.RepositoryMemory
-	apiRuleHandler      *api.RuleHandler
-	apiJudgeHandler     *api.DecisionHandler
-	healthxHandler      *healthx.Handler
+	credentialsFetcher  	credentials.Fetcher
+	credentialsVerifier 	credentials.Verifier
+	credentialsSigner   	credentials.Signer
+	ruleValidator       	rule.Validator
+	ruleRepository      	*rule.RepositoryMemory
+	apiRuleHandler      	*api.RuleHandler
+	apiJudgeHandler     	*api.DecisionHandler
+	apiAuthForwarderHandler	*api.AuthForwardHandler
+	healthxHandler      	*healthx.Handler
 
-	proxyRequestHandler *proxy.RequestHandler
-	proxyProxy          *proxy.Proxy
-	ruleFetcher         rule.Fetcher
+	proxyRequestHandler 	*proxy.RequestHandler
+	proxyProxy          	*proxy.Proxy
+	ruleFetcher         	rule.Fetcher
 
 	authenticators map[string]authn.Authenticator
 	authorizers    map[string]authz.Authorizer
@@ -180,6 +181,13 @@ func (r *RegistryMemory) DecisionHandler() *api.DecisionHandler {
 		r.apiJudgeHandler = api.NewJudgeHandler(r)
 	}
 	return r.apiJudgeHandler
+}
+
+func (r *RegistryMemory) AuthForwardHandler() *api.AuthForwardHandler {
+	if r.apiAuthForwarderHandler == nil {
+		r.apiAuthForwarderHandler = api.NewAuthForwarderHandler(r)
+	}
+	return r.apiAuthForwarderHandler
 }
 
 func (r *RegistryMemory) CredentialsFetcher() credentials.Fetcher {

--- a/driver/registry_memory.go
+++ b/driver/registry_memory.go
@@ -50,7 +50,7 @@ type RegistryMemory struct {
 	ruleRepository      	*rule.RepositoryMemory
 	apiRuleHandler      	*api.RuleHandler
 	apiJudgeHandler     	*api.DecisionHandler
-	apiAuthForwarderHandler	*api.AuthForwardHandler
+	apiDecisionTraefikerHandler	*api.DecisionTraefikHandler
 	healthxHandler      	*healthx.Handler
 
 	proxyRequestHandler *proxy.RequestHandler
@@ -183,11 +183,11 @@ func (r *RegistryMemory) DecisionHandler() *api.DecisionHandler {
 	return r.apiJudgeHandler
 }
 
-func (r *RegistryMemory) AuthForwardHandler() *api.AuthForwardHandler {
-	if r.apiAuthForwarderHandler == nil {
-		r.apiAuthForwarderHandler = api.NewAuthForwarderHandler(r)
+func (r *RegistryMemory) DecisionTraefikHandler() *api.DecisionTraefikHandler {
+	if r.apiDecisionTraefikerHandler == nil {
+		r.apiDecisionTraefikerHandler = api.NewDecisionTraefikerHandler(r)
 	}
-	return r.apiAuthForwarderHandler
+	return r.apiDecisionTraefikerHandler
 }
 
 func (r *RegistryMemory) CredentialsFetcher() credentials.Fetcher {

--- a/driver/registry_memory.go
+++ b/driver/registry_memory.go
@@ -53,9 +53,9 @@ type RegistryMemory struct {
 	apiAuthForwarderHandler	*api.AuthForwardHandler
 	healthxHandler      	*healthx.Handler
 
-	proxyRequestHandler 	*proxy.RequestHandler
-	proxyProxy          	*proxy.Proxy
-	ruleFetcher         	rule.Fetcher
+	proxyRequestHandler *proxy.RequestHandler
+	proxyProxy          *proxy.Proxy
+	ruleFetcher         rule.Fetcher
 
 	authenticators map[string]authn.Authenticator
 	authorizers    map[string]authz.Authorizer

--- a/driver/registry_memory.go
+++ b/driver/registry_memory.go
@@ -43,15 +43,15 @@ type RegistryMemory struct {
 
 	ch *api.CredentialsHandler
 
-	credentialsFetcher  	credentials.Fetcher
-	credentialsVerifier 	credentials.Verifier
-	credentialsSigner   	credentials.Signer
-	ruleValidator       	rule.Validator
-	ruleRepository      	*rule.RepositoryMemory
-	apiRuleHandler      	*api.RuleHandler
-	apiJudgeHandler     	*api.DecisionHandler
+	credentialsFetcher  		credentials.Fetcher
+	credentialsVerifier 		credentials.Verifier
+	credentialsSigner   		credentials.Signer
+	ruleValidator       		rule.Validator
+	ruleRepository      		*rule.RepositoryMemory
+	apiRuleHandler      		*api.RuleHandler
+	apiJudgeHandler     		*api.DecisionHandler
 	apiDecisionTraefikerHandler	*api.DecisionTraefikHandler
-	healthxHandler      	*healthx.Handler
+	healthxHandler      		*healthx.Handler
 
 	proxyRequestHandler *proxy.RequestHandler
 	proxyProxy          *proxy.Proxy


### PR DESCRIPTION
Behaves identical to /decisions except that it gets the url and method from the headers.
This allows integration with Traefik's ForwardAuth middleware.

## Related issue

#263 

## Proposed changes

Add integration with Traefik by adding a new `/auth_forward` endpoint that behaves identical to `/decisions` except that it gets the url and method from the following headers:

- `X-Forwarded-Uri`
- `X-Forwarded-Method`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

I've copied the `decision.go` file, renamed where appropriate, and changed the rule matcher input. Found references to `DecisionHandler` and added the new `AuthForwardHandler` accordingly.
I've tested locally with this config https://gist.github.com/MVanderlee/2dba10f1ed6c869630eab27847bc2d12

The endpoint only has to support GET but wasn't sure how that's achieved. 

Please review carefully as I'm not familiar with GoLang.