### PR TITLE
Feature/global auth session

### DIFF
--- a/pipeline/authn/authenticator.go
+++ b/pipeline/authn/authenticator.go
@@ -3,6 +3,7 @@ package authn
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/pkg/errors"
 
@@ -19,7 +20,7 @@ var ErrAuthenticatorNotEnabled = herodot.DefaultError{
 }
 
 type Authenticator interface {
-	Authenticate(r *http.Request, config json.RawMessage, rule pipeline.Rule) (*AuthenticationSession, error)
+	Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, rule pipeline.Rule) error
 	GetID() string
 	Validate(config json.RawMessage) error
 }
@@ -37,9 +38,15 @@ func NewErrAuthenticatorMisconfigured(a Authenticator, err error) *herodot.Defau
 }
 
 type AuthenticationSession struct {
-	Subject string                 `json:"subject"`
-	Extra   map[string]interface{} `json:"extra"`
-	Header  http.Header            `json:"header"`
+	Subject      string                 `json:"subject"`
+	Extra        map[string]interface{} `json:"extra"`
+	Header       http.Header            `json:"header"`
+	MatchContext MatchContext           `json:"matchContext"`
+}
+
+type MatchContext struct {
+	RegexpCaptureGroups []string `json:"regexpCaptureGroups"`
+	URL                 *url.URL `json:"url"`
 }
 
 func (a *AuthenticationSession) SetHeader(key, val string) {

--- a/pipeline/authn/authenticator.go
+++ b/pipeline/authn/authenticator.go
@@ -41,11 +41,11 @@ type AuthenticationSession struct {
 	Subject      string                 `json:"subject"`
 	Extra        map[string]interface{} `json:"extra"`
 	Header       http.Header            `json:"header"`
-	MatchContext MatchContext           `json:"matchContext"`
+	MatchContext MatchContext           `json:"match_context"`
 }
 
 type MatchContext struct {
-	RegexpCaptureGroups []string `json:"regexpCaptureGroups"`
+	RegexpCaptureGroups []string `json:"regexp_capture_groups"`
 	URL                 *url.URL `json:"url"`
 }
 

--- a/pipeline/authn/authenticator_anonymous.go
+++ b/pipeline/authn/authenticator_anonymous.go
@@ -48,17 +48,17 @@ func (a *AuthenticatorAnonymous) Config(config json.RawMessage) (*AuthenticatorA
 	return &c, nil
 }
 
-func (a *AuthenticatorAnonymous) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
+func (a *AuthenticatorAnonymous) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
 	if len(r.Header.Get("Authorization")) != 0 {
-		return nil, errors.WithStack(ErrAuthenticatorNotResponsible)
+		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
 	cf, err := a.Config(config)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &AuthenticationSession{
-		Subject: stringsx.Coalesce(cf.Subject, "anonymous"),
-	}, nil
+	session.Subject = stringsx.Coalesce(cf.Subject, "anonymous")
+
+	return nil
 }

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -316,7 +316,8 @@ func TestAuthenticatorJWT(t *testing.T) {
 				}
 
 				tc.config, _ = sjson.Set(tc.config, "jwks_urls", keys)
-				session, err := a.Authenticate(tc.r, json.RawMessage([]byte(tc.config)), nil)
+				session := new(AuthenticationSession)
+				err := a.Authenticate(tc.r, session, json.RawMessage([]byte(tc.config)), nil)
 				if tc.expectErr {
 					require.Error(t, err)
 					if tc.expectCode != 0 {

--- a/pipeline/authn/authenticator_noop.go
+++ b/pipeline/authn/authenticator_noop.go
@@ -31,6 +31,6 @@ func (a *AuthenticatorNoOp) Validate(config json.RawMessage) error {
 	return nil
 }
 
-func (a *AuthenticatorNoOp) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
-	return &AuthenticationSession{Subject: ""}, nil
+func (a *AuthenticatorNoOp) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
+	return nil
 }

--- a/pipeline/authn/authenticator_noop_test.go
+++ b/pipeline/authn/authenticator_noop_test.go
@@ -41,7 +41,7 @@ func TestAuthenticatorNoop(t *testing.T) {
 	assert.Equal(t, "noop", a.GetID())
 
 	t.Run("method=authenticate", func(t *testing.T) {
-		_, err := a.Authenticate(nil, nil, nil)
+		err := a.Authenticate(nil, nil, nil, nil)
 		require.NoError(t, err)
 	})
 

--- a/pipeline/authn/authenticator_oauth2_client_credentials.go
+++ b/pipeline/authn/authenticator_oauth2_client_credentials.go
@@ -55,25 +55,25 @@ func (a *AuthenticatorOAuth2ClientCredentials) Config(config json.RawMessage) (*
 	return &c, nil
 }
 
-func (a *AuthenticatorOAuth2ClientCredentials) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
+func (a *AuthenticatorOAuth2ClientCredentials) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
 	cf, err := a.Config(config)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	user, password, ok := r.BasicAuth()
 	if !ok {
-		return nil, errors.WithStack(ErrAuthenticatorNotResponsible)
+		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
 	user, err = url.QueryUnescape(user)
 	if err != nil {
-		return nil, errors.Wrapf(helper.ErrUnauthorized, err.Error())
+		return errors.Wrapf(helper.ErrUnauthorized, err.Error())
 	}
 
 	password, err = url.QueryUnescape(password)
 	if err != nil {
-		return nil, errors.Wrapf(helper.ErrUnauthorized, err.Error())
+		return errors.Wrapf(helper.ErrUnauthorized, err.Error())
 	}
 
 	c := &clientcredentials.Config{
@@ -90,14 +90,13 @@ func (a *AuthenticatorOAuth2ClientCredentials) Authenticate(r *http.Request, con
 		httpx.NewResilientClientLatencyToleranceMedium(nil),
 	))
 	if err != nil {
-		return nil, errors.Wrapf(helper.ErrUnauthorized, err.Error())
+		return errors.Wrapf(helper.ErrUnauthorized, err.Error())
 	}
 
 	if token.AccessToken == "" {
-		return nil, errors.WithStack(helper.ErrUnauthorized)
+		return errors.WithStack(helper.ErrUnauthorized)
 	}
 
-	return &AuthenticationSession{
-		Subject: user,
-	}, nil
+	session.Subject = user
+	return nil
 }

--- a/pipeline/authn/authenticator_oauth2_client_credentials_test.go
+++ b/pipeline/authn/authenticator_oauth2_client_credentials_test.go
@@ -93,7 +93,8 @@ func TestAuthenticatorOAuth2ClientCredentials(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("method=authenticate/case=%d", k), func(t *testing.T) {
-			session, err := a.Authenticate(tc.r, tc.config, nil)
+			session := new(authn.AuthenticationSession)
+			err := a.Authenticate(tc.r, session, tc.config, nil)
 
 			if tc.expectErr != nil {
 				require.EqualError(t, errors.Cause(err), tc.expectErr.Error())

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -332,7 +332,8 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 
 				tc.config, _ = sjson.SetBytes(tc.config, "introspection_url", ts.URL+"/oauth2/introspect")
 				tc.config, _ = sjson.SetBytes(tc.config, "scope_strategy", "exact")
-				sess, err := a.Authenticate(tc.r, tc.config, nil)
+				sess := new(AuthenticationSession)
+				err := a.Authenticate(tc.r, sess, tc.config, nil)
 				if tc.expectErr {
 					require.Error(t, err)
 					if tc.expectExactErr != nil {

--- a/pipeline/authn/authenticator_unauthorized.go
+++ b/pipeline/authn/authenticator_unauthorized.go
@@ -55,6 +55,6 @@ func (a *AuthenticatorUnauthorized) GetID() string {
 	return "unauthorized"
 }
 
-func (a *AuthenticatorUnauthorized) Authenticate(r *http.Request, config json.RawMessage, _ pipeline.Rule) (*AuthenticationSession, error) {
-	return nil, errors.WithStack(helper.ErrUnauthorized)
+func (a *AuthenticatorUnauthorized) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
+	return errors.WithStack(helper.ErrUnauthorized)
 }

--- a/pipeline/authn/authenticator_unauthorized_test.go
+++ b/pipeline/authn/authenticator_unauthorized_test.go
@@ -42,7 +42,7 @@ func TestAuthenticatorBroken(t *testing.T) {
 	assert.Equal(t, "unauthorized", a.GetID())
 
 	t.Run("method=authenticate", func(t *testing.T) {
-		_, err := a.Authenticate(&http.Request{Header: http.Header{}}, nil, nil)
+		err := a.Authenticate(&http.Request{Header: http.Header{}}, nil, nil, nil)
 		require.Error(t, err)
 	})
 

--- a/pipeline/authz/keto_engine_acp_ory.go
+++ b/pipeline/authz/keto_engine_acp_ory.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/pipeline"
 	"github.com/ory/oathkeeper/pipeline/authn"
-	"github.com/ory/oathkeeper/pipeline/mutate"
+	"github.com/ory/oathkeeper/x"
 
 	"github.com/ory/x/urlx"
 
@@ -83,7 +83,7 @@ func NewAuthorizerKetoEngineACPORY(c configuration.Provider) *AuthorizerKetoEngi
 				"requestedAt":     time.Now().UTC(),
 			}
 		},
-		t: mutate.NewTemplate("keto_engine_acp_ory"),
+		t: x.NewTemplate("keto_engine_acp_ory"),
 	}
 }
 

--- a/pipeline/authz/keto_engine_acp_ory_test.go
+++ b/pipeline/authz/keto_engine_acp_ory_test.go
@@ -99,7 +99,7 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			config: []byte(`{ "required_action": "action:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}", "required_resource": "resource:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}" }`),
+			config: []byte(`{ "required_action": "action:{{ printIndex .MatchContext.RegexpCaptureGroups (sub 1 1 | int)}}:{{ index .MatchContext.RegexpCaptureGroups (sub 2 1 | int)}}", "required_resource": "resource:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}" }`),
 			r:      &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde")},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pipeline/authz/keto_engine_acp_ory_test.go
+++ b/pipeline/authz/keto_engine_acp_ory_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/internal"
 
-	"github.com/ory/oathkeeper/pipeline"
 	"github.com/ory/oathkeeper/pipeline/authn"
 	. "github.com/ory/oathkeeper/pipeline/authz"
 
@@ -52,6 +51,8 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 	conf := internal.NewConfigurationWithDefaults()
 	reg := internal.NewRegistry(conf)
 
+	rule := &rule.Rule{ID: "TestAuthorizer"}
+
 	a, err := reg.PipelineAuthorizer("keto_engine_acp_ory")
 	require.NoError(t, err)
 	assert.Equal(t, "keto_engine_acp_ory", a.GetID())
@@ -61,33 +62,20 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 		r         *http.Request
 		session   *authn.AuthenticationSession
 		config    json.RawMessage
-		rule      pipeline.Rule
 		expectErr bool
 	}{
 		{
 			expectErr: true,
 		},
 		{
-			config: []byte(`{ "required_action": "action", "required_resource": "resource" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/",
-				},
-			},
+			config:    []byte(`{ "required_action": "action", "required_resource": "resource" }`),
 			r:         &http.Request{URL: &url.URL{}},
 			session:   new(authn.AuthenticationSession),
 			expectErr: true,
 		},
 		{
 			config: []byte(`{ "required_action": "action", "required_resource": "resource", "flavor": "regex" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/",
-				},
-			},
-			r: &http.Request{URL: &url.URL{}},
+			r:      &http.Request{URL: &url.URL{}},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusForbidden)
@@ -98,13 +86,7 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 		},
 		{
 			config: []byte(`{ "required_action": "action", "required_resource": "resource", "flavor": "exact" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/",
-				},
-			},
-			r: &http.Request{URL: &url.URL{}},
+			r:      &http.Request{URL: &url.URL{}},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					assert.Contains(t, r.Header, "Content-Type")
@@ -117,14 +99,8 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			config: []byte(`{ "required_action": "action:$1:$2", "required_resource": "resource:$1:$2" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/api/users/<[0-9]+>/<[a-z]+>",
-				},
-			},
-			r: &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde")},
+			config: []byte(`{ "required_action": "action:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}", "required_resource": "resource:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}" }`),
+			r:      &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde")},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					var ki AuthorizerKetoEngineACPORYRequestBody
@@ -139,18 +115,17 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 					w.Write([]byte(`{"allowed":true}`))
 				}))
 			},
-			session:   &authn.AuthenticationSession{Subject: "peter"},
+			session: &authn.AuthenticationSession{
+				Subject: "peter",
+				MatchContext: authn.MatchContext{
+					RegexpCaptureGroups: []string{"1234", "abcde"},
+				},
+			},
 			expectErr: false,
 		},
 		{
-			config: []byte(`{ "required_action": "action:$1:$2", "required_resource": "resource:$1:$2", "subject": "{{ .Extra.name }}" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/api/users/<[0-9]+>/<[a-z]+>",
-				},
-			},
-			r: &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde")},
+			config: []byte(`{ "required_action": "action:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}", "required_resource": "resource:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ index .MatchContext.RegexpCaptureGroups 1}}", "subject": "{{ .Extra.name }}" }`),
+			r:      &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde")},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					var ki AuthorizerKetoEngineACPORYRequestBody
@@ -165,25 +140,23 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 					w.Write([]byte(`{"allowed":true}`))
 				}))
 			},
-			session:   &authn.AuthenticationSession{Extra: map[string]interface{}{"name": "peter"}},
+			session: &authn.AuthenticationSession{
+				Extra: map[string]interface{}{"name": "peter"},
+				MatchContext: authn.MatchContext{
+					RegexpCaptureGroups: []string{"1234", "abcde"},
+				}},
 			expectErr: false,
 		},
 		{
-			config: []byte(`{ "required_action": "action:$1:$2", "required_resource": "resource:$1:$2", "subject": "{{ .Extra.name }}" }`),
-			rule: &rule.Rule{
-				Match: &rule.Match{
-					Methods: []string{"POST"},
-					URL:     "https://localhost/api/users/<[0-9]+>/<[a-z]+>",
-				},
-			},
-			r: &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde?limit=10")},
+			config: []byte(`{ "required_action": "action:{{ index .MatchContext.RegexpCaptureGroups 0 }}:{{ .Extra.name }}", "required_resource": "resource:{{ index .MatchContext.RegexpCaptureGroups 0}}:{{ .Extra.apiVersion }}", "subject": "{{ .Extra.name }}" }`),
+			r:      &http.Request{URL: urlx.ParseOrPanic("https://localhost/api/users/1234/abcde?limit=10")},
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					var ki AuthorizerKetoEngineACPORYRequestBody
 					require.NoError(t, json.NewDecoder(r.Body).Decode(&ki))
 					assert.EqualValues(t, AuthorizerKetoEngineACPORYRequestBody{
-						Action:   "action:1234:abcde",
-						Resource: "resource:1234:abcde",
+						Action:   "action:1234:peter",
+						Resource: "resource:1234:1.0",
 						Context:  map[string]interface{}{},
 						Subject:  "peter",
 					}, ki)
@@ -191,7 +164,12 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 					w.Write([]byte(`{"allowed":true}`))
 				}))
 			},
-			session:   &authn.AuthenticationSession{Extra: map[string]interface{}{"name": "peter"}},
+			session: &authn.AuthenticationSession{
+				Extra: map[string]interface{}{
+					"name":       "peter",
+					"apiVersion": "1.0"},
+				MatchContext: authn.MatchContext{RegexpCaptureGroups: []string{"1234"}},
+			},
 			expectErr: false,
 		},
 	} {
@@ -211,7 +189,7 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 			})
 
 			tc.config, _ = sjson.SetBytes(tc.config, "base_url", baseURL)
-			err := a.Authorize(tc.r, tc.session, tc.config, tc.rule)
+			err := a.Authorize(tc.r, tc.session, tc.config, rule)
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {
@@ -224,15 +202,13 @@ func TestAuthorizerKetoWarden(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"","required_action":"foo","required_resource":"bar"}`)))
 
