### PR TITLE
cmd: Add option to disable access log for health endpoints

### DIFF
--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -19,6 +19,17 @@
         }
       }
     },
+    "accessLog": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disable_for_health": {
+          "title": "Disable for healthcheck endpoints",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
     "scopeStrategy": {
       "title": "Scope Strategy",
       "type": "string",
@@ -64,6 +75,9 @@
             },
             "tls": {
               "$ref": "https://raw.githubusercontent.com/ory/x/master/.schemas/tlsx/viper.schema.json#"
+            },
+            "access_log": {
+              "$ref": "#/definitions/accessLog"
             }
           }
         },
@@ -137,6 +151,9 @@
             },
             "tls": {
               "$ref": "https://raw.githubusercontent.com/ory/x/master/.schemas/tlsx/viper.schema.json#"
+            },
+            "access_log": {
+              "$ref": "#/definitions/accessLog"
             }
           }
         }

--- a/docs/.oathkeeper.yaml
+++ b/docs/.oathkeeper.yaml
@@ -44,6 +44,11 @@ serve:
         path: /path/to/cert.pem
         base64: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlEWlRDQ0FrMmdBd0lCQWdJRVY1eE90REFOQmdr...
 
+    # Access Log configuration for proxy server.
+    access_log:
+      # Disable access log for health endpoints.
+      disable_for_health: false
+
   api:
     port: 1235
     host: 127.0.0.2
@@ -72,6 +77,11 @@ serve:
       cert:
         path: /path/to/cert.pem
         base64: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlEWlRDQ0FrMmdBd0lCQWdJRVY1eE90REFOQmdr...
+
+    # Access Log configuration for api server.
+    access_log:
+      # Disable access log for health endpoints.
+      disable_for_health: false
 
 # Configures Access Rules
 access_rules:

--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -30,7 +30,9 @@ type Provider interface {
 	AccessRuleRepositories() []url.URL
 
 	ProxyServeAddress() string
+	ProxyDisableHealthAccessLog() bool
 	APIServeAddress() string
+	APIDisableHealthAccessLog() bool
 
 	ToScopeStrategy(value string, key string) fosite.ScopeStrategy
 	ParseURLs(sources []string) ([]url.URL, error)

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -29,14 +29,16 @@ import (
 var _ Provider = new(ViperProvider)
 
 const (
-	ViperKeyProxyReadTimeout       = "serve.proxy.timeout.read"
-	ViperKeyProxyWriteTimeout      = "serve.proxy.timeout.write"
-	ViperKeyProxyIdleTimeout       = "serve.proxy.timeout.idle"
-	ViperKeyProxyServeAddressHost  = "serve.proxy.host"
-	ViperKeyProxyServeAddressPort  = "serve.proxy.port"
-	ViperKeyAPIServeAddressHost    = "serve.api.host"
-	ViperKeyAPIServeAddressPort    = "serve.api.port"
-	ViperKeyAccessRuleRepositories = "access_rules.repositories"
+	ViperKeyProxyReadTimeout            = "serve.proxy.timeout.read"
+	ViperKeyProxyWriteTimeout           = "serve.proxy.timeout.write"
+	ViperKeyProxyIdleTimeout            = "serve.proxy.timeout.idle"
+	ViperKeyProxyServeAddressHost       = "serve.proxy.host"
+	ViperKeyProxyServeAddressPort       = "serve.proxy.port"
+	ViperKeyProxyDisableHealthAccessLog = "serve.proxy.access_log.disable_for_health"
+	ViperKeyAPIServeAddressHost         = "serve.api.host"
+	ViperKeyAPIServeAddressPort         = "serve.api.port"
+	ViperKeyAPIDisableHealthAccessLog   = "serve.api.access_log.disable_for_health"
+	ViperKeyAccessRuleRepositories      = "access_rules.repositories"
 )
 
 // Authorizers
@@ -93,8 +95,10 @@ func BindEnvs() {
 		ViperKeyProxyIdleTimeout,
 		ViperKeyProxyServeAddressHost,
 		ViperKeyProxyServeAddressPort,
+		ViperKeyProxyDisableHealthAccessLog,
 		ViperKeyAPIServeAddressHost,
 		ViperKeyAPIServeAddressPort,
+		ViperKeyAPIDisableHealthAccessLog,
 		ViperKeyAccessRuleRepositories,
 		ViperKeyAuthorizerAllowIsEnabled,
 		ViperKeyAuthorizerDenyIsEnabled,
@@ -163,12 +167,20 @@ func (v *ViperProvider) ProxyServeAddress() string {
 	)
 }
 
+func (v *ViperProvider) ProxyDisableHealthAccessLog() bool {
+	return viperx.GetBool(v.l, ViperKeyProxyDisableHealthAccessLog, false)
+}
+
 func (v *ViperProvider) APIServeAddress() string {
 	return fmt.Sprintf(
 		"%s:%d",
 		viperx.GetString(v.l, ViperKeyAPIServeAddressHost, ""),
 		viperx.GetInt(v.l, ViperKeyAPIServeAddressPort, 4456),
 	)
+}
+
+func (v *ViperProvider) APIDisableHealthAccessLog() bool {
+	return viperx.GetBool(v.l, ViperKeyAPIDisableHealthAccessLog, false)
 }
 
 func (v *ViperProvider) ParseURLs(sources []string) ([]url.URL, error) {


### PR DESCRIPTION
## Proposed changes

This changeset adds an option to disable access log for health endpoints.
This is especially helpful in environments like Kubernetes, where
special preprocessing filters would be required otherwise.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

The same idea and reasoning as in https://github.com/ory/hydra/pull/1458