### PR TITLE
fix: update shebangs to use bash from /usr/bin/env instead of /bin/ for better portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 export GO111MODULE := on
 export PATH := .bin:${PATH}

--- a/scripts/run-format.sh
+++ b/scripts/run-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/run-gensdk.sh
+++ b/scripts/run-gensdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/run-genswag.sh
+++ b/scripts/run-genswag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/run-mock.sh
+++ b/scripts/run-mock.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/test-format.sh
+++ b/scripts/test-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/test/reload/run.sh
+++ b/test/reload/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 


### PR DESCRIPTION
Fixes #693

## Proposed changes

As said in the issue, on some systems, bash doesn't lie in /bin/, but in other places, like /usr/local/bin/bash (FreeBSD) or even in unpredictable paths like /nix/store/y0vp7qcjz02rsgawlgmx8ilbh2wimcg5-system-path/bin/bash (NixOS).
It makes the installation impossible without modifying the Makefile.
This PR replaces all `/bin/bash` shebangs with `/usr/bin/env bash`, improving portability.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

I consider `/usr/bin env` to be more portable, because env is more likely to be in `/usr/bin` than bash is to be in `/bin`.