### PR TITLE
pipeline/authn: add unit test for token_from->cookie for both jwt and oauth2_introspection authenticators (#330)

### DIFF
--- a/.schemas/authenticators.jwt.schema.json
+++ b/.schemas/authenticators.jwt.schema.json
@@ -52,7 +52,7 @@
     },
     "token_from": {
       "title": "Token From",
-      "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
+      "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header, query, or cookie) must be specified.",
       "oneOf": [
         {
           "type": "object",
@@ -63,7 +63,7 @@
             "header": {
               "title": "Header",
               "type": "string",
-              "description": "The header (case insensitive) that must contain a token for request authentication. It can't be set along with query_parameter."
+              "description": "The header (case insensitive) that must contain a token for request authentication. It can't be set along with query_parameter or cookie."
             }
           }
         },
@@ -76,7 +76,20 @@
             "query_parameter": {
               "title": "Query Parameter",
               "type": "string",
-              "description": "The query parameter (case sensitive) that must contain a token for request authentication. It can't be set along with header."
+              "description": "The query parameter (case sensitive) that must contain a token for request authentication. It can't be set along with header or cookie."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "cookie"
+          ],
+          "properties": {
+            "cookie": {
+              "title": "Cookie",
+              "type": "string",
+              "description": "The cookie (case sensitive) that must contain a token for request authentication. It can't be set along with header or query_parameter."
             }
           }
         }

--- a/.schemas/authenticators.oauth2_introspection.schema.json
+++ b/.schemas/authenticators.oauth2_introspection.schema.json
@@ -104,7 +104,7 @@
     },
     "token_from": {
       "title": "Token From",
-      "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header or query) must be specified.",
+      "description": "The location of the token.\n If not configured, the token will be received from a default location - 'Authorization' header.\n One and only one location (header, query, or cookie) must be specified.",
       "oneOf": [
         {
           "type": "object",
@@ -115,7 +115,7 @@
             "header": {
               "title": "Header",
               "type": "string",
-              "description": "The header (case insensitive) that must contain a token for request authentication.\n It can't be set along with query_parameter."
+              "description": "The header (case insensitive) that must contain a token for request authentication.\n It can't be set along with query_parameter or cookie."
             }
           }
         },
@@ -128,7 +128,20 @@
             "query_parameter": {
               "title": "Query Parameter",
               "type": "string",
-              "description": "The query parameter (case sensitive) that must contain a token for request authentication.\n It can't be set along with header."
+              "description": "The query parameter (case sensitive) that must contain a token for request authentication.\n It can't be set along with header or cookie."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "cookie"
+          ],
+          "properties": {
+            "cookie": {
+              "title": "Cookie",
+              "type": "string",
+              "description": "The cookie (case sensitive) that must contain a token for request authentication.\n It can't be set along with header or query_parameter."
             }
           }
         }

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -425,7 +425,7 @@
                 "header": {
                   "title": "Header",
                   "type": "string",
-                  "description": "The header (case insensitive) that must contain a token for request authentication. It can't be set along with query_parameter."
+                  "description": "The header (case insensitive) that must contain a token for request authentication.\n It can't be set along with query_parameter or cookie."
                 }
               }
             },
@@ -436,7 +436,18 @@
                 "query_parameter": {
                   "title": "Query Parameter",
                   "type": "string",
-                  "description": "The query parameter (case sensitive) that must contain a token for request authentication. It can't be set along with header."
+                  "description": "The query parameter (case sensitive) that must contain a token for request authentication.\n It can't be set along with header or cookie."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cookie": {
+                  "title": "Cookie",
+                  "type": "string",
+                  "description": "The cookie (case sensitive) that must contain a token for request authentication.\n It can't be set along with header or query_parameter."
                 }
               }
             }

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -126,6 +126,16 @@ func TestAuthenticatorJWT(t *testing.T) {
 				expectExactErr: ErrAuthenticatorNotResponsible,
 			},
 			{
+				d: "should return error saying that authenticator is not responsible for validating the request, as the token was not provided in a proper location (cookie)",
+				r: &http.Request{Header: http.Header{"Cookie": []string{"biscuit=" + gen(keys[1], jwt.MapClaims{
+					"sub": "sub",
+					"exp": now.Add(time.Hour).Unix(),
+				})}}},
+				config:         `{"token_from": {"cookie": "cake"}}`,
+				expectErr:      true,
+				expectExactErr: ErrAuthenticatorNotResponsible,
+			},
+			{
 				d: "should pass because the valid JWT token was provided in a proper location (custom header)",
 				r: &http.Request{Header: http.Header{"X-Custom-Header": []string{gen(keys[1], jwt.MapClaims{
 					"sub": "sub",
@@ -147,6 +157,15 @@ func TestAuthenticatorJWT(t *testing.T) {
 					},
 				},
 				config:    `{"token_from": {"query_parameter": "token"}}`,
+				expectErr: false,
+			},
+			{
+				d: "should pass because the valid JWT token was provided in a proper location (cookie)",
+				r: &http.Request{Header: http.Header{"Cookie": []string{"biscuit=" + gen(keys[1], jwt.MapClaims{
+					"sub": "sub",
+					"exp": now.Add(time.Hour).Unix(),
+				})}}},
+				config:    `{"token_from": {"cookie": "biscuit"}}`,
 				expectErr: false,
 			},
 			{

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -102,7 +102,14 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				expectExactErr: ErrAuthenticatorNotResponsible,
 			},
 			{
-				d:         "should pass because the valid JWT token was provided in a proper location (custom header)",
+				d:              "should return error saying that authenticator is not responsible for validating the request, as the token was not provided in a proper location (cookie)",
+				r:              &http.Request{Header: http.Header{"Cookie": {"biscuit=bearer token"}}},
+				config:         []byte(`{"token_from": {"cookie": "cake"}}`),
+				expectErr:      true,
+				expectExactErr: ErrAuthenticatorNotResponsible,
+			},
+			{
+				d:         "should pass because the valid token was provided in a proper location (custom header)",
 				r:         &http.Request{Header: http.Header{"X-Custom-Header": {"token"}}},
 				config:    []byte(`{"token_from": {"header": "X-Custom-Header"}}`),
 				expectErr: false,
@@ -117,13 +124,28 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				},
 			},
 			{
-				d: "should pass because the valid JWT token was provided in a proper location (custom query parameter)",
+				d: "should pass because the valid token was provided in a proper location (custom query parameter)",
 				r: &http.Request{
 					Form: map[string][]string{
 						"token": []string{"token"},
 					},
 				},
 				config:    []byte(`{"token_from": {"query_parameter": "token"}}`),
+				expectErr: false,
+				setup: func(t *testing.T, m *httprouter.Router) {
+					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "token", r.Form.Get("token"))
+						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
+							Active: true,
+						}))
+					})
+				},
+			},
+			{
+				d:         "should pass because the valid token was provided in a proper location (cookie)",
+				r:         &http.Request{Header: http.Header{"Cookie": {"biscuit=token"}}},
+				config:    []byte(`{"token_from": {"cookie": "biscuit"}}`),
 				expectErr: false,
 				setup: func(t *testing.T, m *httprouter.Router) {
 					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {


### PR DESCRIPTION
pipeline/authn: add unit test for token_from->cookie for both jwt and oauth2_introspection authenticators (#330)

Update the schemas to add missing cookie config element

Signed-off-by: Grigoriev, Nikolai <ngrigoriev@gmail.com>



## Proposed changes

Add both negative and positive unit tests for both authenticators for "cookie" token origin

## Checklist



- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have read the [security policy](../security/policy)
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] Separate PR is provided for docs repo

