### PR TITLE
fix: Don't send scope with OAuth2 introspection request

### DIFF
--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -85,7 +85,7 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session
 		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
-	body := url.Values{"token": {token}, "scope": {strings.Join(cf.Scopes, " ")}}
+	body := url.Values{"token": {token}}
 	introspectReq, err := http.NewRequest(http.MethodPost, cf.IntrospectionURL, strings.NewReader(body.Encode()))
 	if err != nil {
 		return errors.WithStack(err)

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -86,6 +86,12 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session
 	}
 
 	body := url.Values{"token": {token}}
+
+	ss := a.c.ToScopeStrategy(cf.ScopeStrategy, "authenticators.oauth2_introspection.scope_strategy")
+	if ss == nil {
+		body.Add("scope", strings.Join(cf.Scopes, " "))
+	}
+
 	introspectReq, err := http.NewRequest(http.MethodPost, cf.IntrospectionURL, strings.NewReader(body.Encode()))
 	if err != nil {
 		return errors.WithStack(err)
@@ -129,7 +135,7 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session
 		}
 	}
 
-	if ss := a.c.ToScopeStrategy(cf.ScopeStrategy, "authenticators.oauth2_introspection.scope_strategy"); ss != nil {
+	if ss != nil {
 		for _, scope := range cf.Scopes {
 			if !ss(strings.Split(i.Scope, " "), scope) {
 				return errors.WithStack(helper.ErrForbidden.WithReason(fmt.Sprintf("Scope %s was not granted", scope)))

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -70,7 +70,7 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 						require.NoError(t, r.ParseForm())
 						require.Equal(t, "token", r.Form.Get("token"))
-						require.Equal(t, "scope-a scope-b", r.Form.Get("scope"))
+						require.Equal(t, "", r.Form.Get("scope"))
 						w.WriteHeader(http.StatusNotFound)
 					})
 				},
@@ -205,7 +205,7 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 						require.NoError(t, r.ParseForm())
 						require.Equal(t, "token", r.Form.Get("token"))
-						require.Equal(t, "scope-a scope-b", r.Form.Get("scope"))
+						require.Equal(t, "", r.Form.Get("scope"))
 						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
 							Active:   true,
 							Subject:  "subject",
@@ -227,7 +227,7 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 						require.NoError(t, r.ParseForm())
 						require.Equal(t, "token", r.Form.Get("token"))
-						require.Equal(t, "scope-a scope-b scope-c", r.Form.Get("scope"))
+						require.Equal(t, "", r.Form.Get("scope"))
 						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
 							Active:   true,
 							Subject:  "subject",

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -70,7 +70,7 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 						require.NoError(t, r.ParseForm())
 						require.Equal(t, "token", r.Form.Get("token"))
-						require.Equal(t, "", r.Form.Get("scope"))
+						require.Equal(t, "scope-a scope-b", r.Form.Get("scope"))
 						w.WriteHeader(http.StatusNotFound)
 					})
 				},
