### PR TITLE
feat : Docker compose improvement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,13 @@
 version: '3.7'
 
 services:
-
-  volume-populate: 
-  # this is just used to copy the content of ./.docker_compose to oathkeeper-volume
-    image: busybox
-    command: cp -r /src/. /dest
-    volumes:
-      - ./.docker_compose:/src:Z
-      - oathkeeper-volume:/dest
-
   oathkeeper:
     build:
       context: .
       dockerfile: Dockerfile-dc
     ports:
-      - 4455:4455
-      - 4456:4456
+      - "4455:4455"
+      - "4456:4456"
     command:
       serve --config=/etc/config/oathkeeper/config.yaml
     environment:
@@ -26,13 +17,17 @@ services:
       - TRACING_PROVIDER_JAEGER_SAMPLING_TYPE=const
       - TRACING_PROVIDER_JAEGER_SAMPLING_VALUE=1
     volumes:
-      - oathkeeper-volume:/etc/config/oathkeeper
+      - ./.docker_compose:/etc/config/oathkeeper:Z
     restart: on-failure
 
   jaeger:
     image: jaegertracing/all-in-one
     ports:
-      - 16686:16686 # The UI port
-
-volumes:
-  oathkeeper-volume:
+      - "16686:16686" # The UI port
+#      These are ports for collecting, sampling, agents, ...
+#      - "5775:5775/udp"
+#      - "6831:6831/udp"
+#      - "6832:6832/udp"
+#      - "5778:5778"
+#      - "14268:14268"
+#      - "9411:9411"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,13 @@ version: '3.7'
 
 services:
 
-  volume-populate: # this is just used to copy the content
+  volume-populate: 
+  # this is just used to copy the content of ./.docker_compose to oathkeeper-volume
     image: busybox
-    command: cp -r /tmp/src/. /data
+    command: cp -r /src/. /dest
     volumes:
-      - ./.docker_compose:/tmp/src:Z
-      - oathkeeper-volume:/data
+      - ./.docker_compose:/src:Z
+      - oathkeeper-volume:/dest
 
   oathkeeper:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,21 @@
 version: '3.7'
 
 services:
+
+  volume-populate: # this is just used to copy the content
+    image: busybox
+    command: cp -r /tmp/src/. /data
+    volumes:
+      - ./.docker_compose:/tmp/src:Z
+      - oathkeeper-volume:/data
+
   oathkeeper:
     build:
       context: .
       dockerfile: Dockerfile-dc
     ports:
-      - "4455:4455"
-      - "4456:4456"
+      - 4455:4455
+      - 4456:4456
     command:
       serve --config=/etc/config/oathkeeper/config.yaml
     environment:
@@ -17,18 +25,13 @@ services:
       - TRACING_PROVIDER_JAEGER_SAMPLING_TYPE=const
       - TRACING_PROVIDER_JAEGER_SAMPLING_VALUE=1
     volumes:
-      - type: bind
-        source: ./.docker_compose
-        target: /etc/config/oathkeeper
+      - oathkeeper-volume:/etc/config/oathkeeper
     restart: on-failure
+
   jaeger:
     image: jaegertracing/all-in-one
     ports:
-      - "16686:16686" # The UI port
-#      These are ports for collecting, sampling, agents, ...
-#      - "5775:5775/udp"
-#      - "6831:6831/udp"
-#      - "6832:6832/udp"
-#      - "5778:5778"
-#      - "14268:14268"
-#      - "9411:9411"
+      - 16686:16686 # The UI port
+
+volumes:
+  oathkeeper-volume:


### PR DESCRIPTION
## Related issue
#488 

## Proposed changes

This PR should allow the docker-compose to run out of the box.

It uses a temporary container (busybox) to copy the content of `./.docker_compose/` into a named volume used by oathkeeper

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).