### PR TITLE
feat: Add support for requesting an audience to the OAuth2 Introspection pr…

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -696,6 +696,15 @@
               "title": "OAuth 2.0 Token URL",
               "description": "The OAuth 2.0 Token Endpoint where the OAuth 2.0 Client Credentials Grant will be performed.\n\n>If pre-authorization is enabled, this value is required."
             },
+            "audience": {
+              "type": "string",
+              "title": "OAuth 2.0 Audience",
+              "description": "The OAuth 2.0 Audience to be requested during the OAuth 2.0 Client Credentials Grant.",
+              "examples": [
+                "http://www.example.com",
+                "services:my-app"
+              ]
+            },
             "scope": {
               "type": "array",
               "items": {

--- a/.schemas/authenticators.oauth2_introspection.schema.json
+++ b/.schemas/authenticators.oauth2_introspection.schema.json
@@ -61,6 +61,15 @@
               "title": "OAuth 2.0 Token URL",
               "description": "The OAuth 2.0 Token Endpoint where the OAuth 2.0 Client Credentials Grant will be performed.\n\n>If pre-authorization is enabled, this value is required."
             },
+            "audience": {
+              "type": "string",
+              "title": "OAuth 2.0 Audience",
+              "description": "The OAuth 2.0 Audience to be requested during the OAuth 2.0 Client Credentials Grant.",
+              "examples": [
+                "http://www.example.com",
+                "services:my-app"
+              ]
+            },
             "scope": {
               "type": "array",
               "items": {

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -561,6 +561,15 @@
               "title": "OAuth 2.0 Token URL",
               "description": "The OAuth 2.0 Token Endpoint where the OAuth 2.0 Client Credentials Grant will be performed.\n\n>If pre-authorization is enabled, this value is required."
             },
+            "audience": {
+              "type": "string",
+              "title": "OAuth 2.0 Audience",
+              "description": "The OAuth 2.0 Audience to be requested during the OAuth 2.0 Client Credentials Grant.",
+              "examples": [
+                "http://www.example.com",
+                "services:my-app"
+              ]
+            },
             "scope": {
               "type": "array",
               "items": {

--- a/docs/docs/pipeline/authn.md
+++ b/docs/docs/pipeline/authn.md
@@ -592,6 +592,8 @@ was granted the requested scope.
     to be used for the OAuth 2.0 Client Credentials Grant.
   - `token_url` (string, required if enabled) - The OAuth 2.0 Token Endpoint
     where the OAuth 2.0 Client Credentials Grant will be performed.
+  - `audience` (string, optional) - The OAuth 2.0 Audience to be requested
+    during the OAuth 2.0 Client Credentials Grant.
   - `scope` ([]string, optional) - The OAuth 2.0 Scope to be requested during
     the OAuth 2.0 Client Credentials Grant.
 - `token_from` (object, optional) - The location of the bearer token. If not

--- a/driver/configuration/provider_viper_public_test.go
+++ b/driver/configuration/provider_viper_public_test.go
@@ -52,7 +52,7 @@ func TestPipelineConfig(t *testing.T) {
 		p := setup(t)
 
 		require.NoError(t, p.PipelineConfig("authenticators", "oauth2_introspection", nil, &res))
-		assert.JSONEq(t, `{"cache":{"enabled":false},"introspection_url":"https://override/path","pre_authorization":{"client_id":"some_id","client_secret":"some_secret","enabled":true,"scope":["foo","bar"],"token_url":"https://my-website.com/oauth2/token"},"retry":{"max_delay":"100ms", "give_up_after":"1s"},"scope_strategy":"exact"}`, string(res), "%s", res)
+		assert.JSONEq(t, `{"cache":{"enabled":false},"introspection_url":"https://override/path","pre_authorization":{"client_id":"some_id","client_secret":"some_secret","enabled":true,"audience":"some_audience","scope":["foo","bar"],"token_url":"https://my-website.com/oauth2/token"},"retry":{"max_delay":"100ms", "give_up_after":"1s"},"scope_strategy":"exact"}`, string(res), "%s", res)
 
 		// Cleanup
 		require.NoError(t, os.Setenv("AUTHENTICATORS_OAUTH2_INTROSPECTION_CONFIG_INTROSPECTION_URL", ""))
@@ -308,6 +308,7 @@ func TestViperProvider(t *testing.T) {
 				ClientID:     "some_id",
 				ClientSecret: "some_secret",
 				TokenURL:     "https://my-website.com/oauth2/token",
+				Audience:     "some_audience",
 				Scope:        []string{"foo", "bar"},
 				Enabled:      true,
 			}, config.PreAuth)

--- a/internal/config/.oathkeeper.yaml
+++ b/internal/config/.oathkeeper.yaml
@@ -217,6 +217,9 @@ authenticators:
         # REQUIRED IF ENABLED - The OAuth 2.0 Client Secret to be used for the OAuth 2.0 Client Credentials Grant.
         client_secret: some_secret
 
+        # The OAuth 2.0 Audience to be requested during the OAuth 2.0 Client Credentials Grant.
+        audience: some_audience
+
         # The OAuth 2.0 Scope to be requested during the OAuth 2.0 Client Credentials Grant.
         scope:
           - foo

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -42,6 +42,7 @@ type AuthenticatorOAuth2IntrospectionPreAuthConfiguration struct {
 	Enabled      bool     `json:"enabled"`
 	ClientID     string   `json:"client_id"`
 	ClientSecret string   `json:"client_secret"`
+	Audience     string   `json:"target_audience"`
 	Scope        []string `json:"scope"`
 	TokenURL     string   `json:"token_url"`
 }
@@ -265,11 +266,18 @@ func (a *AuthenticatorOAuth2Introspection) Config(config json.RawMessage) (*Auth
 	var rt http.RoundTripper
 
 	if c.PreAuth != nil && c.PreAuth.Enabled {
+		var ep url.Values
+
+		if c.PreAuth.Audience != "" {
+			ep = url.Values{"audience": {c.PreAuth.Audience}}
+		}
+
 		rt = (&clientcredentials.Config{
-			ClientID:     c.PreAuth.ClientID,
-			ClientSecret: c.PreAuth.ClientSecret,
-			Scopes:       c.PreAuth.Scope,
-			TokenURL:     c.PreAuth.TokenURL,
+			ClientID:       c.PreAuth.ClientID,
+			ClientSecret:   c.PreAuth.ClientSecret,
+			Scopes:         c.PreAuth.Scope,
+			EndpointParams: ep,
+			TokenURL:       c.PreAuth.TokenURL,
 		}).Client(context.Background()).Transport
 	}
 

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -42,7 +42,7 @@ type AuthenticatorOAuth2IntrospectionPreAuthConfiguration struct {
 	Enabled      bool     `json:"enabled"`
 	ClientID     string   `json:"client_id"`
 	ClientSecret string   `json:"client_secret"`
-	Audience     string   `json:"target_audience"`
+	Audience     string   `json:"audience"`
 	Scope        []string `json:"scope"`
 	TokenURL     string   `json:"token_url"`
 }


### PR DESCRIPTION
## Related issue

#677

## Proposed changes

Adding an option to request an audience, and adding the audience to the preauth request.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
