### PR TITLE
fix: use pipe to pass body remote authorizer

### DIFF
--- a/pipeline/authz/remote_test.go
+++ b/pipeline/authz/remote_test.go
@@ -1,7 +1,6 @@
 package authz_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -72,6 +71,21 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "nobody",
+			setup: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assert.Contains(t, r.Header, "Content-Type")
+					assert.Contains(t, r.Header["Content-Type"], "text/plain")
+					body, err := ioutil.ReadAll(r.Body)
+					require.NoError(t, err)
+					assert.Equal(t, "", string(body))
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			body:   "",
+			config: json.RawMessage(`{}`),
+		},
+		{
 			name: "ok",
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -92,11 +106,11 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					body, err := ioutil.ReadAll(r.Body)
 					require.NoError(t, err)
-					assert.Equal(t, bytes.Repeat([]byte("1"), 1024*1024*50), body)
+					assert.True(t, strings.Repeat("1", 1024*1024) == string(body))
 					w.WriteHeader(http.StatusOK)
 				}))
 			},
-			body:   strings.Repeat("1", 1024*1024*50),
+			body:   strings.Repeat("1", 1024*1024),
 			config: json.RawMessage(`{}`),
 		},
 		{

--- a/pipeline/authz/utils.go
+++ b/pipeline/authz/utils.go
@@ -13,7 +13,11 @@ func pipeRequestBody(r *http.Request, w io.Writer) error {
 	}
 
 	var body bytes.Buffer
+	defer r.Body.Close()
 	_, err := io.Copy(w, io.TeeReader(r.Body, &body))
+	if err != nil {
+		return err
+	}
 	r.Body = ioutil.NopCloser(&body)
 	return err
 }


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

The big request test introduced in #416 appears to be flaky and fails every so often. I've made some changes to it and have also changed the piping to use a pipe to pass the original request to the `remote` authorizer. Instead of creating two in memory buffers.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
