### PR TITLE
feat: Forward original authorization header when using remote (json) authorizer

### DIFF
--- a/pipeline/authz/remote.go
+++ b/pipeline/authz/remote.go
@@ -65,6 +65,7 @@ func (a *AuthorizerRemote) Authorize(r *http.Request, session *authn.Authenticat
 		return errors.WithStack(err)
 	}
 	req.Header.Add("Content-Type", r.Header.Get("Content-Type"))
+	req.Header.Add("Authorization", r.Header.Get("Authorization"))
 
 	for hdr, templateString := range c.Headers {
 		var tmpl *template.Template

--- a/pipeline/authz/remote.go
+++ b/pipeline/authz/remote.go
@@ -65,7 +65,10 @@ func (a *AuthorizerRemote) Authorize(r *http.Request, session *authn.Authenticat
 		return errors.WithStack(err)
 	}
 	req.Header.Add("Content-Type", r.Header.Get("Content-Type"))
-	req.Header.Add("Authorization", r.Header.Get("Authorization"))
+	authz := r.Header.Get("Authorization")
+	if authz != "" {
+		req.Header.Add("Authorization", authz)
+	}
 
 	for hdr, templateString := range c.Headers {
 		var tmpl *template.Template

--- a/pipeline/authz/remote_json.go
+++ b/pipeline/authz/remote_json.go
@@ -84,7 +84,10 @@ func (a *AuthorizerRemoteJSON) Authorize(r *http.Request, session *authn.Authent
 		return errors.WithStack(err)
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", r.Header.Get("Authorization"))
+	authz := r.Header.Get("Authorization")
+	if authz != "" {
+		req.Header.Add("Authorization", authz)
+	}
 
 	res, err := a.client.Do(req)
 	if err != nil {

--- a/pipeline/authz/remote_json.go
+++ b/pipeline/authz/remote_json.go
@@ -53,7 +53,7 @@ func (a *AuthorizerRemoteJSON) GetID() string {
 }
 
 // Authorize implements the Authorizer interface.
-func (a *AuthorizerRemoteJSON) Authorize(_ *http.Request, session *authn.AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
+func (a *AuthorizerRemoteJSON) Authorize(r *http.Request, session *authn.AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
 	c, err := a.Config(config)
 	if err != nil {
 		return err
@@ -84,6 +84,7 @@ func (a *AuthorizerRemoteJSON) Authorize(_ *http.Request, session *authn.Authent
 		return errors.WithStack(err)
 	}
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", r.Header.Get("Authorization"))
 
 	res, err := a.client.Do(req)
 	if err != nil {

--- a/pipeline/authz/remote_json_test.go
+++ b/pipeline/authz/remote_json_test.go
@@ -87,6 +87,8 @@ func TestAuthorizerRemoteJSONAuthorize(t *testing.T) {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					assert.Contains(t, r.Header, "Content-Type")
 					assert.Contains(t, r.Header["Content-Type"], "application/json")
+					assert.Contains(t, r.Header, "Authorization")
+					assert.Contains(t, r.Header["Authorization"], "Bearer token")
 					body, err := ioutil.ReadAll(r.Body)
 					require.NoError(t, err)
 					assert.Equal(t, string(body), "{}")
@@ -139,7 +141,11 @@ func TestAuthorizerRemoteJSONAuthorize(t *testing.T) {
 
 			p := configuration.NewViperProvider(logrusx.New("", ""))
 			a := NewAuthorizerRemoteJSON(p)
-			if err := a.Authorize(&http.Request{}, tt.session, tt.config, &rule.Rule{}); (err != nil) != tt.wantErr {
+			if err := a.Authorize(&http.Request{
+				Header: map[string][]string{
+					"Authorization": {"Bearer token"},
+				},
+			}, tt.session, tt.config, &rule.Rule{}); (err != nil) != tt.wantErr {
 				t.Errorf("Authorize() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pipeline/authz/remote_test.go
+++ b/pipeline/authz/remote_test.go
@@ -92,8 +92,7 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					assert.Contains(t, r.Header, "Content-Type")
 					assert.Contains(t, r.Header["Content-Type"], "text/plain")
-					assert.Contains(t, r.Header, "Authorization")
-					assert.Contains(t, r.Header["Authorization"], "Bearer token")
+					assert.Nil(t, r.Header["Authorization"])
 					body, err := ioutil.ReadAll(r.Body)
 					require.NoError(t, err)
 					assert.Equal(t, "testtest", string(body))
@@ -147,9 +146,8 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 			a := NewAuthorizerRemote(p)
 			r := &http.Request{
 				Header: map[string][]string{
-					"Content-Type":  {"text/plain"},
-					"User-Agent":    {"Fancy Browser 5.1"},
-					"Authorization": {"Bearer token"},
+					"Content-Type": {"text/plain"},
+					"User-Agent":   {"Fancy Browser 5.1"},
 				},
 			}
 			if tt.body != "" {

--- a/pipeline/authz/remote_test.go
+++ b/pipeline/authz/remote_test.go
@@ -92,6 +92,8 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					assert.Contains(t, r.Header, "Content-Type")
 					assert.Contains(t, r.Header["Content-Type"], "text/plain")
+					assert.Contains(t, r.Header, "Authorization")
+					assert.Contains(t, r.Header["Authorization"], "Bearer token")
 					body, err := ioutil.ReadAll(r.Body)
 					require.NoError(t, err)
 					assert.Equal(t, "testtest", string(body))
@@ -145,8 +147,9 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 			a := NewAuthorizerRemote(p)
 			r := &http.Request{
 				Header: map[string][]string{
-					"Content-Type": {"text/plain"},
-					"User-Agent":   {"Fancy Browser 5.1"},
+					"Content-Type":  {"text/plain"},
+					"User-Agent":    {"Fancy Browser 5.1"},
+					"Authorization": {"Bearer token"},
 				},
 			}
 			if tt.body != "" {


### PR DESCRIPTION
## Related issue

#528 

## Proposed changes

Sometimes the user/subject from the authSession is not enough when attempting to make informed access control decisions. This PR grants access to the authorization header from the original request when using the `remote` and `remote_json` authorizers so that additional information can be extracted from the token if need be.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

n/a