### PR TITLE
fix: Make glob patterns match only one path segment.

### DIFF
--- a/rule/engine_glob.go
+++ b/rule/engine_glob.go
@@ -100,5 +100,5 @@ func compileGlob(pattern string, delimiterStart, delimiterEnd rune) (glob.Glob, 
 	buffer.WriteString(glob.QuoteMeta(raw))
 
 	// Compile full regexp.
-	return glob.Compile(buffer.String())
+	return glob.Compile(buffer.String(), '.', '/')
 }

--- a/rule/engine_glob_test.go
+++ b/rule/engine_glob_test.go
@@ -242,6 +242,15 @@ func TestIsMatch(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
+		{
+			name: "asterisk matches only one path segment",
+			args: args{
+				pattern:      `http://example.com/<*>`,
+				matchAgainst: "http://example.com/foo/bar",
+			},
+			want:    false,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Related issue

Fixes #630.

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

This makes `/` also a separator for glob patterns as well as the presumably default value of `.`. This allows using `<*>` for matching only one path segment.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
