### PR TITLE
Fix configuration with env vars

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,11 +30,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ory/gojsonschema"
-
+	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/viper"
-	"github.com/ory/x/viperx"
-
 	"github.com/ory/x/logrusx"
+	"github.com/ory/x/viperx"
 )
 
 var schemas = packr.New("schemas", "../.schemas")
@@ -63,6 +62,7 @@ func init() {
 	}
 
 	cobra.OnInitialize(func() {
+		configuration.BindEnvs()
 		viperx.InitializeConfig("oathkeeper", "", nil)
 
 		logger = logrusx.New()

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -87,7 +87,7 @@ const (
 )
 
 func BindEnvs() {
-	if err := viper.BindEnv(
+	keys := []string{
 		ViperKeyProxyReadTimeout,
 		ViperKeyProxyWriteTimeout,
 		ViperKeyProxyIdleTimeout,
@@ -112,8 +112,13 @@ func BindEnvs() {
 		ViperKeyAuthenticatorOAuth2ClientCredentialsIsEnabled,
 		ViperKeyAuthenticatorOAuth2TokenIntrospectionIsEnabled,
 		ViperKeyAuthenticatorUnauthorizedIsEnabled,
-	); err != nil {
-		panic(err.Error())
+	}
+
+	for _, key := range keys {
+		env := strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+		if err := viper.BindEnv(key, env); err != nil {
+			panic(err.Error())
+		}
 	}
 }
 

--- a/driver/configuration/provider_viper_public_test.go
+++ b/driver/configuration/provider_viper_public_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/rs/cors"
@@ -341,4 +342,22 @@ func TestAuthenticatorOAuth2TokenIntrospectionPreAuthorization(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestViperProvider_envs(t *testing.T) {
+	p := NewViperProvider(logrus.New())
+	BindEnvs()
+
+	assert.Equal(t, ":4455", p.ProxyServeAddress())
+	assert.Equal(t, false, p.AuthenticatorIsEnabled("oauth2_introspection"))
+
+	err := os.Setenv("SERVE_PROXY_HOST", "foo")
+	require.NoError(t, err)
+	err = os.Setenv("SERVE_PROXY_PORT", "8080")
+	require.NoError(t, err)
+	err = os.Setenv("AUTHENTICATORS_OAUTH2_INTROSPECTION_ENABLED", "true")
+	require.NoError(t, err)
+
+	assert.Equal(t, "foo:8080", p.ProxyServeAddress())
+	assert.Equal(t, true, p.AuthenticatorIsEnabled("oauth2_introspection"))
 }


### PR DESCRIPTION
## Related issue

- https://github.com/ory/oathkeeper/issues/276
- https://github.com/ory/oathkeeper/issues/270

## Proposed changes

Currently env vars do not work for any configuration property. One reason is because [BindEnv](https://github.com/ory/oathkeeper/blob/40e3b891b99a41bee4b7be1a2cf7463bfb64f8db/driver/configuration/provider_viper.go#L90) is never called. The other thing that actually the usage of BindEnv is incorrect: this function DOES NOT accept multiple keys (see [source](https://github.com/spf13/viper/blob/master/viper.go#L960) for details). Even if BindEnv would be used correctly, it will not resolve env vars like `SERVE_PROXY_PORT` because it does not replaces dots with underscores.

This MR provides the same way of loading env vars as in [hydra](https://github.com/ory/hydra/blob/master/driver/configuration/provider_viper.go#L72).

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)
