### PR TITLE
cmd: Add health check commands

### DIFF
--- a/cmd/health.go
+++ b/cmd/health.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -9,7 +9,7 @@ import (
 // healthCmd represents the health command
 var healthCmd = &cobra.Command{
 	Use:   "health",
-	Short: "Commands for checking health",
+	Short: "Commands for checking the status of an ORY Oathkeeper deployment",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(cmd.UsageString())
 	},

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -10,6 +10,10 @@ import (
 var healthCmd = &cobra.Command{
 	Use:   "health",
 	Short: "Commands for checking the status of an ORY Oathkeeper deployment",
+	Long: `Note:
+  The endpoint URL should point to a single ORY Oathkeeper deployment.
+  If the endpoint URL points to a Load Balancer, these commands will effective test the Load Balancer.
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(cmd.UsageString())
 	},

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+// healthCmd represents the health command
+var healthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Commands for checking health",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(cmd.UsageString())
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(healthCmd)
+	healthCmd.PersistentFlags().StringP("endpoint", "e", "", "The endpoint URL of ORY Oathkeeper's management API")
+}

--- a/cmd/health_alive.go
+++ b/cmd/health_alive.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/ory/oathkeeper/sdk/go/oathkeeper/client/api"
+	"github.com/ory/x/cmdx"
+	"github.com/spf13/cobra"
+)
+
+// healthCmd represents the health command
+var healthAliveCmd = &cobra.Command{
+	Use:   "alive",
+	Short: "Command for checking alive status",
+	Run: func(cmd *cobra.Command, args []string) {
+		client := newClient(cmd)
+
+		r, err := client.API.IsInstanceAlive(api.NewIsInstanceAliveParams())
+		cmdx.Must(err, "%s", err)
+		fmt.Println(cmdx.FormatResponse(r.Payload))
+	},
+}
+
+func init() {
+	healthCmd.AddCommand(healthAliveCmd)
+}

--- a/cmd/health_alive.go
+++ b/cmd/health_alive.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/ory/oathkeeper/sdk/go/oathkeeper/client/api"
 	"github.com/ory/x/cmdx"
 	"github.com/spf13/cobra"

--- a/cmd/health_alive.go
+++ b/cmd/health_alive.go
@@ -11,7 +11,7 @@ import (
 // healthCmd represents the health command
 var healthAliveCmd = &cobra.Command{
 	Use:   "alive",
-	Short: "Command for checking alive status",
+	Short: "Checks if an ORY Oathkeeper deployment is alive",
 	Run: func(cmd *cobra.Command, args []string) {
 		client := newClient(cmd)
 

--- a/cmd/health_alive.go
+++ b/cmd/health_alive.go
@@ -15,6 +15,10 @@ var healthAliveCmd = &cobra.Command{
 	Short: "Checks if an ORY Oathkeeper deployment is alive",
 	Long: `Usage example:
   oathkeeper health --endpoint=http://localhost:4456/ alive
+
+Note:
+  The endpoint URL should point to a single ORY Oathkeeper deployment.
+  If the endpoint URL points to a Load Balancer, these commands will effective test the Load Balancer.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := newClient(cmd)
@@ -28,7 +32,6 @@ var healthAliveCmd = &cobra.Command{
 		if r.Payload.Status != "ok" {
 			os.Exit(1)
 		}
-		os.Exit(0)
 	},
 }
 

--- a/cmd/health_alive.go
+++ b/cmd/health_alive.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/ory/oathkeeper/sdk/go/oathkeeper/client/api"
 	"github.com/ory/x/cmdx"
@@ -12,12 +13,22 @@ import (
 var healthAliveCmd = &cobra.Command{
 	Use:   "alive",
 	Short: "Checks if an ORY Oathkeeper deployment is alive",
+	Long: `Usage example:
+  oathkeeper health --endpoint=http://localhost:4456/ alive
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := newClient(cmd)
 
 		r, err := client.API.IsInstanceAlive(api.NewIsInstanceAliveParams())
+		// If err, print err and exit 1
 		cmdx.Must(err, "%s", err)
+		// Print payload
 		fmt.Println(cmdx.FormatResponse(r.Payload))
+		// When healthy, ORY Oathkeeper always returns a status of "ok"
+		if r.Payload.Status != "ok" {
+			os.Exit(1)
+		}
+		os.Exit(0)
 	},
 }
 

--- a/cmd/health_ready.go
+++ b/cmd/health_ready.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/ory/oathkeeper/sdk/go/oathkeeper/client/api"
 	"github.com/ory/x/cmdx"
@@ -11,13 +12,23 @@ import (
 // healthCmd represents the health command
 var healthReadyCmd = &cobra.Command{
 	Use:   "ready",
-	Short: "Command for checking readiness status",
+	Short: "Checks if an ORY Oathkeeper deployment is ready",
+	Long: `Usage example:
+  oathkeeper health --endpoint=http://localhost:4456/ ready
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := newClient(cmd)
 
 		r, err := client.API.IsInstanceReady(api.NewIsInstanceReadyParams())
+		// If err, print err and exit 1
 		cmdx.Must(err, "%s", err)
+		// Print payload
 		fmt.Println(cmdx.FormatResponse(r.Payload))
+		// When healthy, ORY Oathkeeper always returns a status of "ok"
+		if r.Payload.Status != "ok" {
+			os.Exit(1)
+		}
+		os.Exit(0)
 	},
 }
 

--- a/cmd/health_ready.go
+++ b/cmd/health_ready.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/ory/oathkeeper/sdk/go/oathkeeper/client/api"
+	"github.com/ory/x/cmdx"
+	"github.com/spf13/cobra"
+)
+
+// healthCmd represents the health command
+var healthReadyCmd = &cobra.Command{
+	Use:   "ready",
+	Short: "Command for checking readiness status",
+	Run: func(cmd *cobra.Command, args []string) {
+		client := newClient(cmd)
+
+		r, err := client.API.IsInstanceReady(api.NewIsInstanceReadyParams())
+		cmdx.Must(err, "%s", err)
+		fmt.Println(cmdx.FormatResponse(r.Payload))
+	},
+}
+
+func init() {
+	healthCmd.AddCommand(healthReadyCmd)
+}

--- a/cmd/health_ready.go
+++ b/cmd/health_ready.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/ory/oathkeeper/sdk/go/oathkeeper/client/api"
 	"github.com/ory/x/cmdx"
 	"github.com/spf13/cobra"

--- a/cmd/health_ready.go
+++ b/cmd/health_ready.go
@@ -15,6 +15,10 @@ var healthReadyCmd = &cobra.Command{
 	Short: "Checks if an ORY Oathkeeper deployment is ready",
 	Long: `Usage example:
   oathkeeper health --endpoint=http://localhost:4456/ ready
+
+Note:
+  The endpoint URL should point to a single ORY Oathkeeper deployment.
+  If the endpoint URL points to a Load Balancer, these commands will effective test the Load Balancer.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := newClient(cmd)
@@ -28,7 +32,6 @@ var healthReadyCmd = &cobra.Command{
 		if r.Payload.Status != "ok" {
 			os.Exit(1)
 		}
-		os.Exit(0)
 	},
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -95,6 +95,8 @@ func TestCommandLineInterface(t *testing.T) {
 		},
 		{args: []string{"rules", fmt.Sprintf("--endpoint=http://127.0.0.1:%d/", apiPort), "list"}},
 		{args: []string{"rules", fmt.Sprintf("--endpoint=http://127.0.0.1:%d/", apiPort), "get", "test-rule-4"}},
+		{args: []string{"health", fmt.Sprintf("--endpoint=http://127.0.0.1:%d/", apiPort), "alive"}},
+		{args: []string{"health", fmt.Sprintf("--endpoint=http://127.0.0.1:%d/", apiPort), "ready"}},
 		{args: []string{"credentials", "generate", "--alg", "RS256"}},
 		{args: []string{"credentials", "generate", "--alg", "ES256"}},
 		{args: []string{"credentials", "generate", "--alg", "HS256"}},


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes
Add health check commands to the oathkeeper CLI.

*motivation:*
Support for Docker `HEALTHCHECK`

Docker's `HEALTHCHECK` instruction executes a command e.g. `CMD curl -f http://localhost/ || exit 1` in the container to determine the health status of the container. The exit code of the command determines the health status. The possible exit codes are:

- 0: success - the container is healthy and ready for use
- 1: unhealthy - the container is not working correctly
- 2: reserved - do not use this exit code

Rather than using `curl` (which is not available in the official oathkeeper image) to query the oathkeeper api, we can query the api using oathkeeper's CLI. This has a few advantages:

- No additional dependencies e.g. `curl`
- The health check is portable to other environments
- The health check can be more rigorous than would otherwise be possible with a simple http tool

See [this blog post](https://blog.sixeyed.com/docker-healthchecks-why-not-to-use-curl-or-iwr/) for more details.

*example usage:*
In keeping with the conventions already in place by the `rules` command, the new `health` command has the following usage

- `oathkeeper health -e <endpoint> alive` for checking liveness
- `oathkeeper health -e <endpoint> ready` for checking readiness

```
$ oathkeeper health -e http://localhost:4456 ready
{
    "status": "ok"
}
```

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
