### PR TITLE
allow specifying additional headers for the oauth introspection request

### DIFF
--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -468,9 +468,9 @@
             "type": "string"
           }
         },
-        "request_headers": {
-          "title": "Request Headers",
-          "description": "Additional headers to be added to the request to the OAuth2 Introspection URL",
+        "introspection_request_headers": {
+          "title": "Introspection Request Headers",
+          "description": "Additional headers to be added to the introspection request.",
           "type": "object"
         },
         "token_from": {

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -468,6 +468,11 @@
             "type": "string"
           }
         },
+        "request_headers": {
+          "title": "Request Headers",
+          "description": "Additional headers to be added to the request to the OAuth2 Introspection URL",
+          "type": "object"
+        },
         "token_from": {
           "title": "Token From",
           "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -20,14 +20,14 @@ import (
 )
 
 type AuthenticatorOAuth2IntrospectionConfiguration struct {
-	Scopes              []string                                              `json:"required_scope"`
-	Audience            []string                                              `json:"target_audience"`
-	Issuers             []string                                              `json:"trusted_issuers"`
-	PreAuth             *AuthenticatorOAuth2IntrospectionPreAuthConfiguration `json:"pre_authorization"`
-	ScopeStrategy       string                                                `json:"scope_strategy"`
-	IntrospectionURL    string                                                `json:"introspection_url"`
-	BearerTokenLocation *helper.BearerTokenLocation                           `json:"token_from"`
-	RequestHeaders      map[string]string                                     `json:"request_headers"`
+	Scopes                      []string                                              `json:"required_scope"`
+	Audience                    []string                                              `json:"target_audience"`
+	Issuers                     []string                                              `json:"trusted_issuers"`
+	PreAuth                     *AuthenticatorOAuth2IntrospectionPreAuthConfiguration `json:"pre_authorization"`
+	ScopeStrategy               string                                                `json:"scope_strategy"`
+	IntrospectionURL            string                                                `json:"introspection_url"`
+	BearerTokenLocation         *helper.BearerTokenLocation                           `json:"token_from"`
+	IntrospectionRequestHeaders map[string]string                                     `json:"introspection_request_headers"`
 }
 
 type AuthenticatorOAuth2IntrospectionPreAuthConfiguration struct {
@@ -82,7 +82,7 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, config 
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	for key, value := range cf.RequestHeaders {
+	for key, value := range cf.IntrospectionRequestHeaders {
 		introspectReq.Header.Set(key, value)
 	}
 	// set/override the content-type header


### PR DESCRIPTION

## Proposed changes

Adds the option to specify additional headers to the oauth introspection request. The main use case is for adding an `X-Forwarded-Proto` header for communicating with an internal hydra instance.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

Assuming this is accepted in general, I'll also add this feature to the oauth client credentials athenticator
