### PR TITLE
feat: additional JWT auth debug information

### DIFF
--- a/pipeline/authn/authenticator_jwt.go
+++ b/pipeline/authn/authenticator_jwt.go
@@ -2,10 +2,7 @@ package authn
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"sort"
-	"strings"
 
 	"github.com/form3tech-oss/jwt-go"
 	"github.com/ory/go-convenience/jwtx"
@@ -121,19 +118,9 @@ func (a *AuthenticatorJWT) tryEnrichResultErr(token string, err *herodot.Default
 	if !ok {
 		return err
 	}
-	var claimKeyPairs []string
-	for k, v := range claims {
-		// print just root content of the JWT, skip nested objects
-		if _, ok := v.(map[string]interface{}); ok {
-			continue
-		}
-		if floatVal, ok := v.(float64); ok && v == float64(int64(floatVal)) {
-			// JWT JSON decode deserializes numbers as float64
-			claimKeyPairs = append(claimKeyPairs, fmt.Sprintf("%s=%v", k, int64(floatVal)))
-		} else {
-			claimKeyPairs = append(claimKeyPairs, fmt.Sprintf("%s=%v", k, v))
-		}
+	jsonVal, err2 := json.Marshal(claims)
+	if err2 != nil {
+		return err
 	}
-	sort.Strings(claimKeyPairs)
-	return err.WithDetail("jwt_claims", fmt.Sprintf("%+v", strings.Join(claimKeyPairs, ", ")))
+	return err.WithDetail("jwt_claims", string(jsonVal))
 }

--- a/pipeline/authn/authenticator_jwt.go
+++ b/pipeline/authn/authenticator_jwt.go
@@ -3,13 +3,13 @@ package authn
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/form3tech-oss/jwt-go"
-	"github.com/pkg/errors"
 	"net/http"
 	"strings"
 
+	"github.com/form3tech-oss/jwt-go"
 	"github.com/ory/go-convenience/jwtx"
 	"github.com/ory/herodot"
+	"github.com/pkg/errors"
 
 	"github.com/ory/oathkeeper/credentials"
 	"github.com/ory/oathkeeper/driver/configuration"

--- a/pipeline/authn/authenticator_jwt.go
+++ b/pipeline/authn/authenticator_jwt.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/form3tech-oss/jwt-go"
@@ -133,5 +134,6 @@ func (a *AuthenticatorJWT) tryEnrichResultErr(token string, err *herodot.Default
 			claimKeyPairs = append(claimKeyPairs, fmt.Sprintf("%s=%v", k, v))
 		}
 	}
+	sort.Strings(claimKeyPairs)
 	return err.WithDetail("jwt_claims", fmt.Sprintf("%+v", strings.Join(claimKeyPairs, ", ")))
 }

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -327,7 +327,7 @@ func TestAuthenticatorJWT(t *testing.T) {
 				extraErrAssert: func(err error) {
 					defaultError := err.(*herodot.DefaultError)
 					require.Error(t, defaultError)
-					require.Equal(t, fmt.Sprintf("exp=%d, scope=[scope-1 scope-2], sub=sub", now.Add(time.Hour).Unix()), defaultError.DetailsField["jwt_claims"])
+					require.Equal(t, fmt.Sprintf("{\"exp\":%v,\"realm_access\":{\"roles\":[\"role-1\",\"role-2\"]},\"scope\":[\"scope-1\",\"scope-2\"],\"sub\":\"sub\"}", now.Add(time.Hour).Unix()), defaultError.DetailsField["jwt_claims"])
 				},
 			},
 		} {

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -74,6 +74,7 @@ func TestAuthenticatorJWT(t *testing.T) {
 			expectExactErr error
 			expectCode     int
 			expectSess     *AuthenticationSession
+			extraErrAssert func(err error)
 		}{
 			{
 				d:         "should fail because no payloads",
@@ -308,6 +309,27 @@ func TestAuthenticatorJWT(t *testing.T) {
 				expectErr:  true,
 				expectCode: 401,
 			},
+			{
+				d: "failed JWT authorization results in error with jwt_claims in DetailsField",
+				r: &http.Request{Header: http.Header{"Authorization": []string{"bearer " + gen(keys[2], jwt.MapClaims{
+					"sub":   "sub",
+					"exp":   now.Add(time.Hour).Unix(),
+					"scope": []string{"scope-1", "scope-2"},
+					"realm_access": map[string][]string{
+						"roles": {
+							"role-1",
+							"role-2",
+						},
+					},
+				})}}},
+				config:    `{"required_scope": ["scope-1", "scope-2", "scope-3"]}`,
+				expectErr: true,
+				extraErrAssert: func(err error) {
+					defaultError := err.(*herodot.DefaultError)
+					require.Error(t, defaultError)
+					require.Equal(t, fmt.Sprintf("exp=%d, scope=[scope-1 scope-2], sub=sub", now.Add(time.Hour).Unix()), defaultError.DetailsField["jwt_claims"])
+				},
+			},
 		} {
 			t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
 				if tc.setup != nil {
@@ -324,6 +346,9 @@ func TestAuthenticatorJWT(t *testing.T) {
 					}
 					if tc.expectExactErr != nil {
 						assert.EqualError(t, err, tc.expectExactErr.Error())
+					}
+					if tc.extraErrAssert != nil {
+						tc.extraErrAssert(err)
 					}
 				} else {
 					require.NoError(t, err, "%#v", errors.Cause(err))


### PR DESCRIPTION
JWT Claims added to error details field. Closes #668

## Related issue
#668 @aeneasr 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes
Added `jwt_claims` to the result error details field in cases where the JWT Authenticator failed to authorize the provided JWT.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
