### PR TITLE
fix windows path error

### DIFF
--- a/rule/fetcher_default.go
+++ b/rule/fetcher_default.go
@@ -144,14 +144,15 @@ func (f *FetcherDefault) configUpdate(ctx context.Context, watcher *fsnotify.Wat
 }
 
 func (f *FetcherDefault) sourceUpdate(e event) ([]Rule, error) {
-	if e.path.Scheme == "file" {
-		u, err := url.Parse("file://" + filepath.Clean(strings.TrimPrefix(e.path.String(), "file://")))
-		if err != nil {
-			return nil, err
-		}
-
-		e.path = *u
-	}
+// unnecessary code will make an error on windows machine 
+//	if e.path.Scheme == "file" {
+//		u, err := url.Parse("file://" + filepath.Clean(strings.TrimPrefix(e.path.String(), "file://")))
+//		if err != nil {
+//			return nil, err
+//		}
+//
+//		e.path = *u
+//	}
 
 	rules, err := f.fetch(e.path)
 	if err != nil {


### PR DESCRIPTION
this issue is happened on windows 10 system,it may cased by incorrect string parse with url.Parse() method .that split string with ' : ',and make it wrong . The error message is as follows：

time="2020-01-08T15:43:39+08:00" level=error msg="Unable to update access rules from given location, changes will be ignored. Check the configuration or restart the service if the issue persists." error="parse file://\F:\aweso
meProject\bin\resource-server.json: invalid port ":\\awesomeProject\\bin\\resource-server.json" after host" file="file:///F:/awesomeProject/bin/resource-server.json"

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
