### PR TITLE
Support alternative token location

### DIFF
--- a/.schemas/authenticators.jwt.schema.json
+++ b/.schemas/authenticators.jwt.schema.json
@@ -52,7 +52,7 @@
     },
     "token_from": {
       "title": "Token From",
-      "description": "The location of the bearer token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n Only one location (header or query) can be specified.",
+      "description": "The location of the bearer token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
       "oneOf": [
         {
           "type": "object",
@@ -63,7 +63,7 @@
             "header": {
               "title": "Header",
               "type": "string",
-              "description": "The header that must contain a Bearer token for request authentication. It can't be set along with query_parameter."
+              "description": "The header (case insensitive) that must contain a Bearer token for request authentication. It can't be set along with query_parameter."
             }
           }
         },
@@ -76,7 +76,7 @@
             "query_parameter": {
               "title": "Query Parameter",
               "type": "string",
-              "description": "The query parameter that must contain a Bearer token for request authentication. It can't be set along with header."
+              "description": "The query parameter (case sensitive) that must contain a Bearer token for request authentication. It can't be set along with header."
             }
           }
         }

--- a/.schemas/authenticators.jwt.schema.json
+++ b/.schemas/authenticators.jwt.schema.json
@@ -49,6 +49,38 @@
     },
     "scope_strategy": {
       "$ref": "https://raw.githubusercontent.com/ory/oathkeeper/master/.schemas/scope_strategy.schema.json#"
+    },
+    "token_from": {
+      "title": "Token From",
+      "description": "The location of the bearer token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n Only one location (header or query) can be specified.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "header"
+          ],
+          "properties": {
+            "header": {
+              "title": "Header",
+              "type": "string",
+              "description": "The header that must contain a Bearer token for request authentication. It can't be set along with query_parameter."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "query_parameter"
+          ],
+          "properties": {
+            "query_parameter": {
+              "title": "Query Parameter",
+              "type": "string",
+              "description": "The query parameter that must contain a Bearer token for request authentication. It can't be set along with header."
+            }
+          }
+        }
+      ]
     }
   },
   "additionalProperties": false

--- a/.schemas/authenticators.jwt.schema.json
+++ b/.schemas/authenticators.jwt.schema.json
@@ -52,7 +52,7 @@
     },
     "token_from": {
       "title": "Token From",
-      "description": "The location of the bearer token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
+      "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
       "oneOf": [
         {
           "type": "object",
@@ -63,7 +63,7 @@
             "header": {
               "title": "Header",
               "type": "string",
-              "description": "The header (case insensitive) that must contain a Bearer token for request authentication. It can't be set along with query_parameter."
+              "description": "The header (case insensitive) that must contain a token for request authentication. It can't be set along with query_parameter."
             }
           }
         },
@@ -76,7 +76,7 @@
             "query_parameter": {
               "title": "Query Parameter",
               "type": "string",
-              "description": "The query parameter (case sensitive) that must contain a Bearer token for request authentication. It can't be set along with header."
+              "description": "The query parameter (case sensitive) that must contain a token for request authentication. It can't be set along with header."
             }
           }
         }

--- a/.schemas/authenticators.oauth2_introspection.schema.json
+++ b/.schemas/authenticators.oauth2_introspection.schema.json
@@ -104,7 +104,7 @@
     },
     "token_from": {
       "title": "Token From",
-      "description": "The location of the bearer token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n Only one location (header or query) can be specified.",
+      "description": "The location of the bearer token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
       "oneOf": [
         {
           "type": "object",
@@ -115,7 +115,7 @@
             "header": {
               "title": "Header",
               "type": "string",
-              "description": "The header that must contain a Bearer token for request authentication. It can't be set along with query_parameter."
+              "description": "The header (case insensitive) that must contain a Bearer token for request authentication.\n It can't be set along with query_parameter."
             }
           }
         },
@@ -128,7 +128,7 @@
             "query_parameter": {
               "title": "Query Parameter",
               "type": "string",
-              "description": "The query parameter that must contain a Bearer token for request authentication. It can't be set along with header."
+              "description": "The query parameter (case sensitive) that must contain a Bearer token for request authentication.\n It can't be set along with header."
             }
           }
         }

--- a/.schemas/authenticators.oauth2_introspection.schema.json
+++ b/.schemas/authenticators.oauth2_introspection.schema.json
@@ -101,6 +101,38 @@
       "items": {
         "type": "string"
       }
