### PR TITLE
Hash enabled check to further improve performance

### DIFF
--- a/driver/configuration/provider_viper_public_test.go
+++ b/driver/configuration/provider_viper_public_test.go
@@ -123,6 +123,39 @@ func BenchmarkPipelineConfig(b *testing.B) {
 	}
 }
 
+/*
+go test ./... -v -bench=. -run BenchmarkPipelineEnabled -benchtime=10s
+
+v0.35.4
+11708	   1009975 ns/op
+
+v0.35.5
+18848694	       603 ns/op
+*/
+
+func BenchmarkPipelineEnabled(b *testing.B) {
+	viper.Reset()
+	viperx.InitializeConfig(
+		"oathkeeper",
+		"./../../docs/",
+		logrus.New(),
+	)
+
+	err := viperx.Validate(gojsonschema.NewReferenceLoader("file://../../.schemas/config.schema.json"))
+	if err != nil {
+		viperx.LoggerWithValidationErrorFields(logrus.New(), err).Error("unable to validate")
+	}
+	require.NoError(b, err)
+
+	p := NewViperProvider(logrus.New())
+
+	for n := 0; n < b.N; n++ {
+		p.AuthorizerIsEnabled("allow")
+		p.AuthenticatorIsEnabled("noop")
+		p.MutatorIsEnabled("noop")
+	}
+}
+
 func TestViperProvider(t *testing.T) {
 	viper.Reset()
 	viperx.InitializeConfig(

--- a/pipeline/authn/authenticator_anonymous_test.go
+++ b/pipeline/authn/authenticator_anonymous_test.go
@@ -58,6 +58,7 @@ func TestAuthenticatorAnonymous(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthenticatorAnonymousIsEnabled, true)
 		require.NoError(t, a.Validate(json.RawMessage(`{"subject":"foo"}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorAnonymousIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"subject":"foo"}`)))
 	})

--- a/pipeline/authn/authenticator_noop_test.go
+++ b/pipeline/authn/authenticator_noop_test.go
@@ -49,6 +49,7 @@ func TestAuthenticatorNoop(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthenticatorNoopIsEnabled, true)
 		require.NoError(t, a.Validate(nil))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorNoopIsEnabled, false)
 		require.Error(t, a.Validate(nil))
 	})

--- a/pipeline/authn/authenticator_oauth2_client_credentials_test.go
+++ b/pipeline/authn/authenticator_oauth2_client_credentials_test.go
@@ -111,12 +111,15 @@ func TestAuthenticatorOAuth2ClientCredentials(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2ClientCredentialsIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"token_url":""}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2ClientCredentialsIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"token_url":"`+ts.URL+"/oauth2/token"+`"}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2ClientCredentialsIsEnabled, true)
 		require.Error(t, a.Validate(json.RawMessage(`{"token_url":""}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2ClientCredentialsIsEnabled, true)
 		require.NoError(t, a.Validate(json.RawMessage(`{"token_url":"`+ts.URL+"/oauth2/token"+`"}`)))
 	})

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -353,12 +353,15 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2TokenIntrospectionIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"introspection_url":""}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2TokenIntrospectionIsEnabled, true)
 		require.Error(t, a.Validate(json.RawMessage(`{"introspection_url":""}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2TokenIntrospectionIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"introspection_url":"/oauth2/token"}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2TokenIntrospectionIsEnabled, true)
 		require.Error(t, a.Validate(json.RawMessage(`{"introspection_url":"/oauth2/token"}`)))
 	})

--- a/pipeline/authn/authenticator_unauthorized_test.go
+++ b/pipeline/authn/authenticator_unauthorized_test.go
@@ -50,6 +50,7 @@ func TestAuthenticatorBroken(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthenticatorUnauthorizedIsEnabled, true)
 		require.NoError(t, a.Validate(nil))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorUnauthorizedIsEnabled, false)
 		require.Error(t, a.Validate(nil))
 	})

--- a/pipeline/authz/authorizer_allow_test.go
+++ b/pipeline/authz/authorizer_allow_test.go
@@ -48,6 +48,7 @@ func TestAuthorizerAllow(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthorizerAllowIsEnabled, true)
 		require.NoError(t, a.Validate(nil))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthorizerAllowIsEnabled, false)
 		require.Error(t, a.Validate(nil))
 	})