@@ -198,9 +198,53 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				expectErr: false,
 			},
 			{
-				d:      "should pass because active and scope matching",
+				d:      "should pass because no scope strategy",
 				r:      &http.Request{Header: http.Header{"Authorization": {"bearer token"}}},
 				config: []byte(`{ "required_scope": ["scope-a", "scope-b"] }`),
+				setup: func(t *testing.T, m *httprouter.Router) {
+					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "token", r.Form.Get("token"))
+						require.Equal(t, "scope-a scope-b", r.Form.Get("scope"))
+						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
+							Active:   true,
+							Subject:  "subject",
+							Audience: []string{"audience"},
+							Issuer:   "issuer",
+							Username: "username",
+							Extra:    map[string]interface{}{"extra": "foo"},
+							Scope:    "scope-z",
+						}))
+					})
+				},
+				expectErr: false,
+			},
+			{
+				d:      "should pass because scope strategy is `none`",
+				r:      &http.Request{Header: http.Header{"Authorization": {"bearer token"}}},
+				config: []byte(`{ "scope_strategy": "none", "required_scope": ["scope-a", "scope-b"] }`),
+				setup: func(t *testing.T, m *httprouter.Router) {
+					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "token", r.Form.Get("token"))
+						require.Equal(t, "scope-a scope-b", r.Form.Get("scope"))
+						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
+							Active:   true,
+							Subject:  "subject",
+							Audience: []string{"audience"},
+							Issuer:   "issuer",
+							Username: "username",
+							Extra:    map[string]interface{}{"extra": "foo"},
+							Scope:    "scope-z",
+						}))
+					})
+				},
+				expectErr: false,
+			},
+			{
+				d:      "should pass because active and scope matching exactly",
+				r:      &http.Request{Header: http.Header{"Authorization": {"bearer token"}}},
+				config: []byte(`{ "scope_strategy": "exact", "required_scope": ["scope-a", "scope-b"] }`),
 				setup: func(t *testing.T, m *httprouter.Router) {
 					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 						require.NoError(t, r.ParseForm())
@@ -220,9 +264,97 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				expectErr: false,
 			},
 			{
-				d:      "should fail because active but scope not matching",
+				d:      "should fail because active but scope not matching exactly",
 				r:      &http.Request{Header: http.Header{"Authorization": {"bearer token"}}},
-				config: []byte(`{ "required_scope": ["scope-a", "scope-b", "scope-c"] }`),
+				config: []byte(`{ "scope_strategy": "exact", "required_scope": ["scope-a", "scope-b", "scope-c"] }`),
+				setup: func(t *testing.T, m *httprouter.Router) {
+					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "token", r.Form.Get("token"))
+						require.Equal(t, "", r.Form.Get("scope"))
+						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
+							Active:   true,
+							Subject:  "subject",
+							Audience: []string{"audience"},
+							Issuer:   "issuer",
+							Username: "username",
+							Extra:    map[string]interface{}{"extra": "foo"},
+							Scope:    "scope-a scope-b",
+						}))
+					})
+				},
+				expectErr: true,
+			},
+			{
+				d:      "should pass because active and scope matching hierarchically",
+				r:      &http.Request{Header: http.Header{"Authorization": {"bearer token"}}},
+				config: []byte(`{ "scope_strategy": "hierarchic", "required_scope": ["scope-a", "scope-b.foo", "scope-c.bar"] }`),
+				setup: func(t *testing.T, m *httprouter.Router) {
+					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "token", r.Form.Get("token"))
+						require.Equal(t, "", r.Form.Get("scope"))
+						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
+							Active:   true,
+							Subject:  "subject",
+							Audience: []string{"audience"},
+							Issuer:   "issuer",
+							Username: "username",
+							Extra:    map[string]interface{}{"extra": "foo"},
+							Scope:    "scope-a scope-b scope-c.bar",
+						}))
+					})
+				},
+				expectErr: false,
+			},
+			{
+				d:      "should fail because active but scope not matching hierarchically",
+				r:      &http.Request{Header: http.Header{"Authorization": {"bearer token"}}},
+				config: []byte(`{ "scope_strategy": "hierarchic", "required_scope": ["scope-a", "scope-b.foo", "scope-c.bar"] }`),
+				setup: func(t *testing.T, m *httprouter.Router) {
+					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "token", r.Form.Get("token"))
+						require.Equal(t, "", r.Form.Get("scope"))
+						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
+							Active:   true,
+							Subject:  "subject",
+							Audience: []string{"audience"},
+							Issuer:   "issuer",
+							Username: "username",
+							Extra:    map[string]interface{}{"extra": "foo"},
+							Scope:    "scope-a scope-b",
+						}))
+					})
+				},
+				expectErr: true,
+			},
+			{
+				d:      "should pass because active and scope matching wildcard",
+				r:      &http.Request{Header: http.Header{"Authorization": {"bearer token"}}},
+				config: []byte(`{ "scope_strategy": "wildcard", "required_scope": ["scope-a", "scope-b.foo", "scope-c.bar"] }`),
+				setup: func(t *testing.T, m *httprouter.Router) {
+					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "token", r.Form.Get("token"))
+						require.Equal(t, "", r.Form.Get("scope"))
+						require.NoError(t, json.NewEncoder(w).Encode(&AuthenticatorOAuth2IntrospectionResult{
+							Active:   true,
+							Subject:  "subject",
+							Audience: []string{"audience"},
+							Issuer:   "issuer",
+							Username: "username",
+							Extra:    map[string]interface{}{"extra": "foo"},
+							Scope:    "scope-a scope-b.* scope-c.bar",
+						}))
+					})
+				},
+				expectErr: false,
+			},
+			{
+				d:      "should fail because active but scope not matching wildcard",
+				r:      &http.Request{Header: http.Header{"Authorization": {"bearer token"}}},
+				config: []byte(`{ "scope_strategy": "wildcard", "required_scope": ["scope-a", "scope-b.foo", "scope-c.bar"] }`),
 				setup: func(t *testing.T, m *httprouter.Router) {
 					m.POST("/oauth2/introspect", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 						require.NoError(t, r.ParseForm())
@@ -331,7 +463,6 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				defer ts.Close()
 
 				tc.config, _ = sjson.SetBytes(tc.config, "introspection_url", ts.URL+"/oauth2/introspect")
-				tc.config, _ = sjson.SetBytes(tc.config, "scope_strategy", "exact")
 				sess := new(AuthenticationSession)
 				err := a.Authenticate(tc.r, sess, tc.config, nil)
 				if tc.expectErr {


### PR DESCRIPTION
## Related issue

Fixes #377 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Oathkeeper shouldn't send scope with introspection requests and instead should rely on its own scope validation. See linked issue for more details.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
