### PR TITLE
fix: Move Prometheus validation stanza to local schema

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -1062,6 +1062,35 @@
               "$ref": "#/definitions/tlsx"
             }
           }
+        },
+        "prometheus": {
+          "type": "object",
+          "title": "Prometheus scraping endpoint",
+          "additionalProperties": false,
+          "properties": {
+            "port": {
+              "type": "integer",
+              "default": 9000,
+              "title": "Port",
+              "description": "The port to listen on."
+            },
+            "host": {
+              "type": "string",
+              "default": "",
+              "examples": [
+                "localhost",
+                "127.0.0.1"
+              ],
+              "title": "Host",
+              "description": "The network interface to listen on. Leave empty to listen on all interfaces."
+            },
+            "metrics_path": {
+              "type": "string",
+              "default": "/metrics",
+              "title": "Path",
+              "description": "The path to provide metrics on"
+            }
+          }
         }
       }
     },

--- a/driver/configuration/provider_viper_public_test.go
+++ b/driver/configuration/provider_viper_public_test.go
@@ -183,6 +183,11 @@ func TestViperProvider(t *testing.T) {
 		assert.Equal(t, "127.0.0.1:1234", p.ProxyServeAddress())
 		assert.Equal(t, "127.0.0.2:1235", p.APIServeAddress())
 
+		t.Run("group=prometheus", func(t *testing.T) {
+			assert.Equal(t, "localhost:9000", p.PrometheusServeAddress())
+			assert.Equal(t, "/metrics", p.PrometheusMetricsPath())
+		})
+
 		t.Run("group=cors", func(t *testing.T) {
 			assert.True(t, p.CORSEnabled("proxy"))
 			assert.True(t, p.CORSEnabled("api"))

--- a/internal/config/.oathkeeper.yaml
+++ b/internal/config/.oathkeeper.yaml
@@ -73,6 +73,11 @@ serve:
         path: /path/to/cert.pem
         base64: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlEWlRDQ0FrMmdBd0lCQWdJRVY1eE90REFOQmdr...
 
+  prometheus:
+    port: 9000
+    host: localhost
+    metrics_path: /metrics
+
 # Configures Access Rules
 access_rules:
   # Locations (list of URLs) where access rules should be fetched from on boot.


### PR DESCRIPTION
## Related issue

[Prometheus endpoint cannot be validated by local json schema](https://github.com/ory/oathkeeper/issues/438)

### Gist of the issue

The current [v0.38.0-beta.2](https://github.com/claudio-benfatto/oathkeeper/releases/tag/v0.38.0-beta.2) release has introduced prometheus metrics and the following configuration stanza:

```
serve:
  prometheus:
    port: 9000
    host: localhost
    metrics_path: /metrics
```
however the local [config.schema.json](https://github.com/ory/oathkeeper/blob/master/.schema/config.schema.json) does not contain it.
This is also the schema that is loaded on startup [root.go](https://github.com/ory/oathkeeper/blob/master/cmd/root.go#L39) which causes the command to fail with a validation error:

```
INFO[0000] Config file loaded successfully.              path=/etc/auth-oathkeeper/templates/oathkeeper.yaml
FATA[0000] The configuration is invalid and could not be loaded.  [config_key=serve]="additionalProperties \"prometheus\" not allowed" config_file=/etc/auth-oathkeeper/templates/oathkeeper.yaml
```

## Proposed changes

The proposed change is to add the prometheus validation to the local schema

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

I tested the compiled binary against an example configuration containing the prometheus stanza and everything works correctly 