+    },
+    "token_from": {
+      "title": "Token From",
+      "description": "The location of the bearer token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n Only one location (header or query) can be specified.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "header"
+          ],
+          "properties": {
+            "header": {
+              "title": "Header",
+              "type": "string",
+              "description": "The header that must contain a Bearer token for request authentication. It can't be set along with query_parameter."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "query_parameter"
+          ],
+          "properties": {
+            "query_parameter": {
+              "title": "Query Parameter",
+              "type": "string",
+              "description": "The query parameter that must contain a Bearer token for request authentication. It can't be set along with header."
+            }
+          }
+        }
+      ]
     }
   },
   "required": [

--- a/.schemas/authenticators.oauth2_introspection.schema.json
+++ b/.schemas/authenticators.oauth2_introspection.schema.json
@@ -104,7 +104,7 @@
     },
     "token_from": {
       "title": "Token From",
-      "description": "The location of the bearer token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
+      "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
       "oneOf": [
         {
           "type": "object",
@@ -115,7 +115,7 @@
             "header": {
               "title": "Header",
               "type": "string",
-              "description": "The header (case insensitive) that must contain a Bearer token for request authentication.\n It can't be set along with query_parameter."
+              "description": "The header (case insensitive) that must contain a token for request authentication.\n It can't be set along with query_parameter."
             }
           }
         },
@@ -128,7 +128,7 @@
             "query_parameter": {
               "title": "Query Parameter",
               "type": "string",
-              "description": "The query parameter (case sensitive) that must contain a Bearer token for request authentication.\n It can't be set along with header."
+              "description": "The query parameter (case sensitive) that must contain a token for request authentication.\n It can't be set along with header."
             }
           }
         }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bxcodec/faker v2.0.1+incompatible
 	github.com/cenkalti/backoff v2.1.1+incompatible
+	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0

--- a/helper/bearer.go
+++ b/helper/bearer.go
@@ -25,14 +25,28 @@ import (
 	"strings"
 )
 
+const (
+	defaultAuthorizationHeader = "Authorization"
+)
+
 type BearerTokenLocation struct {
 	Header         *string `json:"header"`
 	QueryParameter *string `json:"query_parameter"`
 }
 
 func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation) string {
-	auth := r.Header.Get("Authorization")
-	split := strings.SplitN(auth, " ", 2)
+	var token string
+	if tokenLocation != nil {
+		if tokenLocation.Header != nil {
+			token = r.Header.Get(*tokenLocation.Header)
+		} else if tokenLocation.QueryParameter != nil {
+			token = r.FormValue(*tokenLocation.QueryParameter)
+		}
+	} else {
+		token = r.Header.Get(defaultAuthorizationHeader)
+	}
+
+	split := strings.SplitN(token, " ", 2)
 	if len(split) != 2 || !strings.EqualFold(split[0], "bearer") {
 		return ""
 	}

--- a/helper/bearer.go
+++ b/helper/bearer.go
@@ -35,19 +35,14 @@ type BearerTokenLocation struct {
 }
 
 func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation) string {
-	var token string
 	if tokenLocation != nil {
 		if tokenLocation.Header != nil {
-			token = r.Header.Get(*tokenLocation.Header)
+			return r.Header.Get(*tokenLocation.Header)
 		} else if tokenLocation.QueryParameter != nil {
-			token = r.FormValue(*tokenLocation.QueryParameter)
-		} else {
-			token = r.Header.Get(defaultAuthorizationHeader)
+			return r.FormValue(*tokenLocation.QueryParameter)
 		}
-	} else {
-		token = r.Header.Get(defaultAuthorizationHeader)
 	}
-
+	token := r.Header.Get(defaultAuthorizationHeader)
 	split := strings.SplitN(token, " ", 2)
 	if len(split) != 2 || !strings.EqualFold(split[0], "bearer") {
 		return ""

--- a/helper/bearer.go
+++ b/helper/bearer.go
@@ -25,7 +25,12 @@ import (
 	"strings"
 )
 
-func BearerTokenFromRequest(r *http.Request) string {
+type BearerTokenLocation struct {
+	Header         *string `json:"header"`
+	QueryParameter *string `json:"query_parameter"`
+}
+
+func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation) string {
 	auth := r.Header.Get("Authorization")
 	split := strings.SplitN(auth, " ", 2)
 	if len(split) != 2 || !strings.EqualFold(split[0], "bearer") {

--- a/helper/bearer.go
+++ b/helper/bearer.go
@@ -41,6 +41,8 @@ func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation)
 			token = r.Header.Get(*tokenLocation.Header)
 		} else if tokenLocation.QueryParameter != nil {
 			token = r.FormValue(*tokenLocation.QueryParameter)
+		} else {
+			token = r.Header.Get(defaultAuthorizationHeader)
 		}
 	} else {
 		token = r.Header.Get(defaultAuthorizationHeader)

--- a/helper/bearer_test.go
+++ b/helper/bearer_test.go
@@ -58,4 +58,11 @@ func TestBearerTokenFromRequest(t *testing.T) {
 		token := helper.BearerTokenFromRequest(request, &tokenLocation)
 		assert.Equal(t, expectedToken, token)
 	})
+	t.Run("case=token should be received from default header if custom token location is set, but neither Header nor Query Param is configured", func(t *testing.T) {
+		expectedToken := "token"
+		request := &http.Request{Header: http.Header{defaultHeaderName: {"bearer " + expectedToken}}}
+		tokenLocation := helper.BearerTokenLocation{}
+		token := helper.BearerTokenFromRequest(request, &tokenLocation)
+		assert.Equal(t, expectedToken, token)
+	})
 }

