### PR TITLE
Feature/global auth session

### DIFF
--- a/pipeline/authn/authenticator.go
+++ b/pipeline/authn/authenticator.go
@@ -3,6 +3,7 @@ package authn
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/pkg/errors"
 
@@ -19,7 +20,7 @@ var ErrAuthenticatorNotEnabled = herodot.DefaultError{
 }
 
 type Authenticator interface {
-	Authenticate(r *http.Request, config json.RawMessage, rule pipeline.Rule) (*AuthenticationSession, error)
+	Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, rule pipeline.Rule) error
 	GetID() string
 	Validate(config json.RawMessage) error
 }
@@ -37,9 +38,15 @@ func NewErrAuthenticatorMisconfigured(a Authenticator, err error) *herodot.Defau
 }
 
 type AuthenticationSession struct {
-	Subject string                 `json:"subject"`
-	Extra   map[string]interface{} `json:"extra"`
-	Header  http.Header            `json:"header"`
+	Subject      string                 `json:"subject"`
+	Extra        map[string]interface{} `json:"extra"`
+	Header       http.Header            `json:"header"`
+	MatchContext MatchContext           `json:"matchContext"`
+}
+
+type MatchContext struct {
+	RegexpCaptureGroups []string `json:"regexpCaptureGroups"`
+	URL                 *url.URL `json:"url"`
 }
 
 func (a *AuthenticationSession) SetHeader(key, val string) {

--- a/pipeline/authn/authenticator_anonymous.go
+++ b/pipeline/authn/authenticator_anonymous.go
@@ -48,17 +48,17 @@ func (a *AuthenticatorAnonymous) Config(config json.RawMessage) (*AuthenticatorA
 	return &c, nil
 }
 
-func (a *AuthenticatorAnonymous) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
+func (a *AuthenticatorAnonymous) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
 	if len(r.Header.Get("Authorization")) != 0 {
-		return nil, errors.WithStack(ErrAuthenticatorNotResponsible)
+		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
 	cf, err := a.Config(config)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &AuthenticationSession{
-		Subject: stringsx.Coalesce(cf.Subject, "anonymous"),
-	}, nil
+	session.Subject = stringsx.Coalesce(cf.Subject, "anonymous")
+
+	return nil
 }

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -316,7 +316,8 @@ func TestAuthenticatorJWT(t *testing.T) {
 				}
 
 				tc.config, _ = sjson.Set(tc.config, "jwks_urls", keys)
-				session, err := a.Authenticate(tc.r, json.RawMessage([]byte(tc.config)), nil)
+				session := new(AuthenticationSession)
+				err := a.Authenticate(tc.r, session, json.RawMessage([]byte(tc.config)), nil)
 				if tc.expectErr {
 					require.Error(t, err)
 					if tc.expectCode != 0 {

--- a/pipeline/authn/authenticator_noop.go
+++ b/pipeline/authn/authenticator_noop.go
@@ -31,6 +31,6 @@ func (a *AuthenticatorNoOp) Validate(config json.RawMessage) error {
 	return nil
 }
 
-func (a *AuthenticatorNoOp) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
-	return &AuthenticationSession{Subject: ""}, nil
+func (a *AuthenticatorNoOp) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
+	return nil
 }

--- a/pipeline/authn/authenticator_noop_test.go
+++ b/pipeline/authn/authenticator_noop_test.go
@@ -41,7 +41,7 @@ func TestAuthenticatorNoop(t *testing.T) {
 	assert.Equal(t, "noop", a.GetID())
 
 	t.Run("method=authenticate", func(t *testing.T) {
-		_, err := a.Authenticate(nil, nil, nil)
+		err := a.Authenticate(nil, nil, nil, nil)
 		require.NoError(t, err)
 	})
 

--- a/pipeline/authn/authenticator_oauth2_client_credentials.go
+++ b/pipeline/authn/authenticator_oauth2_client_credentials.go
@@ -55,25 +55,25 @@ func (a *AuthenticatorOAuth2ClientCredentials) Config(config json.RawMessage) (*
 	return &c, nil
 }
 
-func (a *AuthenticatorOAuth2ClientCredentials) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
+func (a *AuthenticatorOAuth2ClientCredentials) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
 	cf, err := a.Config(config)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	user, password, ok := r.BasicAuth()
 	if !ok {
-		return nil, errors.WithStack(ErrAuthenticatorNotResponsible)
+		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
 	user, err = url.QueryUnescape(user)
 	if err != nil {
-		return nil, errors.Wrapf(helper.ErrUnauthorized, err.Error())
+		return errors.Wrapf(helper.ErrUnauthorized, err.Error())
 	}
 
 	password, err = url.QueryUnescape(password)
 	if err != nil {
-		return nil, errors.Wrapf(helper.ErrUnauthorized, err.Error())
+		return errors.Wrapf(helper.ErrUnauthorized, err.Error())
 	}
 
 	c := &clientcredentials.Config{
@@ -90,14 +90,13 @@ func (a *AuthenticatorOAuth2ClientCredentials) Authenticate(r *http.Request, con
 		httpx.NewResilientClientLatencyToleranceMedium(nil),
 	))
 	if err != nil {
-		return nil, errors.Wrapf(helper.ErrUnauthorized, err.Error())
+		return errors.Wrapf(helper.ErrUnauthorized, err.Error())
 	}
 
 	if token.AccessToken == "" {
-		return nil, errors.WithStack(helper.ErrUnauthorized)
+		return errors.WithStack(helper.ErrUnauthorized)
 	}
 
-	return &AuthenticationSession{
-		Subject: user,
-	}, nil
+	session.Subject = user
+	return nil
 }

--- a/pipeline/authn/authenticator_oauth2_client_credentials_test.go
+++ b/pipeline/authn/authenticator_oauth2_client_credentials_test.go
@@ -93,7 +93,8 @@ func TestAuthenticatorOAuth2ClientCredentials(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("method=authenticate/case=%d", k), func(t *testing.T) {
-			session, err := a.Authenticate(tc.r, tc.config, nil)
+			session := new(authn.AuthenticationSession)
+			err := a.Authenticate(tc.r, session, tc.config, nil)
 
 			if tc.expectErr != nil {
 				require.EqualError(t, errors.Cause(err), tc.expectErr.Error())

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -65,22 +65,22 @@ type AuthenticatorOAuth2IntrospectionResult struct {
 	Scope     string                 `json:"scope,omitempty"`
 }
 
-func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
+func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
 	var i AuthenticatorOAuth2IntrospectionResult
 	cf, err := a.Config(config)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	token := helper.BearerTokenFromRequest(r, cf.BearerTokenLocation)
 	if token == "" {
-		return nil, errors.WithStack(ErrAuthenticatorNotResponsible)
+		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
 	body := url.Values{"token": {token}, "scope": {strings.Join(cf.Scopes, " ")}}
 	introspectReq, err := http.NewRequest(http.MethodPost, cf.IntrospectionURL, strings.NewReader(body.Encode()))
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return errors.WithStack(err)
 	}
 	for key, value := range cf.IntrospectionRequestHeaders {
 		introspectReq.Header.Set(key, value)
@@ -89,42 +89,42 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, config 
 	introspectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := a.client.Do(introspectReq)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return errors.WithStack(err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("Introspection returned status code %d but expected %d", resp.StatusCode, http.StatusOK)
+		return errors.Errorf("Introspection returned status code %d but expected %d", resp.StatusCode, http.StatusOK)
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&i); err != nil {
-		return nil, errors.WithStack(err)
+		return errors.WithStack(err)
 	}
 
 	if len(i.TokenType) > 0 && i.TokenType != "access_token" {
-		return nil, errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Introspected token is not an access token but \"%s\"", i.TokenType)))
+		return errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Introspected token is not an access token but \"%s\"", i.TokenType)))
 	}
 
 	if !i.Active {
-		return nil, errors.WithStack(helper.ErrUnauthorized.WithReason("Access token i says token is not active"))
+		return errors.WithStack(helper.ErrUnauthorized.WithReason("Access token i says token is not active"))
 	}
 
 	for _, audience := range cf.Audience {
 		if !stringslice.Has(i.Audience, audience) {
-			return nil, errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Token audience is not intended for target audience %s", audience)))
+			return errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Token audience is not intended for target audience %s", audience)))
 		}
 	}
 
 	if len(cf.Issuers) > 0 {
 		if !stringslice.Has(cf.Issuers, i.Issuer) {
-			return nil, errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Token issuer does not match any trusted issuer")))
+			return errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Token issuer does not match any trusted issuer")))
 		}
 	}
 
 	if ss := a.c.ToScopeStrategy(cf.ScopeStrategy, "authenticators.oauth2_introspection.scope_strategy"); ss != nil {
 		for _, scope := range cf.Scopes {
 			if !ss(strings.Split(i.Scope, " "), scope) {
-				return nil, errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Scope %s was not granted", scope)))
+				return errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Scope %s was not granted", scope)))
 			}
 		}
 	}
@@ -137,10 +137,10 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, config 
 	i.Extra["client_id"] = i.ClientID
 	i.Extra["scope"] = i.Scope
 
-	return &AuthenticationSession{
-		Subject: i.Subject,
-		Extra:   i.Extra,
-	}, nil
+	session.Subject = i.Subject
+	session.Extra = i.Extra
+
+	return nil
 }
 
 func (a *AuthenticatorOAuth2Introspection) Validate(config json.RawMessage) error {

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -332,7 +332,8 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 
 				tc.config, _ = sjson.SetBytes(tc.config, "introspection_url", ts.URL+"/oauth2/introspect")
 				tc.config, _ = sjson.SetBytes(tc.config, "scope_strategy", "exact")
-				sess, err := a.Authenticate(tc.r, tc.config, nil)
+				sess := new(AuthenticationSession)
+				err := a.Authenticate(tc.r, sess, tc.config, nil)
 				if tc.expectErr {
 					require.Error(t, err)
 					if tc.expectExactErr != nil {

--- a/pipeline/authn/authenticator_unauthorized.go
+++ b/pipeline/authn/authenticator_unauthorized.go
@@ -55,6 +55,6 @@ func (a *AuthenticatorUnauthorized) GetID() string {
 	return "unauthorized"
 }
 
-func (a *AuthenticatorUnauthorized) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
-	return nil, errors.WithStack(helper.ErrUnauthorized)
+func (a *AuthenticatorUnauthorized) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
+	return errors.WithStack(helper.ErrUnauthorized)
 }

--- a/pipeline/authn/authenticator_unauthorized_test.go
+++ b/pipeline/authn/authenticator_unauthorized_test.go
@@ -42,7 +42,7 @@ func TestAuthenticatorBroken(t *testing.T) {
 	assert.Equal(t, "unauthorized", a.GetID())
 
 	t.Run("method=authenticate", func(t *testing.T) {
-		_, err := a.Authenticate(&http.Request{Header: http.Header{}}, nil, nil)
+		err := a.Authenticate(&http.Request{Header: http.Header{}}, nil, nil, nil)
 		require.Error(t, err)
 	})
 

--- a/pipeline/authz/keto_engine_acp_ory.go
+++ b/pipeline/authz/keto_engine_acp_ory.go
@@ -140,6 +140,7 @@ func (a *AuthorizerKetoEngineACPORY) Authorize(r *http.Request, session *authn.A
 	}
 
 	req, err := http.NewRequest("POST", urlx.AppendPaths(baseURL, "/engines/acp/ory", flavor, "/allowed").String(), &b)
+	req.Header.Add("Content-Type", "application/json")
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pipeline/authz/keto_engine_acp_ory.go
+++ b/pipeline/authz/keto_engine_acp_ory.go
@@ -22,6 +22,7 @@ package authz
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,6 +35,7 @@ import (
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/pipeline"
 	"github.com/ory/oathkeeper/pipeline/authn"
+	"github.com/ory/oathkeeper/pipeline/mutate"
 
 	"github.com/ory/x/urlx"
 
@@ -51,11 +53,24 @@ type AuthorizerKetoEngineACPORYConfiguration struct {
 	BaseURL          string `json:"base_url"`
 }
 
+func (c *AuthorizerKetoEngineACPORYConfiguration) SubjectTemplateID() string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(c.Subject)))
+}
+
+func (c *AuthorizerKetoEngineACPORYConfiguration) ActionTemplateID() string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(c.RequiredAction)))
+}
+
+func (c *AuthorizerKetoEngineACPORYConfiguration) ResourceTemplateID() string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(c.RequiredResource)))
+}
+
 type AuthorizerKetoEngineACPORY struct {
 	c configuration.Provider
 
 	client         *http.Client
 	contextCreator authorizerKetoWardenContext
+	t              *template.Template
 }
 
 func NewAuthorizerKetoEngineACPORY(c configuration.Provider) *AuthorizerKetoEngineACPORY {
@@ -68,6 +83,7 @@ func NewAuthorizerKetoEngineACPORY(c configuration.Provider) *AuthorizerKetoEngi
 				"requestedAt":     time.Now().UTC(),
 			}
 		},
