### PR TITLE
fix: Added more tests in error_redirect_test.go

### DIFF
--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -43,12 +43,34 @@ func TestErrorRedirect(t *testing.T) {
 				},
 			},
 			{
+				d:          "redirect with 302 should contain a return_to param - absolute (HTTP) ",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"http://test/signin","return_to_query_param":"return_to"}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 302, rw.Code)
+					location, err := url.Parse(rw.Header().Get("Location"))
+					require.NoError(t, err)
+					assert.Equal(t, "/test", location.Query().Get("return_to"))
+				},
+			},
+			{
 				d:          "should redirect with 302 - absolute (HTTPS)",
 				givenError: &herodot.ErrNotFound,
 				config:     `{"to":"https://test/test"}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 302, rw.Code)
 					assert.Equal(t, "https://test/test", rw.Header().Get("Location"))
+				},
+			},
+			{
+				d:          "redirect with 302 should contain a return_to param - absolute (HTTPS) ",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"https://test/signin","return_to_query_param":"return_to"}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 302, rw.Code)
+					location, err := url.Parse(rw.Header().Get("Location"))
+					require.NoError(t, err)
+					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},
 			{
@@ -61,12 +83,34 @@ func TestErrorRedirect(t *testing.T) {
 				},
 			},
 			{
+				d:          "redirect with 302 should contain a return_to param - relative ",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"/test/signin","return_to_query_param":"return_to"}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 302, rw.Code)
+					location, err := url.Parse(rw.Header().Get("Location"))
+					require.NoError(t, err)
+					assert.Equal(t, "/test", location.Query().Get("return_to"))
+				},
+			},
+			{
 				d:          "should redirect with 301 - absolute (HTTP)",
 				givenError: &herodot.ErrNotFound,
 				config:     `{"to":"http://test/test","code":301}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
 					assert.Equal(t, 301, rw.Code)
 					assert.Equal(t, "http://test/test", rw.Header().Get("Location"))
+				},
+			},
+			{
+				d:          "redirect with 301 should contain a return_to param - absolute (HTTP) ",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"http://test/signin","return_to_query_param":"return_to","code":301}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 301, rw.Code)
+					location, err := url.Parse(rw.Header().Get("Location"))
+					require.NoError(t, err)
+					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},
 			{
@@ -79,6 +123,17 @@ func TestErrorRedirect(t *testing.T) {
 				},
 			},
 			{
+				d:          "redirect with 301 should contain a return_to param - absolute (HTTPS) ",
+				givenError: &herodot.ErrNotFound,
+				config:     `{"to":"https://test/signin","return_to_query_param":"return_to","code":301}`,
+				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
+					assert.Equal(t, 301, rw.Code)
+					location, err := url.Parse(rw.Header().Get("Location"))
+					require.NoError(t, err)
+					assert.Equal(t, "/test", location.Query().Get("return_to"))
+				},
+			},
+			{
 				d:          "should redirect with 301 - relative",
 				givenError: &herodot.ErrNotFound,
 				config:     `{"to":"/test", "code":301}`,
@@ -88,11 +143,11 @@ func TestErrorRedirect(t *testing.T) {
 				},
 			},
 			{
-				d:          "should redirect with return_to param",
+				d:          "redirect with 301 should contain a return_to param - relative ",
 				givenError: &herodot.ErrNotFound,
-				config:     `{"to":"http://test/signin","return_to_query_param":"return_to"}`,
+				config:     `{"to":"/test/signin","return_to_query_param":"return_to","code":301}`,
 				assert: func(t *testing.T, rw *httptest.ResponseRecorder) {
-					assert.Equal(t, 302, rw.Code)
+					assert.Equal(t, 301, rw.Code)
 					location, err := url.Parse(rw.Header().Get("Location"))
 					require.NoError(t, err)
 					assert.Equal(t, "/test", location.Query().Get("return_to"))

--- a/pipeline/errors/error_redirect_test.go
+++ b/pipeline/errors/error_redirect_test.go
@@ -50,6 +50,7 @@ func TestErrorRedirect(t *testing.T) {
 					assert.Equal(t, 302, rw.Code)
 					location, err := url.Parse(rw.Header().Get("Location"))
 					require.NoError(t, err)
+					assert.Equal(t, "http://test/signin?return_to=%2Ftest", rw.Header().Get("Location"))
 					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},
@@ -70,6 +71,7 @@ func TestErrorRedirect(t *testing.T) {
 					assert.Equal(t, 302, rw.Code)
 					location, err := url.Parse(rw.Header().Get("Location"))
 					require.NoError(t, err)
+					assert.Equal(t, "https://test/signin?return_to=%2Ftest", rw.Header().Get("Location"))
 					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},
@@ -90,6 +92,7 @@ func TestErrorRedirect(t *testing.T) {
 					assert.Equal(t, 302, rw.Code)
 					location, err := url.Parse(rw.Header().Get("Location"))
 					require.NoError(t, err)
+					assert.Equal(t, "/test/signin?return_to=%2Ftest", rw.Header().Get("Location"))
 					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},
@@ -110,6 +113,7 @@ func TestErrorRedirect(t *testing.T) {
 					assert.Equal(t, 301, rw.Code)
 					location, err := url.Parse(rw.Header().Get("Location"))
 					require.NoError(t, err)
+					assert.Equal(t, "http://test/signin?return_to=%2Ftest", rw.Header().Get("Location"))
 					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},
@@ -130,6 +134,7 @@ func TestErrorRedirect(t *testing.T) {
 					assert.Equal(t, 301, rw.Code)
 					location, err := url.Parse(rw.Header().Get("Location"))
 					require.NoError(t, err)
+					assert.Equal(t, "https://test/signin?return_to=%2Ftest", rw.Header().Get("Location"))
 					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},
@@ -150,6 +155,7 @@ func TestErrorRedirect(t *testing.T) {
 					assert.Equal(t, 301, rw.Code)
 					location, err := url.Parse(rw.Header().Get("Location"))
 					require.NoError(t, err)
+					assert.Equal(t, "/test/signin?return_to=%2Ftest", rw.Header().Get("Location"))
 					assert.Equal(t, "/test", location.Query().Get("return_to"))
 				},
 			},


### PR DESCRIPTION
## Proposed changes

With the inclusion of the new url_param config option to the redirect error handler, I have written a few additional test cases that tests it against all 3 types of redirect - HTTP redirect, HTTPS redirect, Relative URL redirect.

The diff is a little messy because I moved the original test case written by the contributor who added the feature and ordered it according to the type of redirect that was being tested.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