-		viper.Reset()
-		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, true)
-		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"","required_action":"foo","required_resource":"bar"}`)))
-
-		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, false)
 		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"http://foo/bar","required_action":"foo","required_resource":"bar"}`)))
 
 		viper.Reset()
+		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, true)
+		require.Error(t, a.Validate(json.RawMessage(`{"base_url":"","required_action":"foo","required_resource":"bar"}`)))
+
 		viper.Set(configuration.ViperKeyAuthorizerKetoEngineACPORYIsEnabled, true)
 		require.NoError(t, a.Validate(json.RawMessage(`{"base_url":"http://foo/bar","required_action":"foo","required_resource":"bar"}`)))
 	})

--- a/pipeline/mutate/mutator_cookie.go
+++ b/pipeline/mutate/mutator_cookie.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/pipeline"
 	"github.com/ory/oathkeeper/pipeline/authn"
+	"github.com/ory/oathkeeper/x"
 
 	"github.com/pkg/errors"
 )
@@ -26,7 +27,7 @@ type MutatorCookie struct {
 }
 
 func NewMutatorCookie(c configuration.Provider) *MutatorCookie {
-	return &MutatorCookie{c: c, t: NewTemplate("cookie")}
+	return &MutatorCookie{c: c, t: x.NewTemplate("cookie")}
 }
 
 func (a *MutatorCookie) GetID() string {

--- a/pipeline/mutate/mutator_cookie.go
+++ b/pipeline/mutate/mutator_cookie.go
@@ -26,7 +26,7 @@ type MutatorCookie struct {
 }
 
 func NewMutatorCookie(c configuration.Provider) *MutatorCookie {
-	return &MutatorCookie{c: c, t: newTemplate("cookie")}
+	return &MutatorCookie{c: c, t: NewTemplate("cookie")}
 }
 
 func (a *MutatorCookie) GetID() string {

--- a/pipeline/mutate/mutator_header.go
+++ b/pipeline/mutate/mutator_header.go
@@ -24,7 +24,7 @@ type MutatorHeader struct {
 }
 
 func NewMutatorHeader(c configuration.Provider) *MutatorHeader {
-	return &MutatorHeader{c: c, t: newTemplate("header")}
+	return &MutatorHeader{c: c, t: NewTemplate("header")}
 }
 
 func (a *MutatorHeader) GetID() string {

--- a/pipeline/mutate/mutator_header.go
+++ b/pipeline/mutate/mutator_header.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/pipeline"
 	"github.com/ory/oathkeeper/pipeline/authn"
+	"github.com/ory/oathkeeper/x"
 
 	"github.com/pkg/errors"
 )
@@ -24,7 +25,7 @@ type MutatorHeader struct {
 }
 
 func NewMutatorHeader(c configuration.Provider) *MutatorHeader {
-	return &MutatorHeader{c: c, t: NewTemplate("header")}
+	return &MutatorHeader{c: c, t: x.NewTemplate("header")}
 }
 
 func (a *MutatorHeader) GetID() string {

--- a/pipeline/mutate/mutator_header_test.go
+++ b/pipeline/mutate/mutator_header_test.go
@@ -140,6 +140,23 @@ func TestCredentialsIssuerHeaders(t *testing.T) {
 				},
 				Err: nil,
 			},
+			"Use request captures to header": {
+				Session: &authn.AuthenticationSession{
+					Subject: "foo",
+					MatchContext: authn.MatchContext{
+						RegexpCaptureGroups: []string{"Foo", "Bar"},
+					},
+				},
+				Rule: &rule.Rule{ID: "test-rule10"},
+				Config: json.RawMessage([]byte(`{"headers":{
+					"Example-Claims": "{{ index .MatchContext.RegexpCaptureGroups 0}}"
+				}}`)),
+				Request: &http.Request{Header: http.Header{}},
+				Match: http.Header{
+					"Example-Claims": []string{"Foo"},
+				},
+				Err: nil,
+			},
 		}
 
 		t.Run("cache=disabled", func(t *testing.T) {

--- a/pipeline/mutate/mutator_hydrator_test.go
+++ b/pipeline/mutate/mutator_hydrator_test.go
@@ -39,6 +39,14 @@ func setSubject(subject string) func(a *authn.AuthenticationSession) {
 	}
 }
 
+func setMatchContext(groups []string) func(a *authn.AuthenticationSession) {
+	return func(a *authn.AuthenticationSession) {
+		a.MatchContext = authn.MatchContext{
+			RegexpCaptureGroups: groups,
+		}
+	}
+}
+
 func newAuthenticationSession(modifications ...func(a *authn.AuthenticationSession)) *authn.AuthenticationSession {
 	a := authn.AuthenticationSession{}
 	for _, f := range modifications {
@@ -135,6 +143,7 @@ func TestMutatorHydrator(t *testing.T) {
 			"foo": "hello",
 			"bar": 3.14,
 		}
+		sampleCaptureGroups := []string{"resource", "context"}
 		sampleUserId := "user"
 		sampleValidPassword := "passwd1"
 		sampleNotValidPassword := "passwd7"
@@ -176,11 +185,11 @@ func TestMutatorHydrator(t *testing.T) {
 			},
 			"No Changes": {
 				Setup:   defaultRouterSetup(),
-				Session: newAuthenticationSession(setExtra(sampleKey, sampleValue)),
+				Session: newAuthenticationSession(setExtra(sampleKey, sampleValue), setMatchContext(sampleCaptureGroups)),
 				Rule:    &rule.Rule{ID: "test-rule"},
 				Config:  defaultConfigForMutator(),
 				Request: &http.Request{},
-				Match:   newAuthenticationSession(setExtra(sampleKey, sampleValue)),
+				Match:   newAuthenticationSession(setExtra(sampleKey, sampleValue), setMatchContext(sampleCaptureGroups)),
 				Err:     nil,
 			},
 			"No Extra Before And After": {

--- a/pipeline/mutate/mutator_id_token.go
+++ b/pipeline/mutate/mutator_id_token.go
@@ -73,7 +73,7 @@ func NewMutatorIDToken(c configuration.Provider, r MutatorIDTokenRegistry) *Muta
 		MaxCost:     1 << 25,
 		BufferItems: 64,
 	})
-	return &MutatorIDToken{r: r, c: c, templates: newTemplate("id_token"), tokenCache: cache, tokenCacheEnabled: true}
+	return &MutatorIDToken{r: r, c: c, templates: NewTemplate("id_token"), tokenCache: cache, tokenCacheEnabled: true}
 }
 
 func (a *MutatorIDToken) GetID() string {

--- a/pipeline/mutate/mutator_id_token.go
+++ b/pipeline/mutate/mutator_id_token.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/pipeline"
 	"github.com/ory/oathkeeper/pipeline/authn"
+	"github.com/ory/oathkeeper/x"
 )
 
 type MutatorIDTokenRegistry interface {
@@ -73,7 +74,7 @@ func NewMutatorIDToken(c configuration.Provider, r MutatorIDTokenRegistry) *Muta
 		MaxCost:     1 << 25,
 		BufferItems: 64,
 	})
-	return &MutatorIDToken{r: r, c: c, templates: NewTemplate("id_token"), tokenCache: cache, tokenCacheEnabled: true}
+	return &MutatorIDToken{r: r, c: c, templates: x.NewTemplate("id_token"), tokenCache: cache, tokenCacheEnabled: true}
 }
 
 func (a *MutatorIDToken) GetID() string {

--- a/pipeline/mutate/mutator_id_token_test.go
+++ b/pipeline/mutate/mutator_id_token_test.go
@@ -141,6 +141,51 @@ var idTokenTestCases = []idTokenTestCase{
 		Match:   jwt.MapClaims{},
 		K:       "file://../../test/stub/jwks-ecdsa.json",
 	},
+	{
+		Rule: &rule.Rule{ID: "test-rule10"},
+		Session: &authn.AuthenticationSession{
+			Subject: "foo",
+			Extra:   map[string]interface{}{"abc": "value1", "def": "value2"},
+			MatchContext: authn.MatchContext{
+				RegexpCaptureGroups: []string{"user", "pass"},
+			}},
+		Config: json.RawMessage([]byte(`{"claims": "{\"custom-claim\": \"{{ print .Extra.abc }}\", \"custom-claim2\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 1}}\", \"aud\": [\"foo\", \"bar\"]}"}`)),
+		Match: jwt.MapClaims{
+			"custom-claim":  "value1",
+			"custom-claim2": "pass",
+		},
+		K: "file://../../test/stub/jwks-ecdsa.json",
+	},
+	{
+		Rule: &rule.Rule{ID: "test-rule11"},
+		Session: &authn.AuthenticationSession{
+			Subject: "foo",
+			Extra:   map[string]interface{}{"abc": "value1", "def": "value2"},
+			MatchContext: authn.MatchContext{
+				RegexpCaptureGroups: []string{"user"},
+			}},
+		Config: json.RawMessage([]byte(`{"claims": "{\"custom-claim\": \"{{ print .Extra.abc }}\", \"custom-claim2\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 1}}\", \"aud\": [\"foo\", \"bar\"]}"}`)),
+		Match: jwt.MapClaims{
+			"custom-claim":  "value1",
+			"custom-claim2": "",
+		},
+		K: "file://../../test/stub/jwks-ecdsa.json",
+	},
+	{
+		Rule: &rule.Rule{ID: "test-rule12"},
+		Session: &authn.AuthenticationSession{
+			Subject: "foo",
+			Extra:   map[string]interface{}{"abc": "value1", "def": "value2"},
+			MatchContext: authn.MatchContext{
+				RegexpCaptureGroups: []string{},
+			}},
+		Config: json.RawMessage([]byte(`{"claims": "{\"custom-claim\": \"{{ print .Extra.abc }}\", \"custom-claim2\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 0}}\", \"aud\": [\"foo\", \"bar\"]}"}`)),
+		Match: jwt.MapClaims{
+			"custom-claim":  "value1",
+			"custom-claim2": "",
+		},
+		K: "file://../../test/stub/jwks-ecdsa.json",
+	},
 }
 
 func parseToken(h http.Header) string {

--- a/pipeline/mutate/template.go
+++ b/pipeline/mutate/template.go
@@ -2,6 +2,7 @@ package mutate
 
 import (
 	"fmt"
+	"reflect"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
@@ -17,6 +18,19 @@ func newTemplate(id string) *template.Template {
 					return ""
 				}
 				return fmt.Sprintf("%v", i)
+			},
+			"printIndex": func(element interface{}, i int) string {
+				if element == nil {
+					return ""
+				}
+				
+				list := reflect.ValueOf(element)
+				
+				if list.Kind() == reflect.Slice && i < list.Len() {
+					return fmt.Sprintf("%v", list.Index(i))
+				}
+
+				return ""
 			},
 		}).
 		Funcs(sprig.TxtFuncMap())

