### PR TITLE
cmd: Run BindEnv() on boot

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,8 @@ import (
 	"github.com/ory/x/viperx"
 
 	"github.com/ory/x/logrusx"
+
+	"github.com/ory/oathkeeper/driver/configuration"
 )
 
 var schemas = packr.New("schemas", "../.schemas")
@@ -64,6 +66,7 @@ func init() {
 
 	cobra.OnInitialize(func() {
 		viperx.InitializeConfig("oathkeeper", "", nil)
+		configuration.BindEnvs()
 
 		logger = logrusx.New()
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bxcodec/faker v2.0.1+incompatible
 	github.com/cenkalti/backoff v2.1.1+incompatible
-	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Closes #276 
Closes #270

Additionally, lines https://github.com/ory/oathkeeper/commit/89709aabfe002fc5ae2e76016fc45a13d74f3d8b#diff-2449a6ea083767b149400840c05f41bdL43-L74 should be added again.

Also, we need to document changes to the config keys (everything is now prefixed with `CONFIG`).