### PR TITLE
feat: use uri-reference for errors redirect to allow relative urls

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -250,7 +250,7 @@
           "type": "string",
           "format": "uri-reference",
           "examples": [
-            "https://my-app.com/dashboard",
+            "http://my-app.com/dashboard",
             "https://my-app.com/dashboard",
             "/dashboard"
           ]

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -248,7 +248,12 @@
           "title": "Redirect to",
           "description": "Set the redirect target. Must be a http/https URL.",
           "type": "string",
-          "format": "uri"
+          "format": "uri-relative",
+          "examples": [
+            "https://my-app.com/dashboard",
+            "https://my-app.com/dashboard",
+            "/dashboard"
+          ]
         },
         "code": {
           "title": "HTTP Redirect Status Code",

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -246,9 +246,9 @@
       "properties": {
         "to": {
           "title": "Redirect to",
-          "description": "Set the redirect target. Must be a http/https URL.",
+          "description": "Set the redirect target. Can either be a http/https URL, or a relative URL.",
           "type": "string",
-          "format": "uri-relative",
+          "format": "uri-reference",
           "examples": [
             "https://my-app.com/dashboard",
             "https://my-app.com/dashboard",

--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -33,12 +33,21 @@ func TestErrorRedirect(t *testing.T) {
 			assert      func(t *testing.T, recorder *httptest.ResponseRecorder)
 		}{
 			{
-				d:          "should redirect with 302 - absolute",
+				d:          "should redirect with 302 - absolute (HTTP)",
 				givenError: &herodot.ErrNotFound,
 				config:     `{"to":"http://test/test"}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 302, rw.Code)
 					assert.Equal(t, "http://test/test", rw.Header().Get("Location"))
+				},
+			},
+			{
+				d:          "should redirect with 302 - absolute (HTTPS)",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"https://test/test"}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 302, rw.Code)
+					assert.Equal(t, "https://test/test", rw.Header().Get("Location"))
 				},
 			},
 			{
@@ -51,12 +60,21 @@ func TestErrorRedirect(t *testing.T) {
 				},
 			},
 			{
-				d:          "should redirect with 301 - absolute",
+				d:          "should redirect with 301 - absolute (HTTP)",
 				givenError: &herodot.ErrNotFound,
 				config:     `{"to":"http://test/test","code":301}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 301, rw.Code)
 					assert.Equal(t, "http://test/test", rw.Header().Get("Location"))
+				},
+			},
+			{
+				d:          "should redirect with 301 - absolute (HTTPS)",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"https://test/test","code":301}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 301, rw.Code)
+					assert.Equal(t, "https://test/test", rw.Header().Get("Location"))
 				},
 			},
 			{

--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -33,7 +33,7 @@ func TestErrorRedirect(t *testing.T) {
 			assert      func(t *testing.T, recorder *httptest.ResponseRecorder)
 		}{
 			{
-				d:          "should redirect with 302",
+				d:          "should redirect with 302 - absolute",
 				givenError: &herodot.ErrNotFound,
 				config:     `{"to":"http://test/test"}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
@@ -42,12 +42,30 @@ func TestErrorRedirect(t *testing.T) {
 				},
 			},
 			{
-				d:          "should redirect with 301",
+				d:          "should redirect with 302 - relative",
 				givenError: &herodot.ErrNotFound,
-				config:     `{"to":"http://test/test","code":301}`,
+				config:     `{"to":"/test"}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 302, rw.Code)
+					assert.Equal(t, "/test", rw.Header().Get("Location"))
+				},
+			},
+			{
+				d:          "should redirect with 301 - absolute",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"/test","code":301}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 301, rw.Code)
-					assert.Equal(t, "http://test/test", rw.Header().Get("Location"))
+					assert.Equal(t, "/test", rw.Header().Get("Location"))
+				},
+			},
+			{
+				d:          "should redirect with 301 - relative",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"/test"}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 302, rw.Code)
+					assert.Equal(t, "/test", rw.Header().Get("Location"))
 				},
 			},
 		} {

--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -53,10 +53,10 @@ func TestErrorRedirect(t *testing.T) {
 			{
 				d:          "should redirect with 301 - absolute",
 				givenError: &herodot.ErrNotFound,
-				config:     `{"to":"/test","code":301}`,
+				config:     `{"to":"http://test/test","code":301}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 301, rw.Code)
-					assert.Equal(t, "/test", rw.Header().Get("Location"))
+					assert.Equal(t, "http://test/test", rw.Header().Get("Location"))
 				},
 			},
 			{

--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -62,9 +62,9 @@ func TestErrorRedirect(t *testing.T) {
 			{
 				d:          "should redirect with 301 - relative",
 				givenError: &herodot.ErrNotFound,
-				config:     `{"to":"/test"}`,
+				config:     `{"to":"/test", "code":301}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
-					assert.Equal(t, 302, rw.Code)
+					assert.Equal(t, 301, rw.Code)
 					assert.Equal(t, "/test", rw.Header().Get("Location"))
 				},
 			},


### PR DESCRIPTION
This is related to https://github.com/ory/kratos/pull/617

Similar to that of the original PR, we are running a multi-domain setup for our cluster(s).

The original PR for kratos greatly assisted with our deployment process. 

However, we are also utilising oathkeeper as a proxy in our cluster, and as `.oathkeeper.yml`'s errors:handlers:redirect:config:to only allows absolute URIs, we have had to deploy an instance of oathkeeper per domain.

This PR aims to allow for a relative error redirect URL in the oathkeeper configuration file.

I have not built a container to test this yet as I am currently still on leave, but once I'm back in the office I will build it to test directly - it's my first time submitting a PR here, so I would like to get some eyes on it :)


## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
