### PR TITLE
http timeout configurable in oauth2 introspection cauthenticator

### DIFF
--- a/.schemas/authenticators.oauth2_introspection.schema.json
+++ b/.schemas/authenticators.oauth2_introspection.schema.json
@@ -134,29 +134,34 @@
         }
       ]
     },
-    "timeout": {
-      "title": "HTTP Idle Timeout",
-      "type": "string",
-      "default": "500ms",
-      "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
-      "description": "The amount of time to wait for any http action by the oauth2 introspection authenticator.",
-      "examples": [
-        "5s",
-        "5m",
-        "5h"
-      ]
-    },
-    "back_off_max_wait": {
-      "title": "HTTP Idle Timeout",
-      "type": "string",
-      "default": "1s",
-      "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
-      "description": "The maximum amount of time to wait for the retry handler.",
-      "examples": [
-        "5s",
-        "5m",
-        "5h"
-      ]
+    "retry": {
+      "type": "object",
+      "properties": {
+        "conn_timeout": {
+          "title": "Connection Timeout",
+          "type": "string",
+          "default": "500ms",
+          "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+          "description": "Sets the connection timeout. If reached, the request will canceled be retried.",
+          "examples": [
+            "5s",
+            "5m",
+            "5h"
+          ]
+        },
+        "max_wait": {
+          "title": "Max Wait",
+          "type": "string",
+          "default": "1s",
+          "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+          "description": "The request fails after the specified amount of time was reached and no success response was received.",
+          "examples": [
+            "5s",
+            "5m",
+            "5h"
+          ]
+        }
+      }
     }
   },
   "required": [

--- a/.schemas/authenticators.oauth2_introspection.schema.json
+++ b/.schemas/authenticators.oauth2_introspection.schema.json
@@ -133,6 +133,30 @@
           }
         }
       ]
+    },
+    "timeout": {
+      "title": "HTTP Idle Timeout",
+      "type": "string",
+      "default": "500ms",
+      "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+      "description": "The amount of time to wait for any http action by the oauth2 introspection authenticator.",
+      "examples": [
+        "5s",
+        "5m",
+        "5h"
+      ]
+    },
+    "back_off_max_wait": {
+      "title": "HTTP Idle Timeout",
+      "type": "string",
+      "default": "1s",
+      "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+      "description": "The maximum amount of time to wait for the retry handler.",
+      "examples": [
+        "5s",
+        "5m",
+        "5h"
+      ]
     }
   },
   "required": [

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -652,29 +652,34 @@
             }
           ]
         },
-        "timeout": {
-          "title": "HTTP Idle Timeout",
-          "type": "string",
-          "default": "500ms",
-          "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
-          "description": "The amount of time to wait for any http action by the oauth2 introspection authenticator.",
-          "examples": [
-            "5s",
-            "5m",
-            "5h"
-          ]
-        },
-        "back_off_max_wait": {
-          "title": "HTTP Idle Timeout",
-          "type": "string",
-          "default": "1s",
-          "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
-          "description": "The maximum amount of time to wait for the retry handler.",
-          "examples": [
-            "5s",
-            "5m",
-            "5h"
-          ]
+        "retry": {
+          "type": "object",
+          "properties": {
+            "conn_timeout": {
+              "title": "Connection Timeout",
+              "type": "string",
+              "default": "500ms",
+              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+              "description": "Sets the connection timeout. If reached, the request will canceled be retried.",
+              "examples": [
+                "5s",
+                "5m",
+                "5h"
+              ]
+            },
+            "max_wait": {
+              "title": "Max Wait",
+              "type": "string",
+              "default": "1s",
+              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+              "description": "The request fails after the specified amount of time was reached and no success response was received.",
+              "examples": [
+                "5s",
+                "5m",
+                "5h"
+              ]
+            }
+          }
         }
       },
       "required": [

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -651,6 +651,30 @@
               }
             }
           ]
+        },
+        "timeout": {
+          "title": "HTTP Idle Timeout",
+          "type": "string",
+          "default": "500ms",
+          "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+          "description": "The amount of time to wait for any http action by the oauth2 introspection authenticator.",
+          "examples": [
+            "5s",
+            "5m",
+            "5h"
+          ]
+        },
+        "back_off_max_wait": {
+          "title": "HTTP Idle Timeout",
+          "type": "string",
+          "default": "1s",
+          "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+          "description": "The maximum amount of time to wait for the retry handler.",
+          "examples": [
+            "5s",
+            "5m",
+            "5h"
+          ]
         }
       },
       "required": [

--- a/driver/configuration/provider_viper_public_test.go
+++ b/driver/configuration/provider_viper_public_test.go
@@ -46,12 +46,12 @@ func TestPipelineConfig(t *testing.T) {
 		require.NoError(t, os.Setenv("AUTHENTICATORS_OAUTH2_INTROSPECTION_CONFIG_INTROSPECTION_URL", "https://override/path"))
 
 		require.NoError(t, p.PipelineConfig("authenticators", "oauth2_introspection", nil, &res))
-		assert.JSONEq(t, `{"introspection_request_headers":{},"introspection_url":"https://override/path","pre_authorization":{"client_id":"some_id","client_secret":"some_secret","enabled":true,"scope":["foo","bar"],"token_url":"https://my-website.com/oauth2/token"},"required_scope":[],"scope_strategy":"exact","target_audience":[],"trusted_issuers":[]}`, string(res), "%s", res)
+		assert.JSONEq(t, `{"introspection_request_headers":{},"introspection_url":"https://override/path","pre_authorization":{"client_id":"some_id","client_secret":"some_secret","enabled":true,"scope":["foo","bar"],"token_url":"https://my-website.com/oauth2/token"},"required_scope":[],"retry":{"conn_timeout":"500ms", "max_wait":"1s"},"scope_strategy":"exact","target_audience":[],"trusted_issuers":[]}`, string(res), "%s", res)
 
 		require.NoError(t, os.Setenv("AUTHENTICATORS_OAUTH2_INTROSPECTION_CONFIG_INTROSPECTION_URL", ""))
 
 		require.NoError(t, p.PipelineConfig("authenticators", "oauth2_introspection", nil, &res))
-		assert.JSONEq(t, `{"introspection_request_headers":{},"introspection_url":"https://my-website.com/oauth2/introspection","pre_authorization":{"client_id":"some_id","client_secret":"some_secret","enabled":true,"scope":["foo","bar"],"token_url":"https://my-website.com/oauth2/token"},"required_scope":[],"scope_strategy":"exact","target_audience":[],"trusted_issuers":[]}`, string(res), "%s", res)
+		assert.JSONEq(t, `{"introspection_request_headers":{},"introspection_url":"https://my-website.com/oauth2/introspection","pre_authorization":{"client_id":"some_id","client_secret":"some_secret","enabled":true,"scope":["foo","bar"],"token_url":"https://my-website.com/oauth2/token"},"required_scope":[],"retry":{"conn_timeout":"500ms", "max_wait":"1s"},"scope_strategy":"exact","target_audience":[],"trusted_issuers":[]}`, string(res), "%s", res)
 
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/ory/herodot v0.6.2
 	github.com/ory/ladon v1.0.1
 	github.com/ory/viper v1.5.6
-	github.com/ory/x v0.0.87
+	github.com/ory/x v0.0.88
 	github.com/pborman/uuid v1.2.0
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2


### PR DESCRIPTION
## Related issue

https://github.com/ory/oathkeeper/issues/310

## Proposed changes

Make timeout configurable in oauth2 introspection authenticator

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the
      [developer guide](https://github.com/ory/docs) (if appropriate)

