### PR TITLE
feat: Log invalid credentials on info level instead of error/warning

### DIFF
--- a/api/decision.go
+++ b/api/decision.go
@@ -110,7 +110,7 @@ func (h *DecisionHandler) decisions(w http.ResponseWriter, r *http.Request) {
 		h.r.Logger().WithError(err).
 			WithFields(fields).
 			WithField("granted", false).
-			Warn("Access request denied")
+			Info("Access request denied")
 
 		h.r.ProxyRequestHandler().HandleError(w, r, rl, err)
 		return

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -225,6 +225,7 @@ func (d *RequestHandler) HandleRequest(r *http.Request, rl *rule.Rule) (session 
 			// return nil
 			case helper.ErrUnauthorized.ErrorField:
 				d.r.Logger().Info(err)
+				return nil, err
 			default:
 				d.r.Logger().WithError(err).
 					WithFields(fields).
@@ -244,15 +245,11 @@ func (d *RequestHandler) HandleRequest(r *http.Request, rl *rule.Rule) (session 
 
 	if !found {
 		err := errors.WithStack(helper.ErrUnauthorized)
-		// found will only be true if an authenticator was found AND authorisation was granted so check
-		// that this wasn't just a problem with the request
-		if err.Error() != helper.ErrUnauthorized.ErrorField {
-			d.r.Logger().WithError(err).
-				WithFields(fields).
-				WithField("granted", false).
-				WithField("reason_id", "authentication_handler_no_match").
-				Warn("No authentication handler was responsible for handling the authentication request")
-		}
+		d.r.Logger().WithError(err).
+			WithFields(fields).
+			WithField("granted", false).
+			WithField("reason_id", "authentication_handler_no_match").
+			Warn("No authentication handler was responsible for handling the authentication request")
 		return nil, err
 	}
 


### PR DESCRIPTION
## Related issue
[#505 ](https://github.com/ory/oathkeeper/issues/505)

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
Invalid credentials or a malformed request is really the client's responsibility and should therefore not be considered an error.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

In the best of worlds I would also like to not have an error logged in the scenario where e.g. the token was expired:

``` 
level=error msg=An error occurred while handling a request code=401 debug= details=map[] error=The request could not be authorized reason= request-id=194689ec322a9ad1a71ae5 ...
```

but that seems to be rather a large change. Is there any easy way to accomplish this?

