### PR TITLE
feat: Add http method into session.MatchContext

### DIFF
--- a/pipeline/authn/authenticator.go
+++ b/pipeline/authn/authenticator.go
@@ -49,6 +49,7 @@ type AuthenticationSession struct {
 type MatchContext struct {
 	RegexpCaptureGroups []string `json:"regexp_capture_groups"`
 	URL                 *url.URL `json:"url"`
+	Method              string   `json:"method"`
 }
 
 func (a *AuthenticationSession) SetHeader(key, val string) {

--- a/pipeline/authn/authenticator_test.go
+++ b/pipeline/authn/authenticator_test.go
@@ -50,6 +50,7 @@ func TestCopy(t *testing.T) {
 		MatchContext: authn.MatchContext{
 			RegexpCaptureGroups: []string{"a", "b"},
 			URL:                 x.ParseURLOrPanic("https://foo/bar"),
+			Method:              "GET",
 		},
 	}
 
@@ -59,10 +60,12 @@ func TestCopy(t *testing.T) {
 	copied.Header.Add("bazbar", "bar")
 	copied.MatchContext.URL.Host = "asdf"
 	copied.MatchContext.RegexpCaptureGroups[0] = "b"
+	copied.MatchContext.Method = "PUT"
 
 	assert.NotEqual(original.Subject, copied.Subject)
 	assert.NotEqual(original.Extra, copied.Extra)
 	assert.NotEqual(original.Header, copied.Header)
 	assert.NotEqual(original.MatchContext.URL.Host, copied.MatchContext.URL.Host)
 	assert.NotEqual(original.MatchContext.RegexpCaptureGroups, copied.MatchContext.RegexpCaptureGroups)
+	assert.NotEqual(original.MatchContext.Method, copied.MatchContext.Method)
 }

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -350,6 +350,7 @@ func (d *RequestHandler) InitializeAuthnSession(r *http.Request, rl *rule.Rule) 
 		session.MatchContext = authn.MatchContext{
 			RegexpCaptureGroups: values,
 			URL:                 r.URL,
+			Method:              r.Method,
 		}
 	}
 

--- a/proxy/request_handler_test.go
+++ b/proxy/request_handler_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 func newTestRequest(u string) *http.Request {
-	return &http.Request{URL: x.ParseURLOrPanic(u)}
+	return &http.Request{URL: x.ParseURLOrPanic(u), Method: "GET"}
 }
 
 func TestHandleError(t *testing.T) {
@@ -472,8 +472,7 @@ func TestInitializeSession(t *testing.T) {
 			r:                newTestRequest("http://localhost"),
 			matchingStrategy: configuration.Regexp,
 			ruleMatch: rule.Match{
-				URL:    "http://localhost",
-				Method: "GET",
+				URL: "http://localhost",
 			},
 			expectContext: authn.MatchContext{
 				RegexpCaptureGroups: []string{},

--- a/proxy/request_handler_test.go
+++ b/proxy/request_handler_test.go
@@ -472,11 +472,13 @@ func TestInitializeSession(t *testing.T) {
 			r:                newTestRequest("http://localhost"),
 			matchingStrategy: configuration.Regexp,
 			ruleMatch: rule.Match{
-				URL: "http://localhost",
+				URL:    "http://localhost",
+				Method: "GET",
 			},
 			expectContext: authn.MatchContext{
 				RegexpCaptureGroups: []string{},
 				URL:                 x.ParseURLOrPanic("http://localhost"),
+				Method:              "GET",
 			},
 		},
 		{
@@ -489,6 +491,7 @@ func TestInitializeSession(t *testing.T) {
 			expectContext: authn.MatchContext{
 				RegexpCaptureGroups: []string{"user"},
 				URL:                 x.ParseURLOrPanic("http://localhost/user"),
+				Method:              "GET",
 			},
 		},
 		{
@@ -501,6 +504,7 @@ func TestInitializeSession(t *testing.T) {
 			expectContext: authn.MatchContext{
 				RegexpCaptureGroups: []string{"user"},
 				URL:                 x.ParseURLOrPanic("http://localhost/user?param=test"),
+				Method:              "GET",
 			},
 		},
 		{
@@ -513,6 +517,7 @@ func TestInitializeSession(t *testing.T) {
 			expectContext: authn.MatchContext{
 				RegexpCaptureGroups: []string{"http", "user"},
 				URL:                 x.ParseURLOrPanic("http://localhost/user?param=test"),
+				Method:              "GET",
 			},
 		},
 		{
@@ -525,6 +530,7 @@ func TestInitializeSession(t *testing.T) {
 			expectContext: authn.MatchContext{
 				RegexpCaptureGroups: []string{},
 				URL:                 x.ParseURLOrPanic("http://localhost/user?param=test"),
+				Method:              "GET",
 			},
 		},
 	} {


### PR DESCRIPTION
## Related issue

#625

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

The HTTP Request method becomes available in `MatchContext`, so that it may be used in templates.

## Checklist

<!-
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

