### PR TITLE
feat: add and automate version schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   sdk: ory/sdk@0.1.36
   changelog: ory/changelog@0.1.2
-  goreleaser: ory/goreleaser@0.1.13
+  goreleaser: ory/goreleaser@0.1.17
   slack: circleci/slack@3.4.2
   nancy: ory/nancy@0.0.10
   docs: ory/docs@0.0.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,13 @@ workflows:
             tags:
               only: /.*/
       -
+        goreleaser/render-version-schema:
+          requires:
+            - goreleaser/release
+          filters:
+            tags:
+              only: /.*/
+      -
         goreleaser/newsletter-draft:
           chimp-list: f605a41b53
           chimp-segment: 6479485

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ changelog:
 
 brews:
   -
-    github:
+    tap:
       owner: ory
       name: homebrew-oathkeeper
     homepage:  https://www.ory.sh

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -1763,6 +1763,12 @@
         "mem",
         ""
       ]
+    },
+    "version": {
+      "type": "string",
+      "title": "The Oathkeeper version this config is written for.",
+      "description": "SemVer according to https://semver.org/ prefixed with `v` as in our releases.",
+      "pattern": "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
     }
   },
   "required": [],

--- a/.schema/version.schema.json
+++ b/.schema/version.schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://github.com/ory/oathkeeper/.schema/versions.config.schema.json",
+  "$schema": "https://raw.githubusercontent.com/ory/cli/v0.0.21/.schema/version_meta.schema.json#",
+  "title": "All Versions of the ORY Oathkeeper Configuration",
+  "type": "object",
+  "oneOf": []
+}


### PR DESCRIPTION
## Related issue

prepares #500 

## Proposed changes

Analogously to kratos this adds:
- config top level version key
- ory/goreleaser/render-version-schema automation
- the version schema itself

## Further comments

When this is merged we can make a PR to schemastore.org