### PR TITLE
docs: fix typo in pipeline/error.md

### DIFF
--- a/docs/docs/pipeline/error.md
+++ b/docs/docs/pipeline/error.md
@@ -295,7 +295,7 @@ As discussed previously, if this configuration key is left empty, then all
 remote IPs will match!
 
 HTTP Requests that include one of the matching IP Addresses in the
-`X-Forwaded-For` HTTP Header, for example
+`X-Forwarded-For` HTTP Header, for example
 `X-Forwarded-For: 123.123.123.123, ..., 192.168.1.1, ...`, now match this error
 handler.
 

--- a/docs/versioned_docs/version-v0.37/pipeline/error.md
+++ b/docs/versioned_docs/version-v0.37/pipeline/error.md
@@ -296,7 +296,7 @@ As discussed previously, if this configuration key is left empty, then all
 remote IPs will match!
 
 HTTP Requests that include one of the matching IP Addresses in the
-`X-Forwaded-For` HTTP Header, for example
+`X-Forwarded-For` HTTP Header, for example
 `X-Forwarded-For: 123.123.123.123, ..., 192.168.1.1, ...`, now match this error
 handler.
 

--- a/docs/versioned_docs/version-v0.38/pipeline/error.md
+++ b/docs/versioned_docs/version-v0.38/pipeline/error.md
@@ -295,7 +295,7 @@ As discussed previously, if this configuration key is left empty, then all
 remote IPs will match!
 
 HTTP Requests that include one of the matching IP Addresses in the
-`X-Forwaded-For` HTTP Header, for example
+`X-Forwarded-For` HTTP Header, for example
 `X-Forwarded-For: 123.123.123.123, ..., 192.168.1.1, ...`, now match this error
 handler.
 


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes
Fixes a small typo in the pipeline/errors docs `X-Forwaded-For` -> `X-Forwarded-For`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
