### PR TITLE
fix: remove HTTP method restrictions

### DIFF
--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -144,3 +144,45 @@ func TestRule1(t *testing.T) {
 		})
 	}
 }
+
+func TestRuleWithCustomMethod(t *testing.T) {
+	r := &Rule{
+		Match: &Match{
+			Methods: []string{"CUSTOM"},
+			URL:     "https://localhost/users/<(?!admin).*>",
+		},
+	}
+
+	var tests = []struct {
+		method        string
+		url           string
+		expectedMatch bool
+		expectedErr   error
+	}{
+		{
+			method:        "CUSTOM",
+			url:           "https://localhost/users/manager",
+			expectedMatch: true,
+			expectedErr:   nil,
+		},
+		{
+			method:        "CUSTOM",
+			url:           "https://localhost/users/1234?key=value&key1=value1",
+			expectedMatch: true,
+			expectedErr:   nil,
+		},
+		{
+			method:        "DELETE",
+			url:           "https://localhost/users/admin",
+			expectedMatch: false,
+			expectedErr:   nil,
+		},
+	}
+	for ind, tcase := range tests {
+		t.Run(string(ind), func(t *testing.T) {
+			matched, err := r.IsMatching(configuration.Regexp, tcase.method, mustParse(t, tcase.url))
+			assert.Equal(t, tcase.expectedMatch, matched)
+			assert.Equal(t, tcase.expectedErr, err)
+		})
+	}
+}

--- a/rule/validator.go
+++ b/rule/validator.go
@@ -24,26 +24,12 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/pkg/errors"
 
-	"github.com/ory/go-convenience/stringslice"
 	"github.com/ory/herodot"
-
 	"github.com/ory/oathkeeper/pipeline/authn"
 	"github.com/ory/oathkeeper/pipeline/authz"
 	pe "github.com/ory/oathkeeper/pipeline/errors"
 	"github.com/ory/oathkeeper/pipeline/mutate"
 )
-
-var methods = []string{
-	"GET",
-	"POST",
-	"PUT",
-	"HEAD",
-	"DELETE",
-	"PATCH",
-	"OPTIONS",
-	"TRACE",
-	"CONNECT",
-}
 
 type validatorRegistry interface {
 	authn.Registry
@@ -141,12 +127,6 @@ func (v *ValidatorDefault) Validate(r *Rule) error {
 
 	if r.Match.URL == "" {
 		return errors.WithStack(herodot.ErrInternalServerError.WithReasonf(`Value "%s" of "match.url" field is not a valid url.`, r.Match.URL))
-	}
-
-	for _, m := range r.Match.Methods {
-		if !stringslice.Has(methods, m) {
-			return errors.WithStack(herodot.ErrInternalServerError.WithReasonf(`Value "%s" of "match.methods" is not a valid HTTP method, valid methods are: %v`, m, methods))
-		}
 	}
 
 	if r.Upstream.URL == "" {

--- a/rule/validator_test.go
+++ b/rule/validator_test.go
@@ -61,10 +61,6 @@ func TestValidateRule(t *testing.T) {
 			expectErr: `Value "" of "match.url" field is not a valid url.`,
 		},
 		{
-			r:         &Rule{Match: &Match{URL: "https://www.ory.sh", Methods: []string{"FOO"}}},
-			expectErr: `Value "FOO" of "match.methods" is not a valid HTTP method, valid methods are:`,
-		},
-		{
 			r: &Rule{
 				Match:    &Match{URL: "https://www.ory.sh", Methods: []string{"POST"}},
 				Upstream: Upstream{URL: "https://www.ory.sh"},
@@ -133,6 +129,16 @@ func TestValidateRule(t *testing.T) {
 			setup: prep(true, true, true),
 			r: &Rule{
 				Match:          &Match{URL: "https://www.ory.sh", Methods: []string{"POST"}},
+				Upstream:       Upstream{URL: "https://www.ory.sh"},
+				Authenticators: []Handler{{Handler: "noop"}},
+				Authorizer:     Handler{Handler: "allow"},
+				Mutators:       []Handler{{Handler: "noop"}},
+			},
+		},
+		{
+			setup: prep(true, true, true),
+			r: &Rule{
+				Match:          &Match{URL: "https://www.ory.sh", Methods: []string{"MKCOL"}},
 				Upstream:       Upstream{URL: "https://www.ory.sh"},
 				Authenticators: []Handler{{Handler: "noop"}},
 				Authorizer:     Handler{Handler: "allow"},


### PR DESCRIPTION
## Related issue

#471 (and https://community.ory.sh/t/oathkeeper-why-http-methods-are-restricted/1939)

@aeneasr 

## Proposed changes

As proposed, the method list has been removed

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security. vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](docs/docs) [Nothing to change]