+		t: mutate.NewTemplate("keto_engine_acp_ory"),
 	}
 }
 
@@ -101,11 +117,20 @@ func (a *AuthorizerKetoEngineACPORY) Authorize(r *http.Request, session *authn.A
 
 	subject := session.Subject
 	if cf.Subject != "" {
-		templateId := fmt.Sprintf("%s:%s", rule.GetID(), "subject")
-		subject, err = a.ParseSubject(session, templateId, cf.Subject)
+		subject, err = a.parseParameter(session, cf.SubjectTemplateID(), cf.Subject)
 		if err != nil {
 			return errors.WithStack(err)
 		}
+	}
+
+	action, err := a.parseParameter(session, cf.ActionTemplateID(), cf.RequiredAction)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	resource, err := a.parseParameter(session, cf.ResourceTemplateID(), cf.RequiredResource)
+	if err != nil {
+		return errors.WithStack(err)
 	}
 
 	flavor := "regex"
@@ -114,16 +139,6 @@ func (a *AuthorizerKetoEngineACPORY) Authorize(r *http.Request, session *authn.A
 	}
 
 	var b bytes.Buffer
-	u := fmt.Sprintf("%s://%s%s", r.URL.Scheme, r.URL.Host, r.URL.Path)
-
-	action, err := rule.ReplaceAllString(a.c.AccessRuleMatchingStrategy(), u, cf.RequiredAction)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	resource, err := rule.ReplaceAllString(a.c.AccessRuleMatchingStrategy(), u, cf.RequiredResource)
-	if err != nil {
-		return errors.WithStack(err)
-	}
 
 	if err := json.NewEncoder(&b).Encode(&AuthorizerKetoEngineACPORYRequestBody{
 		Action:   action,
@@ -172,29 +187,23 @@ func (a *AuthorizerKetoEngineACPORY) Authorize(r *http.Request, session *authn.A
 	return nil
 }
 
-func (a *AuthorizerKetoEngineACPORY) ParseSubject(session *authn.AuthenticationSession, templateId, templateString string) (string, error) {
-	tmplFn := template.New("rules").
-		Option("missingkey=zero").
-		Funcs(template.FuncMap{
-			"print": func(i interface{}) string {
-				if i == nil {
-					return ""
-				}
-				return fmt.Sprintf("%v", i)
-			},
-		})
+func (a *AuthorizerKetoEngineACPORY) parseParameter(session *authn.AuthenticationSession, templateID, templateString string) (string, error) {
 
-	tmpl, err := tmplFn.New(templateId).Parse(templateString)
-	if err != nil {
+	t := a.t.Lookup(templateID)
+	if t == nil {
+		var err error
+		t, err = a.t.New(templateID).Parse(templateString)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	var b bytes.Buffer
+	if err := t.Execute(&b, session); err != nil {
 		return "", err
 	}
 
-	subject := bytes.Buffer{}
-	err = tmpl.Execute(&subject, session)
-	if err != nil {
-		return "", err
-	}
-	return subject.String(), nil
+	return b.String(), nil
 }
 
 func (a *AuthorizerKetoEngineACPORY) Validate(config json.RawMessage) error {

--- a/pipeline/authz/keto_engine_acp_ory_test.go
+++ b/pipeline/authz/keto_engine_acp_ory_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/internal"
 
-	"github.com/ory/oathkeeper/pipeline"
 	"github.com/ory/oathkeeper/pipeline/authn"
 	. "github.com/ory/oathkeeper/pipeline/authz"
 
@@ -52,6 +51,8 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 	conf := internal.NewConfigurationWithDefaults()
 	reg := internal.NewRegistry(conf)
 
+	rule := &rule.Rule{ID: "TestAuthorizer"}
+
 	a, err := reg.PipelineAuthorizer("keto_engine_acp_ory")
 	require.NoError(t, err)
 	assert.Equal(t, "keto_engine_acp_ory", a.GetID())
@@ -61,33 +62,20 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 		r         *http.Request
 		session   *authn.AuthenticationSession
 		config    json.RawMessage
-		rule      pipeline.Rule
 		expectErr bool
 	}{
 		{
 			expectErr: true,
 		},
 		{
-			config: []byte(`{ "required_action": "action", "required_resource": "resource" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/",
-				},
-			},
+			config:    []byte(`{ "required_action": "action", "required_resource": "resource" }`),
 			r:         &http.Request{URL: &url.URL{}},
 			session:   new(authn.AuthenticationSession),
 			expectErr: true,
 		},
 		{
 			config: []byte(`{ "required_action": "action", "required_resource": "resource", "flavor": "regex" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/",
-				},
-			},
-			r: &http.Request{URL: &url.URL{}},
+			r:      &http.Request{URL: &url.URL{}},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusForbidden)
@@ -98,13 +86,7 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 		},
 		{
 			config: []byte(`{ "required_action": "action", "required_resource": "resource", "flavor": "exact" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/",
-				},
-			},
-			r: &http.Request{URL: &url.URL{}},
+			r:      &http.Request{URL: &url.URL{}},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					assert.Contains(t, r.Header, "Content-Type")
@@ -117,14 +99,8 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			config: []byte(`{ "required_action": "action:$1:$2", "required_resource": "resource:$1:$2" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/api/users/<[0-9]+>/<[a-z]+>",
-				},
-			},
-			r: &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde")},
+			config: []byte(`{ "required_action": "action:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}", "required_resource": "resource:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}" }`),
+			r:      &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde")},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					var ki AuthorizerKetoEngineACPORYRequestBody
@@ -139,18 +115,17 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 					w.Write([]byte(`{"allowed":true}`))
 				}))
 			},
-			session:   &authn.AuthenticationSession{Subject: "peter"},
+			session: &authn.AuthenticationSession{
+				Subject: "peter",
+				MatchContext: authn.MatchContext{
+					RegexpCaptureGroups: []string{"1234", "abcde"},
+				},
+			},
 			expectErr: false,
 		},
 		{
-			config: []byte(`{ "required_action": "action:$1:$2", "required_resource": "resource:$1:$2", "subject": "{{ .Extra.name }}" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/api/users/<[0-9]+>/<[a-z]+>",
-				},
-			},
-			r: &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde")},
+			config: []byte(`{ "required_action": "action:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}", "required_resource": "resource:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}", "subject": "{{ .Extra.name }}" }`),
+			r:      &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde")},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					var ki AuthorizerKetoEngineACPORYRequestBody
@@ -165,25 +140,23 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 					w.Write([]byte(`{"allowed":true}`))
 				}))
 			},
-			session:   &authn.AuthenticationSession{Extra: map[string]interface{}{"name": "peter"}},
+			session: &authn.AuthenticationSession{
+				Extra: map[string]interface{}{"name": "peter"},
+				MatchContext: authn.MatchContext{
+					RegexpCaptureGroups: []string{"1234", "abcde"},
+				}},
 			expectErr: false,
 		},
 		{
-			config: []byte(`{ "required_action": "action:$1:$2", "required_resource": "resource:$1:$2", "subject": "{{ .Extra.name }}" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/api/users/<[0-9]+>/<[a-z]+>",
-				},
-			},
-			r: &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde?limit=10")},
+			config: []byte(`{ "required_action": "action:{{ index .MatchContext.RegexpCaptureGroups 0 }}:{{ .Extra.name }}", "required_resource": "resource:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ .Extra.apiVersion }}", "subject": "{{ .Extra.name }}" }`),
+			r:      &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde?limit=10")},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					var ki AuthorizerKetoEngineACPORYRequestBody
 					require.NoError(t, json.NewDecoder(r.Body).Decode(&ki))
 					assert.EqualValues(t, AuthorizerKetoEngineACPORYRequestBody{
-						Action:   "action:1234:abcde",
-						Resource: "resource:1234:abcde",
+						Action:   "action:1234:peter",
+						Resource: "resource:1234:1.0",
 						Context:  map[string]interface{}{},
 						Subject:  "peter",
 					}, ki)
@@ -191,7 +164,12 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 					w.Write([]byte(`{"allowed":true}`))
 				}))
 			},
