### PR TITLE
feat: cache incoming oauth introspect tokens

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -710,7 +710,7 @@
               "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
               "title": "Cache Time to Live",
               "description": "Can override the default behaviour of using the token exp time, and specify a set time to live for the token in the cache.",
-              "examples": ["5s"]
+              "examples": ["5s"],
               "description": "How long to cache hydrate calls"
             }
           }

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -697,6 +697,24 @@
         },
         "retry": {
           "$ref": "#/definitions/retry"
+        },
+        "cache": {
+          "additionalProperties": false,
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "$ref": "#/definitions/handlerSwitch"
+            },
+            "ttl": {
+              "type": "string",
+              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+              "title": "Cache Time to Live",
+              "description": "How long to cache hydrate calls"
+            }
+          }
         }
       },
       "required": [

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -700,9 +700,6 @@
         },
         "cache": {
           "additionalProperties": false,
-          "required": [
-            "enabled"
-          ],
           "type": "object",
           "properties": {
             "enabled": {
@@ -712,6 +709,8 @@
               "type": "string",
               "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
               "title": "Cache Time to Live",
+              "description": "Can override the default behaviour of using the token exp time, and specify a set time to live for the token in the cache.",
+              "examples": ["5s"]
               "description": "How long to cache hydrate calls"
             }
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@
 
 [Full Changelog](https://github.com/ory/oathkeeper/compare/v0.37.1-beta.1...HEAD)
 
+**Implemented enhancements:**
+
+- Log Rule Id on malformed configuration error [\#383](https://github.com/ory/oathkeeper/issues/383)
+
 **Closed issues:**
 
 - Can't start version 0.19.0-beta.1 [\#400](https://github.com/ory/oathkeeper/issues/400)
@@ -95,6 +99,7 @@
 
 **Merged pull requests:**
 
+- Add new remote authorizer that uses request body and headers [\#416](https://github.com/ory/oathkeeper/pull/416) ([Marlinc](https://github.com/Marlinc))
 - ci: adopt new goreleaser pipeline [\#415](https://github.com/ory/oathkeeper/pull/415) ([aeneasr](https://github.com/aeneasr))
 - docs: update linux install guide [\#414](https://github.com/ory/oathkeeper/pull/414) ([aeneasr](https://github.com/aeneasr))
 - docs: update github templates [\#413](https://github.com/ory/oathkeeper/pull/413) ([aeneasr](https://github.com/aeneasr))
@@ -330,7 +335,6 @@
 **Fixed bugs:**
 
 - Missing Content-type [\#289](https://github.com/ory/oathkeeper/issues/289)
-- Should not fatal when rule configmap changes [\#229](https://github.com/ory/oathkeeper/issues/229)
 
 **Closed issues:**
 
@@ -388,6 +392,7 @@
 
 - Client Credentials Authenticators not compatible with Hydra? [\#260](https://github.com/ory/oathkeeper/issues/260)
 - "jwt" authenticator returns 403 instead of 401 [\#256](https://github.com/ory/oathkeeper/issues/256)
+- Should not fatal when rule configmap changes [\#229](https://github.com/ory/oathkeeper/issues/229)
 
 **Closed issues:**
 
@@ -682,7 +687,6 @@
 - Resolve various issues [\#99](https://github.com/ory/oathkeeper/pull/99) ([aeneasr](https://github.com/aeneasr))
 - Node sdk [\#94](https://github.com/ory/oathkeeper/pull/94) ([aeneasr](https://github.com/aeneasr))
 - judge: Add endpoint for answering access requests directly [\#91](https://github.com/ory/oathkeeper/pull/91) ([aeneasr](https://github.com/aeneasr))
-- health: Introduce health and version endpoint [\#90](https://github.com/ory/oathkeeper/pull/90) ([aeneasr](https://github.com/aeneasr))
 
 ## [v0.13.7+oryOS.7](https://github.com/ory/oathkeeper/tree/v0.13.7+oryOS.7) (2018-11-14)
 
@@ -690,6 +694,7 @@
 
 **Merged pull requests:**
 
+- health: Introduce health and version endpoint [\#90](https://github.com/ory/oathkeeper/pull/90) ([aeneasr](https://github.com/aeneasr))
 - docs: fix broken link [\#87](https://github.com/ory/oathkeeper/pull/87) ([orisano](https://github.com/orisano))
 - README: grammatical fix in stability sentence [\#86](https://github.com/ory/oathkeeper/pull/86) ([philips](https://github.com/philips))
 
@@ -857,6 +862,10 @@
 - Document HYDRA\_JWK\_SET\_ID [\#34](https://github.com/ory/oathkeeper/issues/34)
 - Investigate if the issuer should be oathkeeper or hydra [\#27](https://github.com/ory/oathkeeper/issues/27)
 
+**Merged pull requests:**
+
+- Telemetry [\#36](https://github.com/ory/oathkeeper/pull/36) ([aeneasr](https://github.com/aeneasr))
+
 ## [v0.0.23](https://github.com/ory/oathkeeper/tree/v0.0.23) (2017-11-24)
 
 [Full Changelog](https://github.com/ory/oathkeeper/compare/v0.0.22...v0.0.23)
@@ -868,7 +877,6 @@
 
 **Merged pull requests:**
 
-- Telemetry [\#36](https://github.com/ory/oathkeeper/pull/36) ([aeneasr](https://github.com/aeneasr))
 - Print formatted output string in rule management CLI [\#35](https://github.com/ory/oathkeeper/pull/35) ([aeneasr](https://github.com/aeneasr))
 - docs: Add JWK set docs [\#33](https://github.com/ory/oathkeeper/pull/33) ([aeneasr](https://github.com/aeneasr))
 - Update docs and add tests [\#32](https://github.com/ory/oathkeeper/pull/32) ([aeneasr](https://github.com/aeneasr))
@@ -888,6 +896,7 @@
 **Merged pull requests:**
 
 - Request hydra.keys scope and fix panic [\#30](https://github.com/ory/oathkeeper/pull/30) ([aeneasr](https://github.com/aeneasr))
+- Replace MatchesPath with MatchesURL [\#20](https://github.com/ory/oathkeeper/pull/20) ([aeneasr](https://github.com/aeneasr))
 
 ## [v0.0.20](https://github.com/ory/oathkeeper/tree/v0.0.20) (2017-11-18)
 
@@ -896,6 +905,7 @@
 **Merged pull requests:**
 
 - docs: Improve swagger documentation [\#28](https://github.com/ory/oathkeeper/pull/28) ([aeneasr](https://github.com/aeneasr))
+- cmd: Add rules management capabilities to the cli [\#26](https://github.com/ory/oathkeeper/pull/26) ([aeneasr](https://github.com/aeneasr))
 - unstaged [\#25](https://github.com/ory/oathkeeper/pull/25) ([aeneasr](https://github.com/aeneasr))
 
 ## [v0.0.19](https://github.com/ory/oathkeeper/tree/v0.0.19) (2017-11-13)
@@ -905,6 +915,10 @@
 **Closed issues:**
 
 - evaluator: token\[:5\] will cause panic [\#22](https://github.com/ory/oathkeeper/issues/22)
+
+**Merged pull requests:**
+
+- evaluator: Use full request URL [\#24](https://github.com/ory/oathkeeper/pull/24) ([aeneasr](https://github.com/aeneasr))
 
 ## [v0.0.18](https://github.com/ory/oathkeeper/tree/v0.0.18) (2017-11-13)
 
@@ -926,10 +940,6 @@
 
 [Full Changelog](https://github.com/ory/oathkeeper/compare/v0.0.15...v0.0.16)
 
-**Merged pull requests:**
-
-- Replace MatchesPath with MatchesURL [\#20](https://github.com/ory/oathkeeper/pull/20) ([aeneasr](https://github.com/aeneasr))
-
 ## [v0.0.15](https://github.com/ory/oathkeeper/tree/v0.0.15) (2017-11-09)
 
 [Full Changelog](https://github.com/ory/oathkeeper/compare/v0.0.14...v0.0.15)
@@ -944,7 +954,6 @@
 
 **Merged pull requests:**
 
-- evaluator: Use full request URL [\#24](https://github.com/ory/oathkeeper/pull/24) ([aeneasr](https://github.com/aeneasr))
 - Make refresh\_delay configurable and skip it on boot [\#18](https://github.com/ory/oathkeeper/pull/18) ([aeneasr](https://github.com/aeneasr))
 
 ## [v0.0.13](https://github.com/ory/oathkeeper/tree/v0.0.13) (2017-11-07)
@@ -953,12 +962,15 @@
 
 **Merged pull requests:**
 
-- cmd: Add rules management capabilities to the cli [\#26](https://github.com/ory/oathkeeper/pull/26) ([aeneasr](https://github.com/aeneasr))
 - Store rules path match in plaintext [\#17](https://github.com/ory/oathkeeper/pull/17) ([aeneasr](https://github.com/aeneasr))
 
 ## [v0.0.12](https://github.com/ory/oathkeeper/tree/v0.0.12) (2017-11-07)
 
 [Full Changelog](https://github.com/ory/oathkeeper/compare/v0.0.11...v0.0.12)
+
+**Merged pull requests:**
+
+- Use ladon regex compiler for matches [\#16](https://github.com/ory/oathkeeper/pull/16) ([aeneasr](https://github.com/aeneasr))
 
 ## [v0.0.11](https://github.com/ory/oathkeeper/tree/v0.0.11) (2017-11-06)
 
@@ -987,6 +999,7 @@
 **Merged pull requests:**
 
 - Build oathekeeper docker image statically [\#14](https://github.com/ory/oathkeeper/pull/14) ([aeneasr](https://github.com/aeneasr))
+- Use circle ci build status badge [\#9](https://github.com/ory/oathkeeper/pull/9) ([aeneasr](https://github.com/aeneasr))
 
 ## [v0.0.6](https://github.com/ory/oathkeeper/tree/v0.0.6) (2017-11-03)
 
@@ -1002,10 +1015,8 @@
 
 **Merged pull requests:**
 
-- Use ladon regex compiler for matches [\#16](https://github.com/ory/oathkeeper/pull/16) ([aeneasr](https://github.com/aeneasr))
 - Add cors handling to proxy [\#11](https://github.com/ory/oathkeeper/pull/11) ([aeneasr](https://github.com/aeneasr))
 - Remove goveralls from circle build [\#10](https://github.com/ory/oathkeeper/pull/10) ([aeneasr](https://github.com/aeneasr))
-- Use circle ci build status badge [\#9](https://github.com/ory/oathkeeper/pull/9) ([aeneasr](https://github.com/aeneasr))
 - Switch from glide to golang/dep for vendoring [\#8](https://github.com/ory/oathkeeper/pull/8) ([aeneasr](https://github.com/aeneasr))
 - Resolve tests by replacing nil slice [\#7](https://github.com/ory/oathkeeper/pull/7) ([aeneasr](https://github.com/aeneasr))
 

--- a/driver/configuration/provider_viper_public_test.go
+++ b/driver/configuration/provider_viper_public_test.go
@@ -52,7 +52,7 @@ func TestPipelineConfig(t *testing.T) {
 		p := setup(t)
 
 		require.NoError(t, p.PipelineConfig("authenticators", "oauth2_introspection", nil, &res))
-		assert.JSONEq(t, `{"introspection_url":"https://override/path","pre_authorization":{"client_id":"some_id","client_secret":"some_secret","enabled":true,"scope":["foo","bar"],"token_url":"https://my-website.com/oauth2/token"},"retry":{"max_delay":"100ms", "give_up_after":"1s"},"scope_strategy":"exact"}`, string(res), "%s", res)
+		assert.JSONEq(t, `{"cache":{"enabled":false},"introspection_url":"https://override/path","pre_authorization":{"client_id":"some_id","client_secret":"some_secret","enabled":true,"scope":["foo","bar"],"token_url":"https://my-website.com/oauth2/token"},"retry":{"max_delay":"100ms", "give_up_after":"1s"},"scope_strategy":"exact"}`, string(res), "%s", res)
 
 		// Cleanup
 		require.NoError(t, os.Setenv("AUTHENTICATORS_OAUTH2_INTROSPECTION_CONFIG_INTROSPECTION_URL", ""))

--- a/go.sum
+++ b/go.sum
@@ -897,6 +897,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.1.1/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgraph-io/ristretto"
+
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/clientcredentials"
 
@@ -30,6 +32,7 @@ type AuthenticatorOAuth2IntrospectionConfiguration struct {
 	BearerTokenLocation         *helper.BearerTokenLocation                           `json:"token_from"`
 	IntrospectionRequestHeaders map[string]string                                     `json:"introspection_request_headers"`
 	Retry                       *AuthenticatorOAuth2IntrospectionRetryConfiguration   `json:"retry"`
+	Cache                       cacheConfig                                           `json:"cache"`
 }
 
 type AuthenticatorOAuth2IntrospectionPreAuthConfiguration struct {
@@ -45,16 +48,31 @@ type AuthenticatorOAuth2IntrospectionRetryConfiguration struct {
 	MaxWait string `json:"give_up_after"`
 }
 
+type cacheConfig struct {
+	Enabled bool   `json:"enabled"`
+	TTL     string `json:"ttl"`
+}
+
 type AuthenticatorOAuth2Introspection struct {
 	c configuration.Provider
 
 	client *http.Client
+
+	tokenCache *ristretto.Cache
+	cacheTTL   *time.Duration
 }
 
 func NewAuthenticatorOAuth2Introspection(c configuration.Provider) *AuthenticatorOAuth2Introspection {
 	var rt http.RoundTripper
-
-	return &AuthenticatorOAuth2Introspection{c: c, client: httpx.NewResilientClientLatencyToleranceSmall(rt)}
+	cache, _ := ristretto.NewCache(&ristretto.Config{
+		// This will hold about 1000 unique mutation responses.
+		NumCounters: 10000,
+		// Allocate a max of 32MB
+		MaxCost: 1 << 25,
+		// This is a best-practice value.
+		BufferItems: 64,
+	})
+	return &AuthenticatorOAuth2Introspection{c: c, client: httpx.NewResilientClientLatencyToleranceSmall(rt), tokenCache: cache}
 }
 
 func (a *AuthenticatorOAuth2Introspection) GetID() string {
@@ -71,10 +89,42 @@ type AuthenticatorOAuth2IntrospectionResult struct {
 	Issuer    string                 `json:"iss"`
 	ClientID  string                 `json:"client_id,omitempty"`
 	Scope     string                 `json:"scope,omitempty"`
+	Expires   int64                  `json:"exp"`
+}
+
+func (a *AuthenticatorOAuth2Introspection) tokenFromCache(config *AuthenticatorOAuth2IntrospectionConfiguration, token string) (*AuthenticatorOAuth2IntrospectionResult, bool) {
+	if !config.Cache.Enabled {
+		return nil, false
+	}
+
+	item, found := a.tokenCache.Get(token)
+	if !found {
+		return nil, false
+	}
+
+	i := item.(*AuthenticatorOAuth2IntrospectionResult)
+	expires := time.Unix(i.Expires, 0)
+	if expires.Before(time.Now()) {
+		a.tokenCache.Del(token)
+		return nil, false
+	}
+
+	return i, true
+}
+
+func (a *AuthenticatorOAuth2Introspection) tokenToCache(config *AuthenticatorOAuth2IntrospectionConfiguration, i AuthenticatorOAuth2IntrospectionResult, token string) {
+	if !config.Cache.Enabled {
+		return
+	}
+
+	if a.cacheTTL != nil {
+		a.tokenCache.SetWithTTL(token, &i, 0, *a.cacheTTL)
+	} else {
+		a.tokenCache.Set(token, &i, 0)
+	}
 }
 
 func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
-	var i AuthenticatorOAuth2IntrospectionResult
 	cf, err := a.Config(config)
 	if err != nil {
 		return err
@@ -85,34 +135,41 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session
 		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
-	body := url.Values{"token": {token}}
-
 	ss := a.c.ToScopeStrategy(cf.ScopeStrategy, "authenticators.oauth2_introspection.scope_strategy")
-	if ss == nil {
-		body.Add("scope", strings.Join(cf.Scopes, " "))
-	}
 
-	introspectReq, err := http.NewRequest(http.MethodPost, cf.IntrospectionURL, strings.NewReader(body.Encode()))
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	for key, value := range cf.IntrospectionRequestHeaders {
-		introspectReq.Header.Set(key, value)
-	}
-	// set/override the content-type header
-	introspectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := a.client.Do(introspectReq)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	defer resp.Body.Close()
+	i, ok := a.tokenFromCache(cf, token)
 
-	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("Introspection returned status code %d but expected %d", resp.StatusCode, http.StatusOK)
-	}
+	if !ok {
+		body := url.Values{"token": {token}}
 
-	if err := json.NewDecoder(resp.Body).Decode(&i); err != nil {
-		return errors.WithStack(err)
+		if ss == nil {
+			body.Add("scope", strings.Join(cf.Scopes, " "))
+		}
+
+		introspectReq, err := http.NewRequest(http.MethodPost, cf.IntrospectionURL, strings.NewReader(body.Encode()))
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		for key, value := range cf.IntrospectionRequestHeaders {
+			introspectReq.Header.Set(key, value)
+		}
+		// set/override the content-type header
+		introspectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := a.client.Do(introspectReq)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return errors.Errorf("Introspection returned status code %d but expected %d", resp.StatusCode, http.StatusOK)
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&i); err != nil {
+			return errors.WithStack(err)
+		}
+
+		a.tokenToCache(cf, *i, token)
 	}
 
 	if len(i.TokenType) > 0 && i.TokenType != "access_token" {
@@ -205,6 +262,14 @@ func (a *AuthenticatorOAuth2Introspection) Config(config json.RawMessage) (*Auth
 	}
 
 	a.client = httpx.NewResilientClientLatencyToleranceConfigurable(rt, timeout, maxWait)
+
+	if c.Cache.TTL != "" {
+		cacheTTL, err := time.ParseDuration(c.Cache.TTL)
+		if err != nil {
+			return nil, err
+		}
+		a.cacheTTL = &cacheTTL
+	}
 
 	return &c, nil
 }


### PR DESCRIPTION
## Related issue

#293 

## Proposed changes

Adds ability to cache incoming oauth tokens in the introspector. By default will use the expires time from the token introspect endpoint to determine when to evict, or can override with a set TTL.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
