### PR TITLE
fix: matcher.Match handles nil *url.URL

### DIFF
--- a/rule/matcher_test.go
+++ b/rule/matcher_test.go
@@ -140,6 +140,11 @@ func TestMatcher(t *testing.T) {
 				assert.NotEmpty(t, got.matchingEngine.Checksum())
 			})
 
+			t.Run("case=nil url", func(t *testing.T) {
+				_, err := matcher.Match(context.Background(), "GET", nil)
+				require.Error(t, err)
+			})
+
 			require.NoError(t, matcher.Set(context.Background(), testRules[1:]))
 
 			t.Run("case=updated", func(t *testing.T) {

--- a/rule/repository_memory.go
+++ b/rule/repository_memory.go
@@ -120,15 +120,16 @@ func (m *RepositoryMemory) Set(ctx context.Context, rules []Rule) error {
 }
 
 func (m *RepositoryMemory) Match(_ context.Context, method string, u *url.URL) (*Rule, error) {
+	if u == nil {
+		return nil, errors.WithStack(errors.New("nil URL provided"))
+	}
+
 	m.Lock()
 	defer m.Unlock()
 
 	var rules []Rule
 	for k := range m.rules {
 		r := &m.rules[k]
-		if u == nil {
-			return nil, errors.WithStack(errors.New("nil URL provided"))
-		}
 		if matched, err := r.IsMatching(m.matchingStrategy, method, u); err != nil {
 			return nil, errors.WithStack(err)
 		} else if matched {

--- a/rule/repository_memory.go
+++ b/rule/repository_memory.go
@@ -126,6 +126,9 @@ func (m *RepositoryMemory) Match(_ context.Context, method string, u *url.URL) (
 	var rules []Rule
 	for k := range m.rules {
 		r := &m.rules[k]
+		if u == nil {
+			return nil, errors.WithStack(errors.New("nil URL provided"))
+		}
 		if matched, err := r.IsMatching(m.matchingStrategy, method, u); err != nil {
 			return nil, errors.WithStack(err)
 		} else if matched {


### PR DESCRIPTION
## Related issue

Should fix issue #484 

## Proposed changes

Just add a check for nil `*url.URL` in `RepositoryMemory.Match` 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