-			session:   &authn.AuthenticationSession{Extra: map[string]interface{}{"name": "peter"}},
+			session: &authn.AuthenticationSession{
+				Extra: map[string]interface{}{
+					"name":       "peter",
+					"apiVersion": "1.0"},
+				MatchContext: authn.MatchContext{RegexpCaptureGroups: []string{"1234"}},
+			},
 			expectErr: false,
 		},
 	} {
@@ -211,7 +189,7 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 			})
 
 			tc.config, _ = sjson.SetBytes(tc.config, "base_url", baseURL)
-			err := a.Authorize(tc.r, tc.session, tc.config, tc.rule)
+			err := a.Authorize(tc.r, tc.session, tc.config, rule)
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {
@@ -224,15 +202,13 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"","required_action":"foo","required_resource":"bar"}`)))
 
-		viper.Reset()
-		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, true)
-		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"","required_action":"foo","required_resource":"bar"}`)))
-
-		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"http://foo/bar","required_action":"foo","required_resource":"bar"}`)))
 
 		viper.Reset()
+		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, true)
+		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"","required_action":"foo","required_resource":"bar"}`)))
+
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, true)
 		require.NoError(t, a.Validate(json.RawMessage(`{"base_url":"http://foo/bar","required_action":"foo","required_resource":"bar"}`)))
 	})