--- a/pipeline/authz/authorizer_deny_test.go
+++ b/pipeline/authz/authorizer_deny_test.go
@@ -48,6 +48,7 @@ func TestAuthorizerDeny(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthorizerDenyIsEnabled, true)
 		require.NoError(t, a.Validate(nil))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthorizerDenyIsEnabled, false)
 		require.Error(t, a.Validate(nil))
 	})

--- a/pipeline/authz/keto_engine_acp_ory_test.go
+++ b/pipeline/authz/keto_engine_acp_ory_test.go
@@ -224,12 +224,15 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"","required_action":"foo","required_resource":"bar"}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, true)
 		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"","required_action":"foo","required_resource":"bar"}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"http://foo/bar","required_action":"foo","required_resource":"bar"}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, true)
 		require.NoError(t, a.Validate(json.RawMessage(`{"base_url":"http://foo/bar","required_action":"foo","required_resource":"bar"}`)))
 	})

--- a/pipeline/mutate/mutator_cookie_test.go
+++ b/pipeline/mutate/mutator_cookie_test.go
@@ -209,6 +209,7 @@ func TestCredentialsIssuerCookies(t *testing.T) {
 			viper.Set(configuration.ViperKeyMutatorCookieIsEnabled, true)
 			require.Error(t, a.Validate(json.RawMessage(`{}`)))
 
+			viper.Reset()
 			viper.Set(configuration.ViperKeyMutatorCookieIsEnabled, false)
 			require.Error(t, a.Validate(json.RawMessage(`{"cookies":{}}`)))
 		})

--- a/pipeline/mutate/mutator_header_test.go
+++ b/pipeline/mutate/mutator_header_test.go
@@ -204,6 +204,7 @@ func TestCredentialsIssuerHeaders(t *testing.T) {
 		viper.Set(configuration.ViperKeyMutatorHeaderIsEnabled, true)
 		require.NoError(t, a.Validate(json.RawMessage(`{"headers":{}}`)))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyMutatorHeaderIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"headers":{}}`)))
 	})

--- a/pipeline/mutate/mutator_hydrator_test.go
+++ b/pipeline/mutate/mutator_hydrator_test.go
@@ -351,6 +351,7 @@ func TestMutatorHydrator(t *testing.T) {
 			{enabled: true, shouldPass: true, apiUrl: "http://api/bar"},
 		} {
 			t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+				viper.Reset()
 				viper.Set(configuration.ViperKeyMutatorHydratorIsEnabled, testCase.enabled)
 
 				err := a.Validate(json.RawMessage(`{"api":{"url":"` + testCase.apiUrl + `"}}`))

--- a/pipeline/mutate/mutator_id_token_test.go
+++ b/pipeline/mutate/mutator_id_token_test.go
@@ -258,6 +258,7 @@ func TestMutatorIDToken(t *testing.T) {
 			{e: true, i: "http://baz/foo", j: "http://baz/foo", pass: true},
 		} {
 			t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+				viper.Reset()
 				viper.Set(configuration.ViperKeyMutatorIDTokenIsEnabled, tc.e)
 				// viper.Set(configuration.ViperKeyMutatorIDTokenIssuerURL, tc.i)
 				// viper.Set(configuration.ViperKeyMutatorIDTokenJWKSURL, tc.j)

--- a/pipeline/mutate/mutator_noop_test.go
+++ b/pipeline/mutate/mutator_noop_test.go
@@ -55,6 +55,7 @@ func TestMutatorNoop(t *testing.T) {
 		viper.Set(configuration.ViperKeyMutatorNoopIsEnabled, true)
 		require.NoError(t, a.Validate(nil))
 
+		viper.Reset()
 		viper.Set(configuration.ViperKeyMutatorNoopIsEnabled, false)
 		require.Error(t, a.Validate(nil))
 	})


### PR DESCRIPTION
## Related issue
https://github.com/ory/oathkeeper/issues/346

## Proposed changes

Just found one more thing to cache ;) Also thought about combining it with PipelineConfig but thought this one is clearer to understand and also with less changes

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments
Brings it down from 2 - 3ms to 0.1 - 0.3ms

Before:
![profile002](https://user-images.githubusercontent.com/2729447/73140552-669d6400-407a-11ea-8f48-2c512aa25bb2.png)

After:
![profile001](https://user-images.githubusercontent.com/2729447/73140551-669d6400-407a-11ea-91e0-98728d53b842.png)

