### PR TITLE
chore: pass context through to external requests

### DIFF
--- a/pipeline/authn/authenticator_cookie_session.go
+++ b/pipeline/authn/authenticator_cookie_session.go
@@ -133,11 +133,12 @@ func forwardRequestToSessionStore(r *http.Request, checkSessionURL string, prese
 		reqUrl.Path = r.URL.Path
 	}
 
-	res, err := http.DefaultClient.Do(&http.Request{
+	req := http.Request{
 		Method: r.Method,
 		URL:    reqUrl,
 		Header: r.Header,
-	})
+	}
+	res, err := http.DefaultClient.Do(req.WithContext(r.Context()))
 	if err != nil {
 		return nil, helper.ErrForbidden.WithReason(err.Error()).WithTrace(err)
 	}

--- a/pipeline/authn/authenticator_oauth2_client_credentials.go
+++ b/pipeline/authn/authenticator_oauth2_client_credentials.go
@@ -119,7 +119,7 @@ func (a *AuthenticatorOAuth2ClientCredentials) Authenticate(r *http.Request, ses
 	}
 
 	token, err := c.Token(context.WithValue(
-		context.Background(),
+		r.Context(),
 		oauth2.HTTPClient,
 		c.Client,
 	))

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -155,7 +155,7 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session
 		}
 		// set/override the content-type header
 		introspectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		resp, err := a.client.Do(introspectReq)
+		resp, err := a.client.Do(introspectReq.WithContext(r.Context()))
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/pipeline/authz/keto_engine_acp_ory.go
+++ b/pipeline/authz/keto_engine_acp_ory.go
@@ -160,7 +160,7 @@ func (a *AuthorizerKetoEngineACPORY) Authorize(r *http.Request, session *authn.A
 	}
 	req.Header.Add("Content-Type", "application/json")
 
-	res, err := a.client.Do(req)
+	res, err := a.client.Do(req.WithContext(r.Context()))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pipeline/authz/remote.go
+++ b/pipeline/authz/remote.go
@@ -96,7 +96,7 @@ func (a *AuthorizerRemote) Authorize(r *http.Request, session *authn.Authenticat
 		req.Header.Set(hdr, headerValue.String())
 	}
 
-	res, err := a.client.Do(req)
+	res, err := a.client.Do(req.WithContext(r.Context()))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pipeline/authz/remote_json.go
+++ b/pipeline/authz/remote_json.go
@@ -89,7 +89,7 @@ func (a *AuthorizerRemoteJSON) Authorize(r *http.Request, session *authn.Authent
 		req.Header.Add("Authorization", authz)
 	}
 
-	res, err := a.client.Do(req)
+	res, err := a.client.Do(req.WithContext(r.Context()))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pipeline/mutate/mutator_hydrator.go
+++ b/pipeline/mutate/mutator_hydrator.go
@@ -206,7 +206,7 @@ func (a *MutatorHydrator) Mutate(r *http.Request, session *authn.AuthenticationS
 		client.Transport = httpx.NewResilientRoundTripper(a.client.Transport, maxRetryDelay, giveUpAfter)
 	}
 
-	res, err := client.Do(req)
+	res, err := client.Do(req.WithContext(r.Context()))
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
## Proposed changes

Pass the request context through so that authenticator etc requests have a proper parent context.

This makes sure that the tracing frameworks like Jaeger get the whole picture.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).