### PR TITLE
docs: specify public keys only

### DIFF
--- a/docs/docs/reference/api.mdx
+++ b/docs/docs/reference/api.mdx
@@ -40,7 +40,7 @@ Accept: application/json
 
 ```
 
-This endpoint returns cryptographic keys that are required to, for example,
+This endpoint returns cryptographic public keys that are required to, for example,
 verify signatures of ID Tokens.
 
 #### Responses
@@ -78,22 +78,11 @@ Status Code **500**
   "keys": [
     {
       "alg": "string",
-      "crv": "string",
-      "d": "string",
-      "dp": "string",
-      "dq": "string",
       "e": "string",
-      "k": "string",
       "kid": "string",
       "kty": "string",
       "n": "string",
-      "p": "string",
-      "q": "string",
-      "qi": "string",
       "use": "string",
-      "x": "string",
-      "x5c": ["string"],
-      "y": "string"
     }
   ]
 }


### PR DESCRIPTION
the .well-known/jwks.json endpoint should (and does) only return the public keys of the JWKS (as described here: https://www.ory.sh/oathkeeper/docs/pipeline/mutator#configuration-1)

## Proposed changes

clarifying the data delivered at the .well-known/jwks.json endoint

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).