### PR TITLE
add cookie as an option for oauth2_introspection authenticator

### DIFF
--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -502,7 +502,7 @@
                 "cookie"
               ],
               "properties": {
-                "query_parameter": {
+                "cookie": {
                   "title": "Cookie",
                   "type": "string",
                   "description": "The cookie (case sensitive) that must contain a token for request authentication.\n It can't be set along with header or query_parameter."

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -481,7 +481,7 @@
                 "header": {
                   "title": "Header",
                   "type": "string",
-                  "description": "The header (case insensitive) that must contain a token for request authentication.\n It can't be set along with query_parameter."
+                  "description": "The header (case insensitive) that must contain a token for request authentication.\n It can't be set along with query_parameter or cookie."
                 }
               }
             },
@@ -493,7 +493,19 @@
                 "query_parameter": {
                   "title": "Query Parameter",
                   "type": "string",
-                  "description": "The query parameter (case sensitive) that must contain a token for request authentication.\n It can't be set along with header."
+                  "description": "The query parameter (case sensitive) that must contain a token for request authentication.\n It can't be set along with header or cookie."
+                }
+              }
+            },
+            {
+              "required": [
+                "cookie"
+              ],
+              "properties": {
+                "query_parameter": {
+                  "title": "Cookie",
+                  "type": "string",
+                  "description": "The cookie (case sensitive) that must contain a token for request authentication.\n It can't be set along with header or query_parameter."
                 }
               }
             }

--- a/helper/bearer.go
+++ b/helper/bearer.go
@@ -32,6 +32,7 @@ const (
 type BearerTokenLocation struct {
 	Header         *string `json:"header"`
 	QueryParameter *string `json:"query_parameter"`
+	Cookie         *string `json:"cookie"`
 }
 
 func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation) string {
@@ -40,6 +41,12 @@ func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation)
 			return r.Header.Get(*tokenLocation.Header)
 		} else if tokenLocation.QueryParameter != nil {
 			return r.FormValue(*tokenLocation.QueryParameter)
+		} else if tokenLocation.Cookie != nil {
+			cookie, err := r.Cookie(*tokenLocation.Cookie)
+			if err != nil {
+				return ""
+			}
+			return cookie.Value
 		}
 	}
 	token := r.Header.Get(defaultAuthorizationHeader)


### PR DESCRIPTION
## Proposed changes

Adds the ability to get the OAuth2 bearer token from a cookie in addition to header or query param. This allows an http-only, secure cookie to be used for storing oauth credentials.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

I'm not quite sure how to properly handle the schema files, I'm guessing there is some compilation going on there that is not documented (vs just editing the `config.schema.json` file as I have for now).
