### PR TITLE
change viper provider to use method that load env vars correctly

### DIFF
--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -16,8 +16,6 @@ import (
 	"github.com/ory/gojsonschema"
 	"github.com/ory/x/jsonx"
 
-	"github.com/ory/viper"
-
 	"github.com/ory/fosite"
 	"github.com/ory/x/corsx"
 	"github.com/ory/x/urlx"
@@ -185,7 +183,7 @@ func (v *ViperProvider) pipelineIsEnabled(prefix, id string) bool {
 
 func (v *ViperProvider) PipelineConfig(prefix, id string, override json.RawMessage, dest interface{}) error {
 	// we need to create a copy for config otherwise we will accidentally override values
-	config, err := x.Deepcopy(viper.GetStringMap(fmt.Sprintf("%s.%s.config", prefix, id)))
+	config, err := x.Deepcopy(viperx.GetStringMapConfig(prefix, id, "config"))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/go-swagger/go-swagger v0.19.0
 	github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013 // indirect
 	github.com/gobuffalo/packr/v2 v2.0.0-rc.15
-	github.com/golang/gddo v0.0.0-20190312205958-5a2505f3dbf0 // indirect
 	github.com/golang/mock v1.3.1
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/handlers v1.4.0 // indirect
@@ -35,11 +34,9 @@ require (
 	github.com/jessevdk/go-flags v1.4.0 // indirect
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/lib/pq v1.0.0
-	github.com/luna-duclos/instrumentedsql v0.0.0-20190316074304-ecad98b20aec // indirect
 	github.com/mattn/goveralls v0.0.3
 	github.com/meatballhat/negroni-logrus v0.0.0-20170801195057-31067281800f
 	github.com/opencontainers/runc v1.0.0-rc5 // indirect
-	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/ory/fosite v0.29.2
 	github.com/ory/go-acc v0.0.0-20181118080137-ddc355013f90
 	github.com/ory/go-convenience v0.1.0
@@ -48,7 +45,7 @@ require (
 	github.com/ory/herodot v0.6.2
 	github.com/ory/ladon v1.0.1
 	github.com/ory/viper v1.5.6
-	github.com/ory/x v0.0.80
+	github.com/ory/x v0.0.87
 	github.com/pborman/uuid v1.2.0
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
@@ -60,7 +57,7 @@ require (
 	github.com/spf13/viper v1.4.0 // indirect
 	github.com/sqs/goreturns v0.0.0-20181028201513-538ac6014518
 	github.com/square/go-jose v2.3.1+incompatible
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/tidwall/gjson v1.3.2
 	github.com/tidwall/sjson v1.0.4
@@ -70,7 +67,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
 	golang.org/x/tools v0.0.0-20191026034945-b2104f82a97d
 	gopkg.in/square/go-jose.v2 v2.3.0
 )


### PR DESCRIPTION
## Related issue

https://github.com/ory/oathkeeper/issues/305

## Proposed changes

Use new helper method

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)
