### PR TITLE
authz: Add Content-Type header in the call to Keto

### DIFF
--- a/pipeline/authz/keto_engine_acp_ory.go
+++ b/pipeline/authz/keto_engine_acp_ory.go
@@ -130,6 +130,7 @@ func (a *AuthorizerKetoEngineACPORY) Authorize(r *http.Request, session *authn.A
 	}
 
 	req, err := http.NewRequest("POST", urlx.AppendPaths(baseURL, "/engines/acp/ory", flavor, "/allowed").String(), &b)
+	req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pipeline/authz/keto_engine_acp_ory_test.go
+++ b/pipeline/authz/keto_engine_acp_ory_test.go
@@ -107,6 +107,8 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 			r: &http.Request{URL: &url.URL{}},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assert.Contains(t, r.Header, "Content-Type")
+					assert.Contains(t, r.Header["Content-Type"], "application/json")
 					assert.Contains(t, r.URL.Path, "exact")
 					w.Write([]byte(`{"allowed":false}`))
 				}))


### PR DESCRIPTION
## Related issue

#289   @aeneasr

## Proposed changes

This change add a Content-Type header when Oathkeeper calls Keto.
As Keto expects a Json body, I added this header:
**Content-Type: application/json**

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