--- a/helper/bearer_test.go
+++ b/helper/bearer_test.go
@@ -1,0 +1,60 @@
+package helper_test
+
+import (
+	"github.com/ory/oathkeeper/helper"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+const (
+	defaultHeaderName = "Authorization"
+)
+
+func TestBearerTokenFromRequest(t *testing.T) {
+	t.Run("case=token should be received from default header if custom location is not set and token is present", func(t *testing.T) {
+		expectedToken := "token"
+		request := &http.Request{Header: http.Header{defaultHeaderName: {"bearer " + expectedToken}}}
+		token := helper.BearerTokenFromRequest(request, nil)
+		assert.Equal(t, expectedToken, token)
+	})
+	t.Run("case=should return empty string if custom location is not set and token is not present in default header", func(t *testing.T) {
+		request := &http.Request{}
+		token := helper.BearerTokenFromRequest(request, nil)
+		assert.Empty(t, token)
+	})
+	t.Run("case=should return empty string if custom location is set to header and token is not present in that header", func(t *testing.T) {
+		customHeaderName := "Custom-Auth-Header"
+		request := &http.Request{Header: http.Header{defaultHeaderName: {"bearer token"}}}
+		tokenLocation := helper.BearerTokenLocation{Header: &customHeaderName}
+		token := helper.BearerTokenFromRequest(request, &tokenLocation)
+		assert.Empty(t, token)
+	})
+	t.Run("case=should return empty string if custom location is set to query parameter and token is not present in that query parameter", func(t *testing.T) {
+		customQueryParameterName := "Custom-Auth"
+		request := &http.Request{Header: http.Header{defaultHeaderName: {"bearer token"}}}
+		tokenLocation := helper.BearerTokenLocation{QueryParameter: &customQueryParameterName}
+		token := helper.BearerTokenFromRequest(request, &tokenLocation)
+		assert.Empty(t, token)
+	})
+	t.Run("case=token should be received from custom header if custom location is set to header and token is present", func(t *testing.T) {
+		expectedToken := "token"
+		customHeaderName := "Custom-Auth-Header"
+		request := &http.Request{Header: http.Header{customHeaderName: {"bearer " + expectedToken}}}
+		tokenLocation := helper.BearerTokenLocation{Header: &customHeaderName}
+		token := helper.BearerTokenFromRequest(request, &tokenLocation)
+		assert.Equal(t, expectedToken, token)
+	})
+	t.Run("case=token should be received from custom header if custom location is set to query parameter and token is present", func(t *testing.T) {
+		expectedToken := "token"
+		customQueryParameterName := "Custom-Auth"
+		request := &http.Request{
+			Form: map[string][]string{
+				customQueryParameterName: []string{"bearer " + expectedToken},
+			},
+		}
+		tokenLocation := helper.BearerTokenLocation{QueryParameter: &customQueryParameterName}
+		token := helper.BearerTokenFromRequest(request, &tokenLocation)
+		assert.Equal(t, expectedToken, token)
+	})
+}

--- a/helper/bearer_test.go
+++ b/helper/bearer_test.go
@@ -1,10 +1,11 @@
 package helper_test
 
 import (
-	"github.com/ory/oathkeeper/helper"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/ory/oathkeeper/helper"
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/helper/bearer_test.go
+++ b/helper/bearer_test.go
@@ -41,7 +41,7 @@ func TestBearerTokenFromRequest(t *testing.T) {
 	t.Run("case=token should be received from custom header if custom location is set to header and token is present", func(t *testing.T) {
 		expectedToken := "token"
 		customHeaderName := "Custom-Auth-Header"
-		request := &http.Request{Header: http.Header{customHeaderName: {"bearer " + expectedToken}}}
+		request := &http.Request{Header: http.Header{customHeaderName: {expectedToken}}}
 		tokenLocation := helper.BearerTokenLocation{Header: &customHeaderName}
 		token := helper.BearerTokenFromRequest(request, &tokenLocation)
 		assert.Equal(t, expectedToken, token)
@@ -51,7 +51,7 @@ func TestBearerTokenFromRequest(t *testing.T) {
 		customQueryParameterName := "Custom-Auth"
 		request := &http.Request{
 			Form: map[string][]string{
-				customQueryParameterName: []string{"bearer " + expectedToken},
+				customQueryParameterName: []string{expectedToken},
 			},
 		}
 		tokenLocation := helper.BearerTokenLocation{QueryParameter: &customQueryParameterName}

--- a/pipeline/authn/authenticator_jwt.go
+++ b/pipeline/authn/authenticator_jwt.go
@@ -21,12 +21,13 @@ type AuthenticatorJWTRegistry interface {
 }
 
 type AuthenticatorOAuth2JWTConfiguration struct {
-	Scope             []string `json:"required_scope"`
-	Audience          []string `json:"target_audience"`
-	Issuers           []string `json:"trusted_issuers"`
-	AllowedAlgorithms []string `json:"allowed_algorithms"`
-	JWKSURLs          []string `json:"jwks_urls"`
-	ScopeStrategy     string   `json:"scope_strategy"`
+	Scope               []string                    `json:"required_scope"`
+	Audience            []string                    `json:"target_audience"`
+	Issuers             []string                    `json:"trusted_issuers"`
+	AllowedAlgorithms   []string                    `json:"allowed_algorithms"`
+	JWKSURLs            []string                    `json:"jwks_urls"`
+	ScopeStrategy       string                      `json:"scope_strategy"`
+	BearerTokenLocation *helper.BearerTokenLocation `json:"token_from"`
 }
 
 type AuthenticatorJWT struct {
@@ -67,14 +68,14 @@ func (a *AuthenticatorJWT) Config(config json.RawMessage) (*AuthenticatorOAuth2J
 }
 
 func (a *AuthenticatorJWT) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
-	token := helper.BearerTokenFromRequest(r)
-	if token == "" {
-		return nil, errors.WithStack(ErrAuthenticatorNotResponsible)
-	}
-
 	cf, err := a.Config(config)
 	if err != nil {
 		return nil, err
+	}
+
+	token := helper.BearerTokenFromRequest(r, cf.BearerTokenLocation)
+	if token == "" {
+		return nil, errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
 	if len(cf.AllowedAlgorithms) == 0 {

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -187,7 +187,7 @@ func TestAuthenticatorJWT(t *testing.T) {
 				expectCode: 401,
 			},
 			{
-				d: "should pass because JWT is missing scope",
+				d: "should fail because JWT is missing scope",
 				r: &http.Request{Header: http.Header{"Authorization": []string{"bearer " + gen(keys[2], jwt.MapClaims{
 					"sub":   "sub",
 					"exp":   now.Add(time.Hour).Unix(),
@@ -197,7 +197,7 @@ func TestAuthenticatorJWT(t *testing.T) {
 				expectErr: true,
 			},
 			{
-				d: "should pass because JWT issuer is untrusted",
+				d: "should fail because JWT issuer is untrusted",
 				r: &http.Request{Header: http.Header{"Authorization": []string{"bearer " + gen(keys[1], jwt.MapClaims{
 					"sub": "sub",
 					"exp": now.Add(time.Hour).Unix(),
@@ -207,7 +207,7 @@ func TestAuthenticatorJWT(t *testing.T) {
 				expectErr: true,
 			},
 			{
-				d: "should pass because JWT is missing audience",
+				d: "should fail because JWT is missing audience",
 				r: &http.Request{Header: http.Header{"Authorization": []string{"bearer " + gen(keys[1], jwt.MapClaims{
 					"sub": "sub",
 					"exp": now.Add(time.Hour).Unix(),

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -101,7 +101,7 @@ func TestAuthenticatorJWT(t *testing.T) {
 					"sub": "sub",
 					"exp": now.Add(time.Hour).Unix(),
 				})}}},
-				config:         `{"token_from": {"header": "X-MyCustomHeaderName"}}`,
+				config:         `{"token_from": {"header": "X-Custom-Header"}}`,
 				expectErr:      true,
 				expectExactErr: ErrAuthenticatorNotResponsible,
 			},
@@ -127,11 +127,11 @@ func TestAuthenticatorJWT(t *testing.T) {
 			},
 			{
 				d: "should pass because the valid JWT token was provided in a proper location (custom header)",
-				r: &http.Request{Header: http.Header{"X-MyCustomHeaderName": []string{"bearer " + gen(keys[1], jwt.MapClaims{
+				r: &http.Request{Header: http.Header{"X-Custom-Header": []string{"bearer " + gen(keys[1], jwt.MapClaims{
 					"sub": "sub",
 					"exp": now.Add(time.Hour).Unix(),
 				})}}},
-				config:    `{"token_from": {"header": "X-MyCustomHeaderName"}}`,
+				config:    `{"token_from": {"header": "X-Custom-Header"}}`,
 				expectErr: false,
 			},
 			{

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -110,10 +110,10 @@ func TestAuthenticatorJWT(t *testing.T) {
 				r: &http.Request{
 					Form: map[string][]string{
 						"someOtherQueryParam": []string{
-							fmt.Sprintf("bearer %s", gen(keys[1], jwt.MapClaims{
+							gen(keys[1], jwt.MapClaims{
 								"sub": "sub",
 								"exp": now.Add(time.Hour).Unix(),
-							})),
+							}),
 						},
 					},
 					Header: http.Header{"Authorization": []string{"bearer " + gen(keys[1], jwt.MapClaims{
@@ -127,7 +127,7 @@ func TestAuthenticatorJWT(t *testing.T) {
 			},
 			{
 				d: "should pass because the valid JWT token was provided in a proper location (custom header)",
-				r: &http.Request{Header: http.Header{"X-Custom-Header": []string{"bearer " + gen(keys[1], jwt.MapClaims{
+				r: &http.Request{Header: http.Header{"X-Custom-Header": []string{gen(keys[1], jwt.MapClaims{
 					"sub": "sub",
 					"exp": now.Add(time.Hour).Unix(),
 				})}}},
@@ -139,10 +139,10 @@ func TestAuthenticatorJWT(t *testing.T) {
 				r: &http.Request{
 					Form: map[string][]string{
 						"token": []string{
-							fmt.Sprintf("bearer %s", gen(keys[1], jwt.MapClaims{
+							gen(keys[1], jwt.MapClaims{
 								"sub": "sub",
 								"exp": now.Add(time.Hour).Unix(),
-							})),
+							}),
 						},
 					},
 				},

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -67,13 +67,14 @@ func TestAuthenticatorJWT(t *testing.T) {
 
 	t.Run("method=authenticate", func(t *testing.T) {
 		for k, tc := range []struct {
-			setup      func()
-			d          string
-			r          *http.Request
-			config     string
-			expectErr  bool
-			expectCode int
-			expectSess *AuthenticationSession
+			setup          func()
+			d              string
+			r              *http.Request
+			config         string
+			expectErr      bool
+			expectExactErr error
+			expectCode     int
+			expectSess     *AuthenticationSession
 		}{
 			{
 				d:         "should fail because no payloads",
@@ -84,6 +85,69 @@ func TestAuthenticatorJWT(t *testing.T) {
 				d:         "should fail because not a jwt",
 				r:         &http.Request{Header: http.Header{"Authorization": []string{"bearer invalid.token.sign"}}},
 				expectErr: true,
+			},
+			{
+				d: "should return error saying that authenticator is not responsible for validating the request, as the token was not provided in a proper location (default)",
+				r: &http.Request{Header: http.Header{"Foobar": []string{"bearer " + gen(keys[1], jwt.MapClaims{
+					"sub": "sub",
+					"exp": now.Add(time.Hour).Unix(),
+				})}}},
+				expectErr:      true,
+				expectExactErr: ErrAuthenticatorNotResponsible,
+			},
+			{
+				d: "should return error saying that authenticator is not responsible for validating the request, as the token was not provided in a proper location (custom header)",
+				r: &http.Request{Header: http.Header{"Authorization": []string{"bearer " + gen(keys[1], jwt.MapClaims{
+					"sub": "sub",
+					"exp": now.Add(time.Hour).Unix(),
+				})}}},
+				config:         `{"token_from": {"header": "X-MyCustomHeaderName"}}`,
+				expectErr:      true,
+				expectExactErr: ErrAuthenticatorNotResponsible,
+			},
+			{
+				d: "should return error saying that authenticator is not responsible for validating the request, as the token was not provided in a proper location (custom query parameter)",
+				r: &http.Request{
+					Form: map[string][]string{
+						"someOtherQueryParam": []string{
+							fmt.Sprintf("bearer %s", gen(keys[1], jwt.MapClaims{
+								"sub": "sub",
+								"exp": now.Add(time.Hour).Unix(),
+							})),
+						},
+					},
+					Header: http.Header{"Authorization": []string{"bearer " + gen(keys[1], jwt.MapClaims{
+						"sub": "sub",
+						"exp": now.Add(time.Hour).Unix(),
+					})}},
+				},
+				config:         `{"token_from": {"query_parameter": "token"}}`,
+				expectErr:      true,
+				expectExactErr: ErrAuthenticatorNotResponsible,
+			},
+			{
+				d: "should pass because the valid JWT token was provided in a proper location (custom header)",
+				r: &http.Request{Header: http.Header{"X-MyCustomHeaderName": []string{"bearer " + gen(keys[1], jwt.MapClaims{
+					"sub": "sub",
+					"exp": now.Add(time.Hour).Unix(),
+				})}}},
+				config:    `{"token_from": {"header": "X-MyCustomHeaderName"}}`,
+				expectErr: false,
+			},
+			{
+				d: "should pass because the valid JWT token was provided in a proper location (custom query parameter)",
+				r: &http.Request{
+					Form: map[string][]string{
+						"token": []string{
+							fmt.Sprintf("bearer %s", gen(keys[1], jwt.MapClaims{
+								"sub": "sub",
+								"exp": now.Add(time.Hour).Unix(),
+							})),
+						},
+					},
+				},
+				config:    `{"token_from": {"query_parameter": "token"}}`,
+				expectErr: false,
 			},
 			{
 				d: "should pass because JWT is valid",
@@ -235,10 +299,13 @@ func TestAuthenticatorJWT(t *testing.T) {
 				tc.config, _ = sjson.Set(tc.config, "jwks_urls", keys)
 				session, err := a.Authenticate(tc.r, json.RawMessage([]byte(tc.config)), nil)
 				if tc.expectErr {
+					require.Error(t, err)
 					if tc.expectCode != 0 {
 						assert.Equal(t, tc.expectCode, herodot.ToDefaultError(err, "").StatusCode(), "Status code mismatch")
 					}
-					require.Error(t, err)
+					if tc.expectExactErr != nil {
+						assert.EqualError(t, err, tc.expectExactErr.Error())
+					}
 				} else {
 					require.NoError(t, err, "%#v", errors.Cause(err))
 				}

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -20,12 +20,13 @@ import (
 )
 
 type AuthenticatorOAuth2IntrospectionConfiguration struct {
-	Scopes           []string                                              `json:"required_scope"`
-	Audience         []string                                              `json:"target_audience"`
-	Issuers          []string                                              `json:"trusted_issuers"`
-	PreAuth          *AuthenticatorOAuth2IntrospectionPreAuthConfiguration `json:"pre_authorization"`
-	ScopeStrategy    string                                                `json:"scope_strategy"`
-	IntrospectionURL string                                                `json:"introspection_url"`
+	Scopes              []string                                              `json:"required_scope"`
+	Audience            []string                                              `json:"target_audience"`
+	Issuers             []string                                              `json:"trusted_issuers"`
+	PreAuth             *AuthenticatorOAuth2IntrospectionPreAuthConfiguration `json:"pre_authorization"`
+	ScopeStrategy       string                                                `json:"scope_strategy"`
+	IntrospectionURL    string                                                `json:"introspection_url"`
+	BearerTokenLocation *helper.BearerTokenLocation                           `json:"token_from"`
 }
 
 type AuthenticatorOAuth2IntrospectionPreAuthConfiguration struct {
@@ -70,7 +71,7 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, config 
 		return nil, err
 	}
 
-	token := helper.BearerTokenFromRequest(r)
+	token := helper.BearerTokenFromRequest(r, cf.BearerTokenLocation)
 	if token == "" {
 		return nil, errors.WithStack(ErrAuthenticatorNotResponsible)
 	}

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -104,7 +104,15 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				r:         &http.Request{Header: http.Header{"X-Custom-Header": {"bearer token"}}},
 				config:    []byte(`{"token_from": {"header": "X-Custom-Header"}}`),
 				expectErr: false,
-				// TODO: will need to set some config here, so the test can pass
+				setup: func(t *testing.T, m *httprouter.Router) {
+					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "token", r.Form.Get("token"))
+						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
+							Active: true,
+						}))
+					})
+				},
 			},
 			{
 				d: "should pass because the valid JWT token was provided in a proper location (custom query parameter)",
@@ -115,7 +123,15 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				},
 				config:    []byte(`{"token_from": {"query_parameter": "token"}}`),
 				expectErr: false,
-				// TODO: will need to set some config here, so the test can pass
+				setup: func(t *testing.T, m *httprouter.Router) {
+					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "token", r.Form.Get("token"))
+						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
+							Active: true,
+						}))
+					})
+				},
 			},
 			{
 				d:      "should fail because not active",

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -83,7 +83,7 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 			{
 				d:              "should return error saying that authenticator is not responsible for validating the request, as the token was not provided in a proper location (custom header)",
 				r:              &http.Request{Header: http.Header{"Authorization": {"bearer token"}}},
-				config:         []byte(`{"token_from": {"header": "X-MyCustomHeaderName"}}`),
+				config:         []byte(`{"token_from": {"header": "X-Custom-Header"}}`),
 				expectErr:      true,
 				expectExactErr: ErrAuthenticatorNotResponsible,
 			},
@@ -101,8 +101,8 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 			},
 			{
 				d:         "should pass because the valid JWT token was provided in a proper location (custom header)",
-				r:         &http.Request{Header: http.Header{"X-MyCustomHeaderName": {"bearer token"}}},
-				config:    []byte(`{"token_from": {"header": "X-MyCustomHeaderName"}}`),
+				r:         &http.Request{Header: http.Header{"X-Custom-Header": {"bearer token"}}},
+				config:    []byte(`{"token_from": {"header": "X-Custom-Header"}}`),
 				expectErr: false,
 				// TODO: will need to set some config here, so the test can pass
 			},

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -92,7 +92,7 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				d: "should return error saying that authenticator is not responsible for validating the request, as the token was not provided in a proper location (custom query parameter)",
 				r: &http.Request{
 					Form: map[string][]string{
-						"someOtherQueryParam": []string{"bearer token"},
+						"someOtherQueryParam": []string{"token"},
 					},
 					Header: http.Header{"Authorization": {"bearer token"}},
 				},
@@ -102,7 +102,7 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 			},
 			{
 				d:         "should pass because the valid JWT token was provided in a proper location (custom header)",
-				r:         &http.Request{Header: http.Header{"X-Custom-Header": {"bearer token"}}},
+				r:         &http.Request{Header: http.Header{"X-Custom-Header": {"token"}}},
 				config:    []byte(`{"token_from": {"header": "X-Custom-Header"}}`),
 				expectErr: false,
 				setup: func(t *testing.T, m *httprouter.Router) {
@@ -119,7 +119,7 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				d: "should pass because the valid JWT token was provided in a proper location (custom query parameter)",
 				r: &http.Request{
 					Form: map[string][]string{
-						"token": []string{"bearer token"},
+						"token": []string{"token"},
 					},
 				},
 				config:    []byte(`{"token_from": {"query_parameter": "token"}}`),

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -23,6 +23,10 @@ package authn_test
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/internal"
@@ -31,9 +35,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/sjson"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestAuthenticatorOAuth2Introspection(t *testing.T) {


### PR DESCRIPTION
## Related issue

#257 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
Add additional optional configuration to jwt and oauth2_introspection authenticators allowing to set from where (which header or query parameter) the token should be received. The configuration is a `token_from` field in per-rule-configuration, as described in a linked issue.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->