### PR TITLE
feat: Enable configuration of timeout settings for oauth2_client_credentials authoriser

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -507,6 +507,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "retry": {
+          "$ref": "#/definitions/retry"
         }
       },
       "required": [

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -507,6 +507,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "retry": {
+          "$ref": "#/definitions/retry"
         }
       },
       "required": [

--- a/docs/docs/pipeline/authn.md
+++ b/docs/docs/pipeline/authn.md
@@ -345,6 +345,10 @@ header as the subject for this request.
 
 - `token_url` (string, required) - The OAuth 2.0 Token Endpoint that will be
   used to validate the client credentials.
+- `retry` (object, optional) - Configures timeout and delay settings for the
+  request against the token endpoint
+  - `give_up_after` (string) timeout
+  - `max_delay` (string) time to wait between retries
 - `required_scope` ([]string, optional) - Sets what scope is required by the URL
   and when making performing OAuth 2.0 Client Credentials request, the scope
   will be included in the request:

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -3,6 +3,8 @@ title: REST API
 id: api
 ---
 
+
+
 ORY Oathkeeper is a reverse proxy that checks the HTTP Authorization for
 validity against a set of rules. This service uses Hydra to validate access
 tokens and policies.

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -7,32 +7,31 @@ title: Configuration
 OPEN AN ISSUE IF YOU WOULD LIKE TO MAKE ADJUSTMENTS HERE AND MAINTAINERS WILL HELP YOU LOCATE THE RIGHT
 FILE -->
 
-If file `$HOME/.oathkeeper.yaml` exists, it will be used as a configuration file
-which supports all configuration settings listed below.
+If file `$HOME/.oathkeeper.yaml` exists, it will be used as a configuration file which supports all
+configuration settings listed below.
 
-You can load the config file from another source using the
-`-c path/to/config.yaml` or `--config path/to/config.yaml` flag:
-`oathkeeper --config path/to/config.yaml`.
+You can load the config file from another source using the `-c path/to/config.yaml` or `--config path/to/config.yaml`
+flag: `oathkeeper --config path/to/config.yaml`.
 
-Config files can be formatted as JSON, YAML and TOML. Some configuration values
-support reloading without server restart. All configuration values can be set
-using environment variables, as documented below.
+Config files can be formatted as JSON, YAML and TOML. Some configuration values support reloading without server restart.
+All configuration values can be set using environment variables, as documented below.
 
-To find out more about edge cases like setting string array values through
-environmental variables head to the
-[Configuring ORY services](https://www.ory.sh/docs/ecosystem/configuring)
-section.
+To find out more about edge cases like setting string array values through environmental variables head to the
+[Configuring ORY services](https://www.ory.sh/docs/ecosystem/configuring) section.
 
 ```yaml
 ## ORY Oathkeeper Configuration
 #
 
+
 ## HTTP(s) ##
 #
 serve:
+  
   ## HTTP REST API ##
   #
   api:
+    
     ## Port ##
     #
     # The port to listen on.
@@ -45,7 +44,7 @@ serve:
     # - Windows Command Line (CMD):
     #    > set SERVE_API_PORT=<value>
     #
-    port: 9067868
+    port: -99148303
 
     ## Host ##
     #
@@ -54,20 +53,21 @@ serve:
     # Examples:
     # - localhost
     # - 127.0.0.1
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export SERVE_API_HOST=<value>
     # - Windows Command Line (CMD):
     #    > set SERVE_API_HOST=<value>
     #
-    host: 127.0.0.1
+    host: localhost
 
     ## Cross Origin Resource Sharing (CORS) ##
     #
     # Configure [Cross Origin Resource Sharing (CORS)](http://www.w3.org/TR/cors/) using the following options.
     #
     cors:
+      
       ## Enable CORS ##
       #
       # If set to true, CORS will be enabled and preflight-requests (OPTION) will be answered.
@@ -80,7 +80,7 @@ serve:
       # - Windows Command Line (CMD):
       #    > set SERVE_API_CORS_ENABLED=<value>
       #
-      enabled: false
+      enabled: true
 
       ## Allowed Origins ##
       #
@@ -92,7 +92,7 @@ serve:
       # - - https://example.com
       #   - https://*.example.com
       #   - https://*.foo.example.com
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SERVE_API_CORS_ALLOWED_ORIGINS=<value>
@@ -100,9 +100,7 @@ serve:
       #    > set SERVE_API_CORS_ALLOWED_ORIGINS=<value>
       #
       allowed_origins:
-        - https://example.com
-        - https://*.example.com
-        - https://*.foo.example.com
+        - "*"
 
       ## Allowed HTTP Methods ##
       #
@@ -117,10 +115,10 @@ serve:
       #    > set SERVE_API_CORS_ALLOWED_METHODS=<value>
       #
       allowed_methods:
-        - HEAD
+        - CONNECT
         - TRACE
-        - GET
         - DELETE
+        - PUT
 
       ## Allowed Request HTTP Headers ##
       #
@@ -135,7 +133,7 @@ serve:
       #    > set SERVE_API_CORS_ALLOWED_HEADERS=<value>
       #
       allowed_headers:
-        - et sit
+        - Ut est in
 
       ## Allowed Response HTTP Headers ##
       #
@@ -150,10 +148,7 @@ serve:
       #    > set SERVE_API_CORS_EXPOSED_HEADERS=<value>
       #
       exposed_headers:
-        - irure ex ipsum
-        - enim
-        - elit
-        - dolor labore ipsum cupidatat
+        - pariatur sunt
 
       ## Allow HTTP Credentials ##
       #
@@ -179,7 +174,7 @@ serve:
       # - Windows Command Line (CMD):
       #    > set SERVE_API_CORS_MAX_AGE=<value>
       #
-      max_age: -92921695
+      max_age: -82494510
 
       ## Enable Debugging ##
       #
@@ -200,9 +195,11 @@ serve:
     # Configure HTTP over TLS (HTTPS). All options can also be set using environment variables by replacing dots (`.`) with underscores (`_`) and uppercasing the key. For example, `some.prefix.tls.key.path` becomes `export SOME_PREFIX_TLS_KEY_PATH`. If all keys are left undefined, TLS will be disabled.
     #
     tls:
+      
       ## Private Key (PEM) ##
       #
       key:
+        
         ## path ##
         #
         # Set this value using environment variables on
@@ -226,6 +223,7 @@ serve:
       ## TLS Certificate (PEM) ##
       #
       cert:
+        
         ## path ##
         #
         # Set this value using environment variables on
@@ -249,6 +247,7 @@ serve:
   ## HTTP Reverse Proxy ##
   #
   proxy:
+    
     ## Port ##
     #
     # The port to listen on.
@@ -261,7 +260,7 @@ serve:
     # - Windows Command Line (CMD):
     #    > set SERVE_PROXY_PORT=<value>
     #
-    port: 55486131
+    port: 3288338
 
     ## Host ##
     #
@@ -270,20 +269,21 @@ serve:
     # Examples:
     # - localhost
     # - 127.0.0.1
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export SERVE_PROXY_HOST=<value>
     # - Windows Command Line (CMD):
     #    > set SERVE_PROXY_HOST=<value>
     #
-    host: ''
+    host: ""
 
     ## HTTP Timeouts ##
     #
     # Control the reverse proxy's HTTP timeouts.
     #
     timeout:
+      
       ## HTTP Read Timeout ##
       #
       # The maximum duration for reading the entire request, including the body.
@@ -294,7 +294,7 @@ serve:
       # - 5s
       # - 5m
       # - 5h
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SERVE_PROXY_TIMEOUT_READ=<value>
@@ -313,14 +313,14 @@ serve:
       # - 5s
       # - 5m
       # - 5h
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SERVE_PROXY_TIMEOUT_WRITE=<value>
       # - Windows Command Line (CMD):
       #    > set SERVE_PROXY_TIMEOUT_WRITE=<value>
       #
-      write: 5h
+      write: 120s
 
       ## HTTP Idle Timeout ##
       #
@@ -332,7 +332,7 @@ serve:
       # - 5s
       # - 5m
       # - 5h
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SERVE_PROXY_TIMEOUT_IDLE=<value>
@@ -346,6 +346,7 @@ serve:
     # Configure [Cross Origin Resource Sharing (CORS)](http://www.w3.org/TR/cors/) using the following options.
     #
     cors:
+      
       ## Enable CORS ##
       #
       # If set to true, CORS will be enabled and preflight-requests (OPTION) will be answered.
@@ -358,7 +359,7 @@ serve:
       # - Windows Command Line (CMD):
       #    > set SERVE_PROXY_CORS_ENABLED=<value>
       #
-      enabled: true
+      enabled: false
 
       ## Allowed Origins ##
       #
@@ -370,7 +371,7 @@ serve:
       # - - https://example.com
       #   - https://*.example.com
       #   - https://*.foo.example.com
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export SERVE_PROXY_CORS_ALLOWED_ORIGINS=<value>
@@ -378,9 +379,7 @@ serve:
       #    > set SERVE_PROXY_CORS_ALLOWED_ORIGINS=<value>
       #
       allowed_origins:
-        - https://example.com
-        - https://*.example.com
-        - https://*.foo.example.com
+        - "*"
 
       ## Allowed HTTP Methods ##
       #
@@ -396,6 +395,10 @@ serve:
       #
       allowed_methods:
         - TRACE
+        - HEAD
+        - CONNECT
+        - PUT
+        - GET
 
       ## Allowed Request HTTP Headers ##
       #
@@ -410,10 +413,10 @@ serve:
       #    > set SERVE_PROXY_CORS_ALLOWED_HEADERS=<value>
       #
       allowed_headers:
-        - reprehenderit do qui
-        - non nostrud quis minim
-        - elit ipsum velit ex
-        - fugiat nulla sunt dolore velit
+        - aliquip minim consectetur
+        - dolore sed fugiat Excepteur
+        - voluptate dolore ipsum aliqua
+        - tempor sit id magna officia
 
       ## Allowed Response HTTP Headers ##
       #
@@ -428,7 +431,11 @@ serve:
       #    > set SERVE_PROXY_CORS_EXPOSED_HEADERS=<value>
       #
       exposed_headers:
-        - adipisicing
+        - do consectetur esse est ut
+        - consequat minim fugiat in aute
+        - do dolor ullamco
+        - exercitation consequat irure amet culpa
+        - Ut elit proident
 
       ## Allow HTTP Credentials ##
       #
@@ -442,7 +449,7 @@ serve:
       # - Windows Command Line (CMD):
       #    > set SERVE_PROXY_CORS_ALLOW_CREDENTIALS=<value>
       #
-      allow_credentials: true
+      allow_credentials: false
 
       ## Maximum Age ##
       #
@@ -454,7 +461,7 @@ serve:
       # - Windows Command Line (CMD):
       #    > set SERVE_PROXY_CORS_MAX_AGE=<value>
       #
-      max_age: -33742573
+      max_age: 78336247
 
       ## Enable Debugging ##
       #
@@ -475,9 +482,11 @@ serve:
     # Configure HTTP over TLS (HTTPS). All options can also be set using environment variables by replacing dots (`.`) with underscores (`_`) and uppercasing the key. For example, `some.prefix.tls.key.path` becomes `export SOME_PREFIX_TLS_KEY_PATH`. If all keys are left undefined, TLS will be disabled.
     #
     tls:
+      
       ## Private Key (PEM) ##
       #
       key:
+        
         ## path ##
         #
         # Set this value using environment variables on
@@ -501,6 +510,7 @@ serve:
       ## TLS Certificate (PEM) ##
       #
       cert:
+        
         ## path ##
         #
         # Set this value using environment variables on
@@ -521,15 +531,64 @@ serve:
         #
         base64: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlEWlRDQ0FrMmdBd0lCQWdJRVY1eE90REFOQmdr...
 
+  ## Prometheus scraping endpoint ##
+  #
+  prometheus:
+    
+    ## Port ##
+    #
+    # The port to listen on.
+    #
+    # Default value: 9000
+    #
+    # Set this value using environment variables on
+    # - Linux/macOS:
+    #    $ export SERVE_PROMETHEUS_PORT=<value>
+    # - Windows Command Line (CMD):
+    #    > set SERVE_PROMETHEUS_PORT=<value>
+    #
+    port: -80084652
+
+    ## Host ##
+    #
+    # The network interface to listen on. Leave empty to listen on all interfaces.
+    #
+    # Examples:
+    # - localhost
+    # - 127.0.0.1
+    # 
+    # Set this value using environment variables on
+    # - Linux/macOS:
+    #    $ export SERVE_PROMETHEUS_HOST=<value>
+    # - Windows Command Line (CMD):
+    #    > set SERVE_PROMETHEUS_HOST=<value>
+    #
+    host: ""
+
+    ## Path ##
+    #
+    # The path to provide metrics on
+    #
+    # Default value: /metrics
+    #
+    # Set this value using environment variables on
+    # - Linux/macOS:
+    #    $ export SERVE_PROMETHEUS_METRICS_PATH=<value>
+    # - Windows Command Line (CMD):
+    #    > set SERVE_PROMETHEUS_METRICS_PATH=<value>
+    #
+    metrics_path: sed nisi magna esse consectetur
+
 ## Access Rules ##
 #
 # Configure access rules. All sub-keys support configuration reloading without restarting.
 #
 access_rules:
+  
   ## Repositories ##
   #
   # Locations (list of URLs) where access rules should be fetched from on boot. It is expected that the documents at those locations return a JSON or YAML Array containing ORY Oathkeeper Access Rules:
-  #
+  # 
   # - If the URL Scheme is `file://`, the access rules (an array of access rules is expected) will be fetched from the local file system.
   # - If the URL Scheme is `inline://`, the access rules (an array of access rules is expected) are expected to be a base64 encoded (with padding!) JSON/YAML string (base64_encode(`[{"id":"foo-rule","authenticators":[....]}]`)).
   # - If the URL Scheme is `http://` or `https://`, the access rules (an array of access rules is expected) will be fetched from the provided HTTP(s) location.
@@ -538,7 +597,7 @@ access_rules:
   # - - file://path/to/rules.json
   #   - inline://W3siaWQiOiJmb28tcnVsZSIsImF1dGhlbnRpY2F0b3JzIjpbXX1d
   #   - https://path-to-my-rules/rules.json
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export ACCESS_RULES_REPOSITORIES=<value>
@@ -558,7 +617,7 @@ access_rules:
   #
   # Examples:
   # - glob
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export ACCESS_RULES_MATCHING_STRATEGY=<value>
@@ -572,11 +631,13 @@ access_rules:
 # For more information on authenticators head over to: https://www.ory.sh/oathkeeper/docs/pipeline/authn
 #
 authenticators:
+  
   ## Anonymous ##
   #
   # The [`anonymous` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#anonymous).
   #
   anonymous:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -585,7 +646,7 @@ authenticators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHENTICATORS_ANONYMOUS_ENABLED=<value>
@@ -599,6 +660,7 @@ authenticators:
     # This section is optional when the authenticator is disabled.
     #
     config:
+      
       ## Anonymous Subject ##
       #
       # Sets the anonymous username.
@@ -609,20 +671,21 @@ authenticators:
       # - guest
       # - anon
       # - unknown
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export AUTHENTICATORS_ANONYMOUS_CONFIG_SUBJECT=<value>
       # - Windows Command Line (CMD):
       #    > set AUTHENTICATORS_ANONYMOUS_CONFIG_SUBJECT=<value>
       #
-      subject: anonymous
+      subject: unknown
 
   ## No Operation (noop) ##
   #
   # The [`noop` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#noop).
   #
   noop:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -631,7 +694,7 @@ authenticators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHENTICATORS_NOOP_ENABLED=<value>
@@ -645,6 +708,7 @@ authenticators:
   # The [`unauthorized` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#unauthorized).
   #
   unauthorized:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -653,7 +717,7 @@ authenticators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHENTICATORS_UNAUTHORIZED_ENABLED=<value>
@@ -667,6 +731,7 @@ authenticators:
   # The [`cookie_session` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#cookie_session).
   #
   cookie_session:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -675,20 +740,21 @@ authenticators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHENTICATORS_COOKIE_SESSION_ENABLED=<value>
     # - Windows Command Line (CMD):
     #    > set AUTHENTICATORS_COOKIE_SESSION_ENABLED=<value>
     #
-    enabled: true
+    enabled: false
 
   ## JSON Web Token (jwt) ##
   #
   # The [`jwt` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#jwt).
   #
   jwt:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -697,7 +763,7 @@ authenticators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHENTICATORS_JWT_ENABLED=<value>
@@ -711,30 +777,7 @@ authenticators:
   # The [`oauth2_client_credentials` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#oauth2_client_credentials).
   #
   oauth2_client_credentials:
-    ## config ##
-    #
-    config:
-      ## token_url ##
-      #
-      # Set this value using environment variables on
-      # - Linux/macOS:
-      #    $ export AUTHENTICATORS_OAUTH2_CLIENT_CREDENTIALS_CONFIG_TOKEN_URL=<value>
-      # - Windows Command Line (CMD):
-      #    > set AUTHENTICATORS_OAUTH2_CLIENT_CREDENTIALS_CONFIG_TOKEN_URL=<value>
-      #
-      token_url: https://my-website.com/oauth2/token
-
-      ## required_scope ##
-      #
-      # Set this value using environment variables on
-      # - Linux/macOS:
-      #    $ export AUTHENTICATORS_OAUTH2_CLIENT_CREDENTIALS_CONFIG_REQUIRED_SCOPE=<value>
-      # - Windows Command Line (CMD):
-      #    > set AUTHENTICATORS_OAUTH2_CLIENT_CREDENTIALS_CONFIG_REQUIRED_SCOPE=<value>
-      #
-      required_scope:
-        - in commodo reprehenderit Ut
-
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -743,20 +786,21 @@ authenticators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHENTICATORS_OAUTH2_CLIENT_CREDENTIALS_ENABLED=<value>
     # - Windows Command Line (CMD):
     #    > set AUTHENTICATORS_OAUTH2_CLIENT_CREDENTIALS_ENABLED=<value>
     #
-    enabled: true
+    enabled: false
 
   ## OAuth 2.0 Token Introspection ##
   #
   # The [`oauth2_introspection` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#oauth2_introspection).
   #
   oauth2_introspection:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -765,7 +809,7 @@ authenticators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHENTICATORS_OAUTH2_INTROSPECTION_ENABLED=<value>
@@ -777,6 +821,7 @@ authenticators:
 ## Error Handling ##
 #
 errors:
+  
   ## Error Handling Fallback ##
   #
   # This array defines how to handle errors when no "when" clause matches. If you have, for example, enabled redirect and json in your access rule, you could tell ORY Oathkeeper to try sending JSON if the request does not match the access rule definition
@@ -785,7 +830,7 @@ errors:
   #
   # Examples:
   # - - redirect
-  #
+  # 
   # Set this value using environment variables on
   # - Linux/macOS:
   #    $ export ERRORS_FALLBACK=<value>
@@ -793,73 +838,18 @@ errors:
   #    > set ERRORS_FALLBACK=<value>
   #
   fallback:
-    - redirect
+    - json
 
   ## Individual Error Handler Configuration ##
   #
   handlers:
+    
     ## HTTP WWW-Authenticate Handler ##
     #
     # Responds with the WWW-Authenticate HTTP Response
     #
     www_authenticate:
-      ## config ##
-      #
-      config:
-        ## realm ##
-        #
-        # Set this value using environment variables on
-        # - Linux/macOS:
-        #    $ export ERRORS_HANDLERS_WWW_AUTHENTICATE_CONFIG_REALM=<value>
-        # - Windows Command Line (CMD):
-        #    > set ERRORS_HANDLERS_WWW_AUTHENTICATE_CONFIG_REALM=<value>
-        #
-        realm: voluptate Lorem Ut
-
-        ## when ##
-        #
-        # Set this value using environment variables on
-        # - Linux/macOS:
-        #    $ export ERRORS_HANDLERS_WWW_AUTHENTICATE_CONFIG_WHEN=<value>
-        # - Windows Command Line (CMD):
-        #    > set ERRORS_HANDLERS_WWW_AUTHENTICATE_CONFIG_WHEN=<value>
-        #
-        when:
-          - error:
-              - forbidden
-              - not_found
-            request:
-              cidr:
-                - Ut voluptate tempor
-              header:
-                content_type: []
-                accept: []
-          - error:
-              - unauthorized
-              - internal_server_error
-              - unauthorized
-            request:
-              cidr:
-                - cupidatat consectetur
-                - nulla deserunt esse sed dolore
-                - sunt commodo
-                - tempor cupidatat
-                - adipisicing
-              header:
-                content_type: []
-                accept: []
-          - error:
-              - not_found
-              - internal_server_error
-            request:
-              cidr:
-                - ullamco
-                - aliqua
-                - incididunt Lorem
-              header:
-                content_type: []
-                accept: []
-
+      
       ## Enabled ##
       #
       # En-/disables this component.
@@ -868,20 +858,100 @@ errors:
       #
       # Examples:
       # - true
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export ERRORS_HANDLERS_WWW_AUTHENTICATE_ENABLED=<value>
       # - Windows Command Line (CMD):
       #    > set ERRORS_HANDLERS_WWW_AUTHENTICATE_ENABLED=<value>
       #
-      enabled: true
+      enabled: false
 
     ## HTTP Redirect Error Handler ##
     #
     # Responds with a 301/302 HTTP redirect.
     #
     redirect:
+      
+      ## config ##
+      #
+      config:
+        
+        ## to ##
+        #
+        # Set this value using environment variables on
+        # - Linux/macOS:
+        #    $ export ERRORS_HANDLERS_REDIRECT_CONFIG_TO=<value>
+        # - Windows Command Line (CMD):
+        #    > set ERRORS_HANDLERS_REDIRECT_CONFIG_TO=<value>
+        #
+        to: https://kJQMmMcbIwfgxuhFpvSqlCbpwpad.slvNW6nfMr8w7
+
+        ## code ##
+        #
+        # Set this value using environment variables on
+        # - Linux/macOS:
+        #    $ export ERRORS_HANDLERS_REDIRECT_CONFIG_CODE=<value>
+        # - Windows Command Line (CMD):
+        #    > set ERRORS_HANDLERS_REDIRECT_CONFIG_CODE=<value>
+        #
+        code: 301
+
+        ## when ##
+        #
+        # Set this value using environment variables on
+        # - Linux/macOS:
+        #    $ export ERRORS_HANDLERS_REDIRECT_CONFIG_WHEN=<value>
+        # - Windows Command Line (CMD):
+        #    > set ERRORS_HANDLERS_REDIRECT_CONFIG_WHEN=<value>
+        #
+        when:
+          - error:
+              - forbidden
+            request:
+              cidr:
+                - officia ullamco laboris
+                - fugiat non Duis
+                - ullamco consectetur occaecat veniam qui
+                - cupidatat tempor voluptate
+                - ad in elit
+              header:
+                content_type: []
+                accept: []
+          - error:
+              - forbidden
+              - forbidden
+              - forbidden
+            request:
+              cidr:
+                - ut id nostrud
+                - officia nulla cillum
+                - exercitation
+              header:
+                content_type: []
+                accept: []
+          - error:
+              - not_found
+              - unauthorized
+              - forbidden
+              - not_found
+            request:
+              cidr:
+                - sint
+              header:
+                content_type: []
+                accept: []
+          - error:
+              - forbidden
+              - internal_server_error
+            request:
+              cidr:
+                - do sit
+                - in ad et
+              header:
+                content_type: []
+                accept: []
+
       ## Enabled ##
       #
       # En-/disables this component.
@@ -890,7 +960,7 @@ errors:
       #
       # Examples:
       # - true
-      #
+      # 
       # Set this value using environment variables on
       # - Linux/macOS:
       #    $ export ERRORS_HANDLERS_REDIRECT_ENABLED=<value>
@@ -906,6 +976,63 @@ errors:
     # Default value: [object Object]
     #
     json:
+      
+      ## config ##
+      #
+      config:
+        
+        ## verbose ##
+        #
+        # Set this value using environment variables on
+        # - Linux/macOS:
+        #    $ export ERRORS_HANDLERS_JSON_CONFIG_VERBOSE=<value>
+        # - Windows Command Line (CMD):
+        #    > set ERRORS_HANDLERS_JSON_CONFIG_VERBOSE=<value>
+        #
+        verbose: true
+
+        ## when ##
+        #
+        # Set this value using environment variables on
+        # - Linux/macOS:
+        #    $ export ERRORS_HANDLERS_JSON_CONFIG_WHEN=<value>
+        # - Windows Command Line (CMD):
+        #    > set ERRORS_HANDLERS_JSON_CONFIG_WHEN=<value>
+        #
+        when:
+          - error:
+              - unauthorized
+            request:
+              cidr:
+                - labore eiusmod dolor exercitation
+                - in in id ut
+                - eiusmod in pariatur nulla fugiat
+              header:
+                content_type: []
+                accept: []
+          - error:
+              - unauthorized
+              - forbidden
+            request:
+              cidr:
+                - culpa elit in
+                - elit ad sunt
+                - voluptate aute exercitation fugiat
+              header:
+                content_type: []
+                accept: []
+          - error:
+              - internal_server_error
+              - internal_server_error
+              - not_found
+              - forbidden
+            request:
+              cidr:
+                - do adipisicing mollit
+              header:
+                content_type: []
+                accept: []
+
       ## Enabled ##
       #
       # En-/disables this component.
@@ -916,18 +1043,20 @@ errors:
       # - Windows Command Line (CMD):
       #    > set ERRORS_HANDLERS_JSON_ENABLED=<value>
       #
-      enabled: false
+      enabled: true
 
 ## Authorizers ##
 #
 # For more information on authorizers head over to: https://www.ory.sh/oathkeeper/docs/pipeline/authz
 #
 authorizers:
+  
   ## Allow ##
   #
   # The [`allow` authorizer](https://www.ory.sh/oathkeeper/docs/pipeline/authz#allow).
   #
   allow:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -936,20 +1065,21 @@ authorizers:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHORIZERS_ALLOW_ENABLED=<value>
     # - Windows Command Line (CMD):
     #    > set AUTHORIZERS_ALLOW_ENABLED=<value>
     #
-    enabled: false
+    enabled: true
 
   ## Deny ##
   #
   # The [`deny` authorizer](https://www.ory.sh/oathkeeper/docs/pipeline/authz#allow).
   #
   deny:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -958,20 +1088,75 @@ authorizers:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHORIZERS_DENY_ENABLED=<value>
     # - Windows Command Line (CMD):
     #    > set AUTHORIZERS_DENY_ENABLED=<value>
     #
-    enabled: true
+    enabled: false
 
   ## ORY Keto Access Control Policies Engine ##
   #
   # The [`keto_engine_acp_ory` authorizer](https://www.ory.sh/oathkeeper/docs/pipeline/authz#keto_engine_acp_ory).
   #
   keto_engine_acp_ory:
+    
+    ## config ##
+    #
+    config:
+      
+      ## base_url ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_BASE_URL=<value>
+      # - Windows Command Line (CMD):
+      #    > set AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_BASE_URL=<value>
+      #
+      base_url: http://my-keto/
+
+      ## required_action ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_REQUIRED_ACTION=<value>
+      # - Windows Command Line (CMD):
+      #    > set AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_REQUIRED_ACTION=<value>
+      #
+      required_action: in
+
+      ## required_resource ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_REQUIRED_RESOURCE=<value>
+      # - Windows Command Line (CMD):
+      #    > set AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_REQUIRED_RESOURCE=<value>
+      #
+      required_resource: in
+
+      ## subject ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_SUBJECT=<value>
+      # - Windows Command Line (CMD):
+      #    > set AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_SUBJECT=<value>
+      #
+      subject: proident minim occaecat quis
+
+      ## flavor ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_FLAVOR=<value>
+      # - Windows Command Line (CMD):
+      #    > set AUTHORIZERS_KETO_ENGINE_ACP_ORY_CONFIG_FLAVOR=<value>
+      #
+      flavor: nostrud laborum exercitation
+
     ## Enabled ##
     #
     # En-/disables this component.
@@ -980,7 +1165,7 @@ authorizers:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHORIZERS_KETO_ENGINE_ACP_ORY_ENABLED=<value>
@@ -994,19 +1179,7 @@ authorizers:
   # The [`remote` authorizer](https://www.ory.sh/oathkeeper/docs/pipeline/authz#remote).
   #
   remote:
-    ## config ##
-    #
-    config:
-      ## remote ##
-      #
-      # Set this value using environment variables on
-      # - Linux/macOS:
-      #    $ export AUTHORIZERS_REMOTE_CONFIG_REMOTE=<value>
-      # - Windows Command Line (CMD):
-      #    > set AUTHORIZERS_REMOTE_CONFIG_REMOTE=<value>
-      #
-      remote: https://host/path
-
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -1015,43 +1188,21 @@ authorizers:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHORIZERS_REMOTE_ENABLED=<value>
     # - Windows Command Line (CMD):
     #    > set AUTHORIZERS_REMOTE_ENABLED=<value>
     #
-    enabled: true
+    enabled: false
 
   ## Remote JSON ##
   #
   # The [`remote_json` authorizer](https://www.ory.sh/oathkeeper/docs/pipeline/authz#remote_json).
   #
   remote_json:
-    ## config ##
-    #
-    config:
-      ## remote ##
-      #
-      # Set this value using environment variables on
-      # - Linux/macOS:
-      #    $ export AUTHORIZERS_REMOTE_JSON_CONFIG_REMOTE=<value>
-      # - Windows Command Line (CMD):
-      #    > set AUTHORIZERS_REMOTE_JSON_CONFIG_REMOTE=<value>
-      #
-      remote: https://host/path
-
-      ## payload ##
-      #
-      # Set this value using environment variables on
-      # - Linux/macOS:
-      #    $ export AUTHORIZERS_REMOTE_JSON_CONFIG_PAYLOAD=<value>
-      # - Windows Command Line (CMD):
-      #    > set AUTHORIZERS_REMOTE_JSON_CONFIG_PAYLOAD=<value>
-      #
-      payload: '{"subject":"{{ .Subject }}"}'
-
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -1060,7 +1211,7 @@ authorizers:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export AUTHORIZERS_REMOTE_JSON_ENABLED=<value>
@@ -1074,11 +1225,13 @@ authorizers:
 # For more information on mutators head over to: https://www.ory.sh/oathkeeper/docs/pipeline/mutator
 #
 mutators:
+  
   ## No Operation (noop) ##
   #
   # The [`noop` mutator](https://www.ory.sh/oathkeeper/docs/pipeline/mutator#noop).
   #
   noop:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -1087,20 +1240,21 @@ mutators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export MUTATORS_NOOP_ENABLED=<value>
     # - Windows Command Line (CMD):
     #    > set MUTATORS_NOOP_ENABLED=<value>
     #
-    enabled: true
+    enabled: false
 
   ## HTTP Cookie ##
   #
   # The [`cookie` mutator](https://www.ory.sh/oathkeeper/docs/pipeline/mutator#cookie).
   #
   cookie:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -1109,20 +1263,21 @@ mutators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export MUTATORS_COOKIE_ENABLED=<value>
     # - Windows Command Line (CMD):
     #    > set MUTATORS_COOKIE_ENABLED=<value>
     #
-    enabled: false
+    enabled: true
 
   ## HTTP Header ##
   #
   # The [`header` mutator](https://www.ory.sh/oathkeeper/docs/pipeline/mutator#header).
   #
   header:
+    
     ## Enabled ##
     #
     # En-/disables this component.
@@ -1131,26 +1286,29 @@ mutators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export MUTATORS_HEADER_ENABLED=<value>
     # - Windows Command Line (CMD):
     #    > set MUTATORS_HEADER_ENABLED=<value>
     #
-    enabled: true
+    enabled: false
 
   ## Hydrator ##
   #
   # The [`hydrator` mutator](https://www.ory.sh/oathkeeper/docs/pipeline/mutator#hydrator).
   #
   hydrator:
+    
     ## config ##
     #
     config:
+      
       ## api ##
       #
       api:
+        
         ## url ##
         #
         # Set this value using environment variables on
@@ -1159,14 +1317,16 @@ mutators:
         # - Windows Command Line (CMD):
         #    > set MUTATORS_HYDRATOR_CONFIG_API_URL=<value>
         #
-        url: https://tssrjsnUDbsckO.nrtcXf1RT2ZZGPGbfQ
+        url: https://wCNcalzJanGyvvQBfKR.ghsInZRlIbjtNQEq8TuovYqsNj,xNhItpea.h2L3b+foYNf.il2Pd
 
         ## auth ##
         #
         auth:
+          
           ## basic ##
           #
           basic:
+            
             ## username ##
             #
             # Set this value using environment variables on
@@ -1175,7 +1335,7 @@ mutators:
             # - Windows Command Line (CMD):
             #    > set MUTATORS_HYDRATOR_CONFIG_API_AUTH_BASIC_USERNAME=<value>
             #
-            username: reprehenderit est ea
+            username: nostrud velit proident fugiat
 
             ## password ##
             #
@@ -1185,11 +1345,12 @@ mutators:
             # - Windows Command Line (CMD):
             #    > set MUTATORS_HYDRATOR_CONFIG_API_AUTH_BASIC_PASSWORD=<value>
             #
-            password: sit labore Duis dolor amet
+            password: laboris deserunt sint
 
         ## retry ##
         #
         retry:
+          
           ## give_up_after ##
           #
           # Set this value using environment variables on
@@ -1198,7 +1359,7 @@ mutators:
           # - Windows Command Line (CMD):
           #    > set MUTATORS_HYDRATOR_CONFIG_API_RETRY_GIVE_UP_AFTER=<value>
           #
-          give_up_after: 8s
+          give_up_after: 2m
 
           ## max_delay ##
           #
@@ -1208,11 +1369,12 @@ mutators:
           # - Windows Command Line (CMD):
           #    > set MUTATORS_HYDRATOR_CONFIG_API_RETRY_MAX_DELAY=<value>
           #
-          max_delay: 641ms
+          max_delay: 76997ns
 
       ## cache ##
       #
       cache:
+        
         ## enabled ##
         #
         # Set this value using environment variables on
@@ -1231,7 +1393,7 @@ mutators:
         # - Windows Command Line (CMD):
         #    > set MUTATORS_HYDRATOR_CONFIG_CACHE_TTL=<value>
         #
-        ttl: 071719509s
+        ttl: 802ms
 
     ## Enabled ##
     #
@@ -1241,23 +1403,25 @@ mutators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export MUTATORS_HYDRATOR_ENABLED=<value>
     # - Windows Command Line (CMD):
     #    > set MUTATORS_HYDRATOR_ENABLED=<value>
     #
-    enabled: false
+    enabled: true
 
   ## ID Token (JSON Web Token) ##
   #
   # The [`id_token` mutator](https://www.ory.sh/oathkeeper/docs/pipeline/mutator#id_token).
   #
   id_token:
+    
     ## config ##
     #
     config:
+      
       ## jwks_url ##
       #
       # Set this value using environment variables on
@@ -1266,7 +1430,7 @@ mutators:
       # - Windows Command Line (CMD):
       #    > set MUTATORS_ID_TOKEN_CONFIG_JWKS_URL=<value>
       #
-      jwks_url: file://../from/this/relative/location.json
+      jwks_url: file:///from/this/absolute/location.json
 
       ## issuer_url ##
       #
@@ -1276,7 +1440,7 @@ mutators:
       # - Windows Command Line (CMD):
       #    > set MUTATORS_ID_TOKEN_CONFIG_ISSUER_URL=<value>
       #
-      issuer_url: sint laborum
+      issuer_url: in in Excepteur
 
       ## claims ##
       #
@@ -1286,7 +1450,7 @@ mutators:
       # - Windows Command Line (CMD):
       #    > set MUTATORS_ID_TOKEN_CONFIG_CLAIMS=<value>
       #
-      claims: veniam proident
+      claims: cupidatat est dolore sit
 
       ## ttl ##
       #
@@ -1296,7 +1460,7 @@ mutators:
       # - Windows Command Line (CMD):
       #    > set MUTATORS_ID_TOKEN_CONFIG_TTL=<value>
       #
-      ttl: 1m
+      ttl: 1h
 
     ## Enabled ##
     #
@@ -1306,7 +1470,7 @@ mutators:
     #
     # Examples:
     # - true
-    #
+    # 
     # Set this value using environment variables on
     # - Linux/macOS:
     #    $ export MUTATORS_ID_TOKEN_ENABLED=<value>
@@ -1320,6 +1484,7 @@ mutators:
 # Configure logging using the following options. Logging will always be sent to stdout and stderr.
 #
 log:
+  
   ## Level ##
   #
   # Debug enables stack traces on errors. Can also be set using environment variable LOG_LEVEL.
@@ -1332,7 +1497,7 @@ log:
   # - Windows Command Line (CMD):
   #    > set LOG_LEVEL=<value>
   #
-  level: info
+  level: debug
 
   ## Format ##
   #
@@ -1346,7 +1511,7 @@ log:
   # - Windows Command Line (CMD):
   #    > set LOG_FORMAT=<value>
   #
-  format: json
+  format: text
 
 ## Profiling ##
 #
@@ -1359,4 +1524,5 @@ log:
 #    > set PROFILING=<value>
 #
 profiling: mem
+
 ```

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.1 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7
 	github.com/julienschmidt/httprouter v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,8 @@ github.com/gorilla/sessions v1.1.2/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE
 github.com/gorilla/sessions v1.1.3 h1:uXoZdcdA5XdXF3QzuSlheVRUvjl+1rKY7zBXL68L9RU=
 github.com/gorilla/sessions v1.1.3/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gotestyourself/gotestyourself v1.3.0/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=

--- a/pipeline/authn/authenticator_oauth2_client_credentials_test.go
+++ b/pipeline/authn/authenticator_oauth2_client_credentials_test.go
@@ -123,5 +123,9 @@ func TestAuthenticatorOAuth2ClientCredentials(t *testing.T) {
 		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2ClientCredentialsIsEnabled, true)
 		require.NoError(t, a.Validate(json.RawMessage(`{"token_url":"`+ts.URL+"/oauth2/token"+`"}`)))
+
+		viper.Reset()
+		viper.Set(configuration.ViperKeyAuthenticatorOAuth2ClientCredentialsIsEnabled, true)
+		require.NoError(t, a.Validate(json.RawMessage(`{"token_url":"`+ts.URL+"/oauth2/token"+`","retry":{"give_up_after":"3s", "max_delay":"100ms"}}`)))
 	})
 }


### PR DESCRIPTION
## Related issue

#442

This was also briefly discussed with @aeneasr [on Slack](https://app.slack.com/client/T010GP8ELBT/C01340V8KSM/thread/C01340V8KSM-1589898335.074600) 

## Proposed changes
Enable users to specify timeout for the oauth2_client_credentials authoriser, much in the same fashion as is possible for the oauth2_introspection authoriser.


## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments
A lot of changes were generated when running `npm gen docs`, which creates rather a lot of noise. Sorry about that.