### PR TITLE
fix: return a 403 when introspection result is inactive

### DIFF
--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -120,7 +120,7 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session
 	}
 
 	if !i.Active {
-		return errors.WithStack(helper.ErrUnauthorized.WithReason("Access token i says token is not active"))
+		return errors.WithStack(helper.ErrForbidden.WithReason("Access token i says token is not active"))
 	}
 
 	for _, audience := range cf.Audience {

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tidwall/sjson"
 
 	"github.com/ory/oathkeeper/driver/configuration"
+	"github.com/ory/oathkeeper/helper"
 	"github.com/ory/oathkeeper/internal"
 	. "github.com/ory/oathkeeper/pipeline/authn"
 	"github.com/ory/viper"
@@ -175,7 +176,8 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 						}))
 					})
 				},
-				expectErr: true,
+				expectErr:      true,
+				expectExactErr: helper.ErrForbidden,
 			},
 			{
 				d:      "should pass because active and no issuer / audience expected",
@@ -283,7 +285,8 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 						}))
 					})
 				},
-				expectErr: true,
+				expectErr:      true,
+				expectExactErr: helper.ErrForbidden,
 			},
 			{
 				d:      "should pass because active and scope matching hierarchically",
@@ -327,7 +330,8 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 						}))
 					})
 				},
-				expectErr: true,
+				expectErr:      true,
+				expectExactErr: helper.ErrForbidden,
 			},
 			{
 				d:      "should pass because active and scope matching wildcard",
@@ -371,7 +375,8 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 						}))
 					})
 				},
-				expectErr: true,
+				expectErr:      true,
+				expectExactErr: helper.ErrForbidden,
 			},
 			{
 				d:      "should fail because active but issuer not matching",
@@ -391,7 +396,8 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 						}))
 					})
 				},
-				expectErr: true,
+				expectErr:      true,
+				expectExactErr: helper.ErrForbidden,
 			},
 			{
 				d:      "should pass because active and issuer matching",
@@ -431,7 +437,8 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 						}))
 					})
 				},
-				expectErr: true,
+				expectErr:      true,
+				expectExactErr: helper.ErrForbidden,
 			},
 			{
 				d:      "should pass",


### PR DESCRIPTION
## Related issue
The issue has been reported 22 days ago, today, and can be found [here](https://github.com/ory/oathkeeper/issues/387).

## Proposed changes
Make the active check return a 403 instead of a 401.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments
The issue describes how a 401 is returned instead of an expected 403 upon a scope check failure. The 401 is returned by the condition that checks whether the introspection result is active. The author of the issue describes how it was expected for `Authenticate` to return a 403 upon a scope check failure. However, based on what the function is doing, it seems that the introspection result was listed as inactive, which caused the 401 to be returned. I am not aware of whether the `!i.Active` block returns a 401 by design. 