### PR TITLE
feat: Add support for  X-Forwarded-Proto header

### DIFF
--- a/api/decision.go
+++ b/api/decision.go
@@ -55,7 +55,7 @@ func (h *DecisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next
 	if len(r.URL.Path) >= len(DecisionPath) && r.URL.Path[:len(DecisionPath)] == DecisionPath {
 		r.URL.Scheme = "http"
 		r.URL.Host = r.Host
-		if r.TLS != nil {
+		if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
 			r.URL.Scheme = "https"
 		}
 		r.URL.Path = r.URL.Path[len(DecisionPath):]


### PR DESCRIPTION
## Related issue

https://github.com/ory/oathkeeper/issues/153 @aeneasr @Entrio

## Proposed changes

Add basic support for the header `X-Forwarded-Proto` which is normally set by an edge proxy like Ambassador, Istio, Traefik, Envoy, etc.

The proposed changes affect **only the decision API** as it is expected to be contacted by another proxy which will take care of SSL termination in most cases. It is important to notice that even if traffic reaching oathkeeper is plain HTTP, it does not mean that the traffic is not encrypted in transit. A good example is service mesh where Envoy or similar technologies (e.g. Linkerd) will secure traffic in transit through sidecars and mTLS.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

**The changes proposed here have been tested in our development environment and they work like a charm for both proper rules matching and redirection URLs.**