### PR TITLE
fix: Misleading HTTP status code for oauth2_client_credentials authenticator

### DIFF
--- a/helper/errors.go
+++ b/helper/errors.go
@@ -73,4 +73,24 @@ var (
 		CodeField:   http.StatusBadRequest,
 		StatusField: http.StatusText(http.StatusBadRequest),
 	}
+	ErrUpstreamServiceNotAvailable = &herodot.DefaultError{
+		ErrorField:  "The upstream service is not available",
+		CodeField:   http.StatusServiceUnavailable,
+		StatusField: http.StatusText(http.StatusServiceUnavailable),
+	}
+	ErrUpstreamServiceTimeout = &herodot.DefaultError{
+		ErrorField:  "The upstream service is timing out",
+		CodeField:   http.StatusGatewayTimeout,
+		StatusField: http.StatusText(http.StatusGatewayTimeout),
+	}
+	ErrUpstreamServiceInternalServerError = &herodot.DefaultError{
+		ErrorField:  "The upstream service encountered an unexpected error",
+		CodeField:   http.StatusInternalServerError,
+		StatusField: http.StatusText(http.StatusInternalServerError),
+	}
+	ErrUpstreamServiceNotFound = &herodot.DefaultError{
+		ErrorField:  "Upstream service not found",
+		CodeField:   http.StatusNotFound,
+		StatusField: http.StatusText(http.StatusNotFound),
+	}
 )

--- a/pipeline/authn/authenticator_oauth2_client_credentials_test.go
+++ b/pipeline/authn/authenticator_oauth2_client_credentials_test.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/ory/herodot"
 	"github.com/ory/oathkeeper/helper"
+	"github.com/tidwall/sjson"
 )
 
 func TestAuthenticatorOAuth2ClientCredentials(t *testing.T) {
@@ -51,48 +52,139 @@ func TestAuthenticatorOAuth2ClientCredentials(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "oauth2_client_credentials", a.GetID())
 
-	h := httprouter.New()
-	h.POST("/oauth2/token", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		h := herodot.NewJSONWriter(logrus.New())
-		u, p, ok := r.BasicAuth()
-		if !ok || u != "client" || p != "secret" {
-			h.WriteError(w, r, helper.ErrUnauthorized)
-			return
-		}
-		h.Write(w, r, map[string]interface{}{"access_token": "foo-token"})
-	})
-	ts := httptest.NewServer(h)
-
 	authOk := &http.Request{Header: http.Header{}}
 	authOk.SetBasicAuth("client", "secret")
 
 	authInvalid := &http.Request{Header: http.Header{}}
 	authInvalid.SetBasicAuth("foo", "bar")
 