--- a/pipeline/mutate/mutator_cookie.go
+++ b/pipeline/mutate/mutator_cookie.go
@@ -26,7 +26,7 @@ type MutatorCookie struct {
 }
 
 func NewMutatorCookie(c configuration.Provider) *MutatorCookie {
-	return &MutatorCookie{c: c, t: newTemplate("cookie")}
+	return &MutatorCookie{c: c, t: NewTemplate("cookie")}
 }
 
 func (a *MutatorCookie) GetID() string {

--- a/pipeline/mutate/mutator_header.go
+++ b/pipeline/mutate/mutator_header.go
@@ -24,7 +24,7 @@ type MutatorHeader struct {
 }
 
 func NewMutatorHeader(c configuration.Provider) *MutatorHeader {
-	return &MutatorHeader{c: c, t: newTemplate("header")}
+	return &MutatorHeader{c: c, t: NewTemplate("header")}
 }
 
 func (a *MutatorHeader) GetID() string {

--- a/pipeline/mutate/mutator_header_test.go
+++ b/pipeline/mutate/mutator_header_test.go
@@ -140,6 +140,23 @@ func TestCredentialsIssuerHeaders(t *testing.T) {
 				},
 				Err: nil,
 			},
+			"Use request captures to header": {
+				Session: &authn.AuthenticationSession{
+					Subject: "foo",
+					MatchContext: authn.MatchContext{
+						RegexpCaptureGroups: []string{"Foo", "Bar"},
+					},
+				},
+				Rule: &rule.Rule{ID: "test-rule10"},
+				Config: json.RawMessage([]byte(`{"headers":{
+					"Example-Claims": "{{ index .MatchContext.RegexpCaptureGroups 0}}"
+				}}`)),
+				Request: &http.Request{Header: http.Header{}},
+				Match: http.Header{
+					"Example-Claims": []string{"Foo"},
+				},
+				Err: nil,
+			},
 		}
 
 		t.Run("cache=disabled", func(t *testing.T) {

--- a/pipeline/mutate/mutator_hydrator_test.go
+++ b/pipeline/mutate/mutator_hydrator_test.go
@@ -39,6 +39,14 @@ func setSubject(subject string) func(a *authn.AuthenticationSession) {
 	}
 }
 
+func setMatchContext(groups []string) func(a *authn.AuthenticationSession) {
+	return func(a *authn.AuthenticationSession) {
+		a.MatchContext = authn.MatchContext{
+			RegexpCaptureGroups: groups,
+		}
+	}
+}
+
 func newAuthenticationSession(modifications ...func(a *authn.AuthenticationSession)) *authn.AuthenticationSession {
 	a := authn.AuthenticationSession{}
 	for _, f := range modifications {
@@ -135,6 +143,7 @@ func TestMutatorHydrator(t *testing.T) {
 			"foo": "hello",
 			"bar": 3.14,
 		}
+		sampleCaptureGroups := []string { "resource", "context"}
 		sampleUserId := "user"
 		sampleValidPassword := "passwd1"
 		sampleNotValidPassword := "passwd7"
@@ -176,11 +185,11 @@ func TestMutatorHydrator(t *testing.T) {
 			},
 			"No Changes": {
 				Setup:   defaultRouterSetup(),
-				Session: newAuthenticationSession(setExtra(sampleKey, sampleValue)),
+				Session: newAuthenticationSession(setExtra(sampleKey, sampleValue), setMatchContext(sampleCaptureGroups)),
 				Rule:    &rule.Rule{ID: "test-rule"},
 				Config:  defaultConfigForMutator(),
 				Request: &http.Request{},
-				Match:   newAuthenticationSession(setExtra(sampleKey, sampleValue)),
+				Match:   newAuthenticationSession(setExtra(sampleKey, sampleValue), setMatchContext(sampleCaptureGroups)),
 				Err:     nil,
 			},
 			"No Extra Before And After": {

--- a/pipeline/mutate/mutator_id_token.go
+++ b/pipeline/mutate/mutator_id_token.go
@@ -63,7 +63,7 @@ func (c *CredentialsIDTokenConfig) ClaimsTemplateID() string {
 }
 
 func NewMutatorIDToken(c configuration.Provider, r MutatorIDTokenRegistry) *MutatorIDToken {
-	return &MutatorIDToken{r: r, c: c, t: newTemplate("id_token")}
+	return &MutatorIDToken{r: r, c: c, t: NewTemplate("id_token")}
 }
 
 func (a *MutatorIDToken) GetID() string {

--- a/pipeline/mutate/mutator_id_token_test.go
+++ b/pipeline/mutate/mutator_id_token_test.go
@@ -156,6 +156,51 @@ func TestMutatorIDToken(t *testing.T) {
 					Match:   jwt.MapClaims{},
 					K:       "file://../../test/stub/jwks-ecdsa.json",
 				},
+				{
+					Rule: &rule.Rule{ID: "test-rule10"},
+					Session: &authn.AuthenticationSession{
+						Subject: "foo",
+						Extra:   map[string]interface{}{"abc": "value1", "def": "value2"},
+						MatchContext: authn.MatchContext{
+							RegexpCaptureGroups: []string{ "user", "pass" },
+						}},
+					Config: json.RawMessage([]byte(`{"claims": "{\"custom-claim\": \"{{ print .Extra.abc }}\", \"custom-claim2\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 1}}\", \"aud\": [\"foo\", \"bar\"]}"}`)),
+					Match: jwt.MapClaims{
+						"custom-claim":  "value1",
+						"custom-claim2": "pass",
+					},
+					K: "file://../../test/stub/jwks-ecdsa.json",
+				},
+				{
+					Rule: &rule.Rule{ID: "test-rule11"},
+					Session: &authn.AuthenticationSession{
+						Subject: "foo",
+						Extra:   map[string]interface{}{"abc": "value1", "def": "value2"},
+						MatchContext: authn.MatchContext{
+							RegexpCaptureGroups: []string{ "user" },
+						}},
+					Config: json.RawMessage([]byte(`{"claims": "{\"custom-claim\": \"{{ print .Extra.abc }}\", \"custom-claim2\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 1}}\", \"aud\": [\"foo\", \"bar\"]}"}`)),
+					Match: jwt.MapClaims{
+						"custom-claim":  "value1",
+						"custom-claim2": "",
+					},
+					K: "file://../../test/stub/jwks-ecdsa.json",
+				},
+				{
+					Rule: &rule.Rule{ID: "test-rule12"},
+					Session: &authn.AuthenticationSession{
+						Subject: "foo",
+						Extra:   map[string]interface{}{"abc": "value1", "def": "value2"},
+						MatchContext: authn.MatchContext{
+							RegexpCaptureGroups: []string{},
+						}},
+					Config: json.RawMessage([]byte(`{"claims": "{\"custom-claim\": \"{{ print .Extra.abc }}\", \"custom-claim2\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 0}}\", \"aud\": [\"foo\", \"bar\"]}"}`)),
+					Match: jwt.MapClaims{
+						"custom-claim":  "value1",
+						"custom-claim2": "",
+					},
+					K: "file://../../test/stub/jwks-ecdsa.json",
+				},
 			}
 
 			for i, tc := range testCases {

--- a/pipeline/mutate/template.go
+++ b/pipeline/mutate/template.go
@@ -2,6 +2,7 @@ package mutate
 
 import (
 	"fmt"
+	"reflect"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
@@ -17,6 +18,19 @@ func newTemplate(id string) *template.Template {
 					return ""
 				}
 				return fmt.Sprintf("%v", i)
+			},
+			"printIndex": func(element interface{}, i int) string {
+				if element == nil {
+					return ""
+				}
+				
+				list := reflect.ValueOf(element)
+				
+				if list.Kind() == reflect.Slice && i < list.Len() {
+					return fmt.Sprintf("%v", list.Index(i))
+				}
+
+				return ""
 			},
 		}).
 		Funcs(sprig.TxtFuncMap())

--- a/pipeline/mutate/template.go
+++ b/pipeline/mutate/template.go
@@ -8,7 +8,8 @@ import (
 	"github.com/Masterminds/sprig"
 )
 
-func newTemplate(id string) *template.Template {
+// NewTemplate creates a template with additional functions
+func NewTemplate(id string) *template.Template {
 	return template.New(id).
 		// Implies that zero value will be used if a key is missing.
 		Option("missingkey=zero").
@@ -23,9 +24,9 @@ func newTemplate(id string) *template.Template {
 				if element == nil {
 					return ""
 				}
-				
+
 				list := reflect.ValueOf(element)
-				
+
 				if list.Kind() == reflect.Slice && i < list.Len() {
 					return fmt.Sprintf("%v", list.Index(i))
 				}

--- a/rule/engine_glob.go
+++ b/rule/engine_glob.go
@@ -31,6 +31,11 @@ func (ge *globMatchingEngine) ReplaceAllString(_, _, _ string) (string, error) {
 	return "", ErrMethodNotImplemented
 }
 
+// FindStringSubmatch is noop for now and always returns an empty array
+func (ge *globMatchingEngine) FindStringSubmatch(pattern, matchAgainst string) ([]string, error) {
+	return []string{}, nil
+}
+
 func (ge *globMatchingEngine) compile(pattern string) error {
 	if ge.table == nil {
 		ge.table = crc64.MakeTable(polynomial)

--- a/rule/engine_regexp.go
+++ b/rule/engine_regexp.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"errors"
 	"hash/crc64"
 
 	"github.com/dlclark/regexp2"
@@ -47,4 +48,23 @@ func (re *regexpMatchingEngine) ReplaceAllString(pattern, input, replacement str
 		return "", err
 	}
 	return re.compiled.Replace(input, replacement, -1, -1)
+}
+
+// FindStringSubmatch returns all captures in matchAgainst following the pattern
+func (re *regexpMatchingEngine) FindStringSubmatch(pattern, matchAgainst string) ([]string, error) {
+	if err := re.compile(pattern); err != nil {
+		return nil, err
+	}
+
+	m, _ := re.compiled.FindStringMatch(matchAgainst)
+	if m == nil {
+		return nil, errors.New("not match")
+	}
+
+	result := []string{}
+	for _, group := range m.Groups()[1:] {
+		result = append(result, group.String())
+	}
+
+	return result, nil
 }

--- a/rule/engine_regexp_test.go
+++ b/rule/engine_regexp_test.go
@@ -1,0 +1,69 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindStringSubmatch(t *testing.T) {
+	type args struct {
+		pattern      string
+		matchAgainst string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "bad pattern",
+			args: args{
+				pattern:      `urn:foo:<.?>`,
+				matchAgainst: "urn:foo:user",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "one group",
+			args: args{
+				pattern:      `urn:foo:<.*>`,
+				matchAgainst: "urn:foo:user",
+			},
+			want:    []string{"user"},
+			wantErr: false,
+		},
+		{
+			name: "several groups",
+			args: args{
+				pattern:      `urn:foo:<.*>:<.*>`,
+				matchAgainst: "urn:foo:user:one",
+			},
+			want:    []string{"user", "one"},
+			wantErr: false,
+		},
+		{
+			name: "classic foo bar",
+			args: args{
+				pattern:      `urn:foo:<foo|bar>`,
+				matchAgainst: "urn:foo:bar",
+			},
+			want:    []string{"bar"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			regexpEngine := new(regexpMatchingEngine)
+			got, err := regexpEngine.FindStringSubmatch(tt.args.pattern, tt.args.matchAgainst)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindStringSubmatch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			assert.ElementsMatch(t, got, tt.want, "FindStringSubmatch() got = %v, want %v", got, tt.want)
+		})
+	}
+}

--- a/rule/matching_engine.go
+++ b/rule/matching_engine.go
@@ -20,5 +20,6 @@ var (
 type MatchingEngine interface {
 	IsMatching(pattern, matchAgainst string) (bool, error)
 	ReplaceAllString(pattern, input, replacement string) (string, error)
+	FindStringSubmatch(pattern, matchAgainst string) ([]string, error)
 	Checksum() uint64
 }

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -217,3 +217,22 @@ func ensureMatchingEngine(rule *Rule, strategy configuration.MatchingStrategy) e
 
 	return errors.Wrap(ErrUnknownMatchingStrategy, string(strategy))
 }
+
+// ExtractRegexGroups returns the values matching the rule pattern
+func (r *Rule) ExtractRegexGroups(strategy configuration.MatchingStrategy, u *url.URL) ([]string, error) {
+	if err := ensureMatchingEngine(r, strategy); err != nil {
+		return nil, err
+	}
+
+	if r.Match == nil {
+		return []string{}, nil
+	}
+
+	matchAgainst := fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Path)
+	groups, err := r.matchingEngine.FindStringSubmatch(r.Match.URL, matchAgainst)
+	if err != nil {
+		return nil, err
+	}
+
+	return groups, nil
+}


### PR DESCRIPTION
## Related issue

[`#292`](https://github.com/ory/oathkeeper/issues/292)

Discussed with @aeneasr 

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

The **AuthenticationSession** is now global to all the life of the request handler.
The signature changes to:

```go
type AuthenticationSession struct {
	Subject      string                 `json:"subject"`
	Extra        map[string]interface{} `json:"extra"`
	Header       http.Header            `json:"header"`
	MatchContext MatchContext           `json:"matchContext"`
}

type MatchContext struct {
	RegexpCaptureGroups []string `json:"regexpCaptureGroups"`
	URL                 *url.URL `json:"url"`
}
```

So it's now possible to use it in all authorizers or mutators.
For example with **mutator_id_token**
```json
{"claims": "{\"custom-claim\": \"{{ print .Extra.abc }}\", \"custom-claim2\": \"{{ index .MatchContext.RegexpCaptureGroups 0 }}\", \"aud\": [\"foo\", \"bar\"]}"}
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

Should we keep compatibility with the **ReplaceAllString** syntax in the config of the _keto_engine_acp_ory_ authorizer?

New syntax
```json
{
  "handler": "keto_engine_acp_ory",
  "config": {
    "required_action": "my:action:{{ index .MatchContext.RegexpCaptureGroups 0 }}",
    "required_resource": "my:resource:{{ index .MatchContext.RegexpCaptureGroups 1 }}:foo:{{ index .MatchContext.RegexpCaptureGroups 0 }}"
  }
}
```
