### PR TITLE
feat: Add url_param config option to redirect error handler.

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -262,7 +262,7 @@
         },
         "url_param": {
           "title": "URL query parameter",
-          "description": "Name of query parameter, where current url will be added to redirect url",
+          "description": "Adds the original URL the request tried to access to the query parameter.",
           "type": "string",
           "pattern": "^[A-Za-z0-9,._~-]*$",
           "default": ""

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -260,6 +260,13 @@
           ],
           "default": 302
         },
+        "url_param": {
+          "title": "URL query parameter",
+          "description": "Name of query parameter, where current url will be added to redirect url",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9,._~-]*$",
+          "default": ""
+        },
         "when": {
           "$ref": "#/definitions/configErrorsWhen"
         }

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -260,7 +260,7 @@
           ],
           "default": 302
         },
-        "url_param": {
+        "return_to_query_param": {
           "title": "URL query parameter",
           "description": "Adds the original URL the request tried to access to the query parameter.",
           "type": "string",

--- a/docs/docs/pipeline/error.md
+++ b/docs/docs/pipeline/error.md
@@ -413,6 +413,8 @@ The `redirect` Error Handler returns a HTTP 302/301 response with a `Location`
 Header. As discussed in the previous section, you can define error matching
 conditions under the `when` key.
 
+If you want to append the current url (where the error happened) to address redirected to, You can specify `return_to_query_param` to set the name of parameter that will hold the url.
+
 **Example**
 
 ```json5
@@ -421,6 +423,7 @@ conditions under the `when` key.
   handler: 'json',
   config: {
     to: 'http://my-website/login', // required!!
+    return_to_query_param: 'return_to',
     code: 301, // defaults to 302 - only 301 and 302 are supported.
     when: [
       // ...
@@ -428,6 +431,8 @@ conditions under the `when` key.
   }
 }
 ```
+
+When the user accesses a protected url `http://my-website/settings`, they will be redirected to `http://my-website/login?return_to=http%3A%2F%2Fmy-website%2Fsettings`. The login page can use the `return_to` paramter to return user to intended page after a successful login.
 
 ### `www_authenticate`
 

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -74,7 +74,7 @@ func (a *ErrorRedirect) RedirectURL(r *http.Request, c *ErrorRedirectConfig) str
 		return c.To
 	}
 
-	url, err := url.Parse(c.To)
+	u, err := url.Parse(c.To)
 	if err != nil {
 		return c.To
 	}

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -69,7 +69,7 @@ func (a *ErrorRedirect) GetID() string {
 	return "redirect"
 }
 
-func (a *ErrorRedirect) RedirectUrl(r *http.Request, c *ErrorRedirectConfig) string {
+func (a *ErrorRedirect) RedirectURL(r *http.Request, c *ErrorRedirectConfig) string {
 	if c.UrlParam == "" {
 		return c.To
 	}

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -16,7 +16,7 @@ type (
 	ErrorRedirectConfig struct {
 		To       string `json:"to"`
 		Code     int    `json:"code"`
-		UrlParam string `json:"url_param"`
+		URLParam string `json:"url_param"`
 	}
 	ErrorRedirect struct {
 		c configuration.Provider

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"encoding/json"
+	"net/url"
 	"net/http"
 
 	"github.com/ory/oathkeeper/driver/configuration"
@@ -13,8 +14,9 @@ var _ Handler = new(ErrorRedirect)
 
 type (
 	ErrorRedirectConfig struct {
-		To   string `json:"to"`
-		Code int    `json:"code"`
+		To   string     `json:"to"`
+		Code int        `json:"code"`
+		UrlParam string `json:"url_param"`
 	}
 	ErrorRedirect struct {
 		c configuration.Provider
@@ -38,7 +40,7 @@ func (a *ErrorRedirect) Handle(w http.ResponseWriter, r *http.Request, config js
 		return err
 	}
 
-	http.Redirect(w, r, c.To, c.Code)
+	http.Redirect(w, r, a.RedirectUrl(r, c), c.Code)
 	return nil
 }
 
@@ -65,4 +67,20 @@ func (a *ErrorRedirect) Config(config json.RawMessage) (*ErrorRedirectConfig, er
 
 func (a *ErrorRedirect) GetID() string {
 	return "redirect"
+}
+
+func (a *ErrorRedirect) RedirectUrl(r *http.Request, c *ErrorRedirectConfig) string {
+	if c.UrlParam == "" {
+		return c.To
+	}
+
+	url, err := url.Parse(c.To)
+	if err == nil {
+		query := url.Query()
+		query.Set(c.UrlParam, r.URL.String())
+		url.RawQuery = query.Encode()
+		return url.String()
+	} else {
+		return c.To
+	}
 }

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -70,7 +70,7 @@ func (a *ErrorRedirect) GetID() string {
 }
 
 func (a *ErrorRedirect) RedirectURL(r *http.Request, c *ErrorRedirectConfig) string {
-	if c.UrlParam == "" {
+	if c.URLParam == "" {
 		return c.To
 	}
 

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -75,12 +75,11 @@ func (a *ErrorRedirect) RedirectURL(r *http.Request, c *ErrorRedirectConfig) str
 	}
 
 	url, err := url.Parse(c.To)
-	if err == nil {
-		query := url.Query()
-		query.Set(c.UrlParam, r.URL.String())
-		url.RawQuery = query.Encode()
-		return url.String()
-	} else {
+	if err != nil {
 		return c.To
 	}
+	q := u.Query()
+	q.Set(c.UrlParam, r.URL.String())
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -79,7 +79,7 @@ func (a *ErrorRedirect) RedirectURL(r *http.Request, c *ErrorRedirectConfig) str
 		return c.To
 	}
 	q := u.Query()
-	q.Set(c.UrlParam, r.URL.String())
+	q.Set(c.URLParam, r.URL.String())
 	u.RawQuery = q.Encode()
 	return u.String()
 }

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -40,7 +40,7 @@ func (a *ErrorRedirect) Handle(w http.ResponseWriter, r *http.Request, config js
 		return err
 	}
 
-	http.Redirect(w, r, a.RedirectUrl(r, c), c.Code)
+	http.Redirect(w, r, a.RedirectURL(r, c), c.Code)
 	return nil
 }
 

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -14,9 +14,9 @@ var _ Handler = new(ErrorRedirect)
 
 type (
 	ErrorRedirectConfig struct {
-		To       string `json:"to"`
-		Code     int    `json:"code"`
-		URLParam string `json:"url_param"`
+		To                 string `json:"to"`
+		Code               int    `json:"code"`
+		ReturnToQueryParam string `json:"return_to_query_param"`
 	}
 	ErrorRedirect struct {
 		c configuration.Provider
@@ -70,7 +70,7 @@ func (a *ErrorRedirect) GetID() string {
 }
 
 func (a *ErrorRedirect) RedirectURL(r *http.Request, c *ErrorRedirectConfig) string {
-	if c.URLParam == "" {
+	if c.ReturnToQueryParam == "" {
 		return c.To
 	}
 
@@ -79,7 +79,7 @@ func (a *ErrorRedirect) RedirectURL(r *http.Request, c *ErrorRedirectConfig) str
 		return c.To
 	}
 	q := u.Query()
-	q.Set(c.URLParam, r.URL.String())
+	q.Set(c.ReturnToQueryParam, r.URL.String())
 	u.RawQuery = q.Encode()
 	return u.String()
 }

--- a/pipeline/errors/error_redirect.go
+++ b/pipeline/errors/error_redirect.go
@@ -2,8 +2,8 @@ package errors
 
 import (
 	"encoding/json"
-	"net/url"
 	"net/http"
+	"net/url"
 
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/pipeline"
@@ -14,8 +14,8 @@ var _ Handler = new(ErrorRedirect)
 
 type (
 	ErrorRedirectConfig struct {
-		To   string     `json:"to"`
-		Code int        `json:"code"`
+		To       string `json:"to"`
+		Code     int    `json:"code"`
 		UrlParam string `json:"url_param"`
 	}
 	ErrorRedirect struct {

--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -57,7 +57,8 @@ func TestErrorRedirect(t *testing.T) {
 				config:     `{"to":"http://test/signin","url_param":"return_to"}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 302, rw.Code)
-					location, _ := url.Parse(rw.Header().Get("Location"))
+					location, err := url.Parse(rw.Header().Get("Location"))
+					require.NoErr(t, err)
 					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},

--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -54,7 +54,7 @@ func TestErrorRedirect(t *testing.T) {
 			{
 				d:          "should redirect with return_to param",
 				givenError: &herodot.ErrNotFound,
-				config:     `{"to":"http://test/signin","url_param":"return_to"}`,
+				config:     `{"to":"http://test/signin","return_to_query_param":"return_to"}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 302, rw.Code)
 					location, err := url.Parse(rw.Header().Get("Location"))

--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,16 @@ func TestErrorRedirect(t *testing.T) {
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 301, rw.Code)
 					assert.Equal(t, "http://test/test", rw.Header().Get("Location"))
+				},
+			},
+			{
+				d:          "should redirect with return_to param",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"http://test/signin","url_param":"return_to"}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 302, rw.Code)
+					location, _ := url.Parse(rw.Header().Get("Location"))
+					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},
 		} {

--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -58,7 +58,7 @@ func TestErrorRedirect(t *testing.T) {
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 302, rw.Code)
 					location, err := url.Parse(rw.Header().Get("Location"))
-					require.NoErr(t, err)
+					require.NoError(t, err)
 					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},


### PR DESCRIPTION
This change introduces a url_param config option for redirect error handler.
If it contains a url paramter name, the redirect url will have this parameter
set, containing the current url (from which Oathkeeper has redirected the user).

This can be useful in passing the return_to url to Kratos, so user can be
redirected to the page they initially wanted to access after a successfull sign in.

## Related issue

https://community.ory.sh/t/how-to-use-the-return-to-query-string-with-oathkeeper-kratos/2149/6

## Proposed changes

Add `url_param` option to redirect error config, which configures a name of paramter that should contain current url (the url that failed the pipeline).

If url_param is given, the redirect error handler will parse the `to:` url and append `url_param` parameter with current url. 

## Checklist

:warning: Disclaimer: I am not a Golang coder. I'd appreciate the feedback on this patch and I intend to make it better. I have not written documentation yet – unsure if my approach is ok.

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

