### PR TITLE
Use default logic if header is Authorization

### DIFF
--- a/helper/bearer.go
+++ b/helper/bearer.go
@@ -38,6 +38,9 @@ type BearerTokenLocation struct {
 func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation) string {
 	if tokenLocation != nil {
 		if tokenLocation.Header != nil {
+			if *tokenLocation.Header == defaultAuthorizationHeader {
+				return DefaultBearerTokenFromRequest(r)
+			}
 			return r.Header.Get(*tokenLocation.Header)
 		} else if tokenLocation.QueryParameter != nil {
 			return r.FormValue(*tokenLocation.QueryParameter)
@@ -49,6 +52,11 @@ func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation)
 			return cookie.Value
 		}
 	}
+
+	return DefaultBearerTokenFromRequest(r)
+}
+
+func DefaultBearerTokenFromRequest(r *http.Request) string {
 	token := r.Header.Get(defaultAuthorizationHeader)
 	split := strings.SplitN(token, " ", 2)
 	if len(split) != 2 || !strings.EqualFold(split[0], "bearer") {

--- a/helper/bearer_test.go
+++ b/helper/bearer_test.go
@@ -66,4 +66,12 @@ func TestBearerTokenFromRequest(t *testing.T) {
 		token := helper.BearerTokenFromRequest(request, &tokenLocation)
 		assert.Equal(t, expectedToken, token)
 	})
+	t.Run("case=token should be received from default header if custom location is set to default location and token is present", func(t *testing.T) {
+		expectedToken := "token"
+		customHeaderName := "Authorization"
+		request := &http.Request{Header: http.Header{customHeaderName: {"bearer " + expectedToken}}}
+		tokenLocation := helper.BearerTokenLocation{Header: &customHeaderName}
+		token := helper.BearerTokenFromRequest(request, &tokenLocation)
+		assert.Equal(t, expectedToken, token)
+	})
 }


### PR DESCRIPTION
## Related issue

https://github.com/ory/oathkeeper/issues/308

## Proposed changes

If Authorization header matches default value, then use the same default logic

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

