### PR TITLE
add preserve_path option for cookie session to not override the path

### DIFF
--- a/.schemas/authenticators.cookie_session.schema.json
+++ b/.schemas/authenticators.cookie_session.schema.json
@@ -22,6 +22,11 @@
       },
       "title": "Only Cookies",
       "description": "A list of possible cookies to look for on incoming requests, and will fallthrough to the next authenticator if none of the passed cookies are set on the request."
+    },
+    "preserve_path": {
+      "title": "Preserve Path",
+      "type": "boolean",
+      "description": "When set to true, any path specified in `check_session_url` will be preserved instead of overwriting the path with the path from the original request"
     }
   },
   "required": [

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -215,6 +215,11 @@
           },
           "title": "Only Cookies",
           "description": "A list of possible cookies to look for on incoming requests, and will fallthrough to the next authenticator if none of the passed cookies are set on the request."
+        },
+        "preserve_path": {
+          "title": "Preserve Path",
+          "type": "boolean",
+          "description": "When set to true, any path specified in `check_session_url` will be preserved instead of overwriting the path with the path from the original request"
         }
       },
       "required": [


### PR DESCRIPTION

## Related issue

#296 

## Proposed changes

This adds a `preserve_path` option to the `cookie_session` authenticator to allow the original path specified to be used to check the session

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

You can configure as follows:

```yaml
authenticators:
  cookie_session:
    enabled: true
    config:
      check_session_url: https://example.com/check-session
      preserve_path: true
```

With `preserve_path` set to `true`, all session check calls will go to the path specified in the `check_session_url` rather than replacing it

I'm not in love with the parameter name, but it's the first thing that came to mind (except using `override_path` instead, but I don't want to change the default behavior)

I'm also thinking that the original request path should be preserved somewhere when this is set, either as a query param (`https://example.com/check-session?path=/original/path`) or as a header (`X-Oathkeeper-Original-Path: /original/path`). Thoughts on that?