--- a/pipeline/mutate/template.go
+++ b/pipeline/mutate/template.go
@@ -8,7 +8,8 @@ import (
 	"github.com/Masterminds/sprig"
 )
 
-func newTemplate(id string) *template.Template {
+// NewTemplate creates a template with additional functions
+func NewTemplate(id string) *template.Template {
 	return template.New(id).
 		// Implies that zero value will be used if a key is missing.
 		Option("missingkey=zero").
@@ -23,9 +24,9 @@ func newTemplate(id string) *template.Template {
 				if element == nil {
 					return ""
 				}
-				
+
 				list := reflect.ValueOf(element)
-				
+
 				if list.Kind() == reflect.Slice && i < list.Len() {
 					return fmt.Sprintf("%v", list.Index(i))
 				}

--- a/rule/engine_glob.go
+++ b/rule/engine_glob.go
@@ -31,6 +31,11 @@ func (ge *globMatchingEngine) ReplaceAllString(_, _, _ string) (string, error) {
 	return "", ErrMethodNotImplemented
 }
 
+// FindStringSubmatch is noop for now and always returns an empty array
+func (ge *globMatchingEngine) FindStringSubmatch(pattern, matchAgainst string) ([]string, error) {
+	return []string{}, nil
+}
+
 func (ge *globMatchingEngine) compile(pattern string) error {
 	if ge.table == nil {
 		ge.table = crc64.MakeTable(polynomial)

--- a/rule/engine_regexp.go
+++ b/rule/engine_regexp.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"errors"
 	"hash/crc64"
 
 	"github.com/dlclark/regexp2"
@@ -48,4 +49,23 @@ func (re *regexpMatchingEngine) ReplaceAllString(pattern, input, replacement str
 		return "", err
 	}
 	return re.compiled.Replace(input, replacement, -1, -1)
+}
+
+// FindStringSubmatch returns all captures in matchAgainst following the pattern
+func (re *regexpMatchingEngine) FindStringSubmatch(pattern, matchAgainst string) ([]string, error) {
+	if err := re.compile(pattern); err != nil {
+		return nil, err
+	}
+
+	m, _ := re.compiled.FindStringMatch(matchAgainst)
+	if m == nil {
+		return nil, errors.New("not match")
+	}
+
+	result := []string{}
+	for _, group := range m.Groups()[1:] {
+		result = append(result, group.String())
+	}
+
+	return result, nil
 }

--- a/rule/engine_regexp_test.go
+++ b/rule/engine_regexp_test.go
@@ -1,0 +1,69 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindStringSubmatch(t *testing.T) {
+	type args struct {
+		pattern      string
+		matchAgainst string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "bad pattern",
+			args: args{
+				pattern:      `urn:foo:<.?>`,
+				matchAgainst: "urn:foo:user",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "one group",
+			args: args{
+				pattern:      `urn:foo:<.*>`,
+				matchAgainst: "urn:foo:user",
+			},
+			want:    []string{"user"},
+			wantErr: false,
+		},
+		{
+			name: "several groups",
+			args: args{
+				pattern:      `urn:foo:<.*>:<.*>`,
+				matchAgainst: "urn:foo:user:one",
+			},
+			want:    []string{"user", "one"},
+			wantErr: false,
+		},
+		{
+			name: "classic foo bar",
+			args: args{
+				pattern:      `urn:foo:<foo|bar>`,
+				matchAgainst: "urn:foo:bar",
+			},
+			want:    []string{"bar"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			regexpEngine := new(regexpMatchingEngine)
+			got, err := regexpEngine.FindStringSubmatch(tt.args.pattern, tt.args.matchAgainst)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindStringSubmatch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			assert.ElementsMatch(t, got, tt.want, "FindStringSubmatch() got = %v, want %v", got, tt.want)
+		})
+	}
+}

--- a/rule/matching_engine.go
+++ b/rule/matching_engine.go
@@ -20,5 +20,6 @@ var (
 type MatchingEngine interface {
 	IsMatching(pattern, matchAgainst string) (bool, error)
 	ReplaceAllString(pattern, input, replacement string) (string, error)
+	FindStringSubmatch(pattern, matchAgainst string) ([]string, error)
 	Checksum() uint64
 }

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -217,3 +217,22 @@ func ensureMatchingEngine(rule *Rule, strategy configuration.MatchingStrategy) e
 
 	return errors.Wrap(ErrUnknownMatchingStrategy, string(strategy))
 }
+
+// ExtractRegexGroups returns the values matching the rule pattern
+func (r *Rule) ExtractRegexGroups(strategy configuration.MatchingStrategy, u *url.URL) ([]string, error) {
+	if err := ensureMatchingEngine(r, strategy); err != nil {
+		return nil, err
+	}
+
+	if r.Match == nil {
+		return []string{}, nil
+	}
+
+	matchAgainst := fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Path)
+	groups, err := r.matchingEngine.FindStringSubmatch(r.Match.URL, matchAgainst)
+	if err != nil {
+		return nil, err
+	}
+
+	return groups, nil
+}

--- a/rule/rule_migrator_test.go
+++ b/rule/rule_migrator_test.go
@@ -81,6 +81,38 @@ func TestRuleMigration(t *testing.T) {
 }`,
 			version: "v0.33.0-beta.1+oryOS.12",
 		},
+		{
+			d: "should migrate to 0.37.0",
+			in: `{
+				"version": "v0.33.0",
+				"authorizer":	
+				  {
+					"handler": "keto_engine_acp_ory",
+					"config": {
+						"required_action": "my:action:$1",
+						"required_resource": "my:resource:$2:foo:$1",
+						"flavor": "exact"
+					}
+				  }
+			  }`,
+			out: `{
+				"id": "",
+				"version": "v0.37.0",
+				"description":"","match":null,"authenticators":null,"errors":null,
+				"authorizer":	
+				  {
+					"handler": "keto_engine_acp_ory",
+					"config": {
+						"required_action": "my:action:{{ printIndex .MatchContext.RegexpCaptureGroups (sub 1 1 | int)}}",
+						"required_resource": "my:resource:{{ printIndex .MatchContext.RegexpCaptureGroups (sub 2 1 | int)}}:foo:{{ printIndex .MatchContext.RegexpCaptureGroups (sub 1 1 | int)}}",
+						"flavor": "exact"
+					}
+				  },
+				"mutators": null,
+				"upstream":{"preserve_host":false,"strip_path":"","url":""}
+			  }`,
+			version: "v0.37.0+oryOS.18",
+		},
 	} {
 		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
 			var r Rule

--- a/x/template.go
+++ b/x/template.go
@@ -1,4 +1,4 @@
-package mutate
+package x
 
 import (
 	"fmt"


### PR DESCRIPTION
## Related issue

[`#292`](https://github.com/ory/oathkeeper/issues/292)

Discussed with @aeneasr 

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

The **AuthenticationSession** is now global to all the life of the request handler.
The signature changes to:

```go
type AuthenticationSession struct {
	Subject      string                 `json:"subject"`
	Extra        map[string]interface{} `json:"extra"`
	Header       http.Header            `json:"header"`
	MatchContext MatchContext           `json:"matchContext"`
}

type MatchContext struct {
	RegexpCaptureGroups []string `json:"regexpCaptureGroups"`
	URL                 *url.URL `json:"url"`
}
```

So it's now possible to use it in all authorizers or mutators.
For example with **mutator_id_token**
```json
{"claims": "{\"custom-claim\": \"{{ print .Extra.abc }}\", \"custom-claim2\": \"{{ index .MatchContext.RegexpCaptureGroups 0 }}\", \"aud\": [\"foo\", \"bar\"]}"}
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

Should we keep compatibility with the **ReplaceAllString** syntax in the config of the _keto_engine_acp_ory_ authorizer?

New syntax
```json
{
  "handler": "keto_engine_acp_ory",
  "config": {
    "required_action": "my:action:{{ index .MatchContext.RegexpCaptureGroups 0 }}",
    "required_resource": "my:resource:{{ index .MatchContext.RegexpCaptureGroups 1 }}:foo:{{ index .MatchContext.RegexpCaptureGroups 0 }}"
  }
}
```