+	upstreamFailure := &http.Request{Header: http.Header{}}
+	upstreamFailure.SetBasicAuth("client", "secret")
+
 	for k, tc := range []struct {
+		d             string
 		r             *http.Request
 		config        json.RawMessage
+		token_url     string
+		setup         func(*testing.T, *httprouter.Router)
 		expectErr     error
 		expectSession *authn.AuthenticationSession
 	}{
 		{
+			d:         "fails due to invalid token url",
 			r:         &http.Request{Header: http.Header{}},
 			expectErr: authn.ErrAuthenticatorNotResponsible,
-			config:    json.RawMessage(`{"token_url":"http://foo"}`),
+			config:    json.RawMessage(`{}`),
+			token_url: "http://foo",
 		},
 		{
+			d:         "fails due to invalid client credentials",
 			r:         authInvalid,
 			expectErr: helper.ErrUnauthorized,
-			config:    json.RawMessage(`{"token_url":"` + ts.URL + "/oauth2/token" + `"}`),
+			config:    json.RawMessage(`{}`),
+			token_url: "",
+			setup: func(t *testing.T, h *httprouter.Router) {
+				h.POST("/oauth2/token", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+					h := herodot.NewJSONWriter(logrus.New())
+					h.WriteError(w, r, helper.ErrUnauthorized)
+				})
+			},
 		},
 		{
+			d:             "passes due to valid client credentials and returns access token",
 			r:             authOk,
 			expectErr:     nil,
 			expectSession: &authn.AuthenticationSession{Subject: "client"},
-			config:        json.RawMessage(`{"token_url":"` + ts.URL + "/oauth2/token" + `"}`),
+			config:        json.RawMessage(`{}`),
+			token_url:     "",
+			setup: func(t *testing.T, h *httprouter.Router) {
+				h.POST("/oauth2/token", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+					h := herodot.NewJSONWriter(logrus.New())
+					h.Write(w, r, map[string]interface{}{"access_token": "foo-token"})
+				})
+			},
+		},
+		{
+			d:         "fails and returns 503 Service Unavailable error due to the unavailability of the upstream service",
+			r:         upstreamFailure,
+			expectErr: helper.ErrUpstreamServiceNotAvailable,
+			config:    json.RawMessage(`{}`),
+			token_url: "",
+			setup: func(t *testing.T, h *httprouter.Router) {
+				h.POST("/oauth2/token", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+					h := herodot.NewJSONWriter(logrus.New())
+					h.WriteError(w, r, helper.ErrUpstreamServiceNotAvailable)
+				})
+			},
+		},
+		{
+			d:         "fails and returns 504 Gateway Timeout error due to upstream service timeout",
+			r:         upstreamFailure,
+			expectErr: helper.ErrUpstreamServiceTimeout,
+			config:    json.RawMessage(`{}`),
+			token_url: "",
+			setup: func(t *testing.T, h *httprouter.Router) {
+				h.POST("/oauth2/token", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+					h := herodot.NewJSONWriter(logrus.New())
+					h.WriteError(w, r, helper.ErrUpstreamServiceTimeout)
+				})
+			},
+		},
+		{
+			d:         "fails and returns 500 Internal Server Error error due to an unexpected error in the upstream service",
+			r:         upstreamFailure,
+			expectErr: helper.ErrUpstreamServiceInternalServerError,
+			config:    json.RawMessage(`{}`),
+			token_url: "",
+			setup: func(t *testing.T, h *httprouter.Router) {
+				h.POST("/oauth2/token", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+					h := herodot.NewJSONWriter(logrus.New())
+					h.WriteError(w, r, helper.ErrUpstreamServiceInternalServerError)
+				})
+			},
+		},
+		{
+			d:         "fails and returns 404 Not Found error as the upstream service could not find the requested resource ",
+			r:         upstreamFailure,
+			expectErr: helper.ErrUpstreamServiceNotFound,
+			config:    json.RawMessage(`{}`),
+			token_url: "",
+			setup: func(t *testing.T, h *httprouter.Router) {
+				h.POST("/oauth2/v1/token", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+					h := herodot.NewJSONWriter(logrus.New())
+					h.Write(w, r, map[string]interface{}{"access_token": "foo-token"})
+				})
+			},
+		},
+		{
+			d:         "fails and returns 401 Unauthorized error as the upstream service returns 403 Forbidden",
+			r:         upstreamFailure,
+			expectErr: helper.ErrUnauthorized,
+			config:    json.RawMessage(`{}`),
+			token_url: "",
+			setup: func(t *testing.T, h *httprouter.Router) {
+				h.POST("/oauth2/token", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+					h := herodot.NewJSONWriter(logrus.New())
+					h.WriteError(w, r, helper.ErrForbidden)
+				})
+			},
 		},
 	} {
 		t.Run(fmt.Sprintf("method=authenticate/case=%d", k), func(t *testing.T) {
+			router := httprouter.New()
+
+			if tc.setup != nil {
+				tc.setup(t, router)
+			}
+
+			ts := httptest.NewServer(router)
+
+			if tc.token_url != "" {
+				tc.config, _ = sjson.SetBytes(tc.config, "token_url", tc.token_url)
+			} else {
+				tc.config, _ = sjson.SetBytes(tc.config, "token_url", ts.URL+"/oauth2/token")
+			}
+
 			session := new(authn.AuthenticationSession)
 			err := a.Authenticate(tc.r, session, tc.config, nil)
 
@@ -107,6 +199,19 @@ func TestAuthenticatorOAuth2ClientCredentials(t *testing.T) {
 			}
 		})
 	}
+
+	h := httprouter.New()
+	h.POST("/oauth2/token", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		h := herodot.NewJSONWriter(logrus.New())
+		u, p, ok := r.BasicAuth()
+		if !ok || u != "client" || p != "secret" {
+			h.WriteError(w, r, helper.ErrUnauthorized)
+			return
+		}
+		h.Write(w, r, map[string]interface{}{"access_token": "foo-token"})
+	})
+
+	ts := httptest.NewServer(h)
 
 	t.Run("method=validate", func(t *testing.T) {
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2ClientCredentialsIsEnabled, false)


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

[Closes #496](https://github.com/ory/oathkeeper/issues/496)

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
