### PR TITLE
chore: update repository template to c704df8e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Table of Contents**
 
 - [Unreleased (2021-04-06)](#unreleased-2021-04-06)
@@ -45,24 +46,24 @@
   - [0.38.1-beta.1 (2020-05-08)](#0381-beta1-2020-05-08)
     - [Bug Fixes](#bug-fixes-8)
 - [0.38.0-beta.2 (2020-05-07)](#0380-beta2-2020-05-07)
-    - [Bug Fixes](#bug-fixes-9)
-    - [Code Refactoring](#code-refactoring)
-    - [Documentation](#documentation-6)
-    - [Features](#features-7)
+  - [Bug Fixes](#bug-fixes-9)
+  - [Code Refactoring](#code-refactoring)
+  - [Documentation](#documentation-6)
+  - [Features](#features-7)
   - [0.37.1-beta.1 (2020-04-03)](#0371-beta1-2020-04-03)
     - [Documentation](#documentation-7)
 - [0.37.0-beta.1 (2020-04-02)](#0370-beta1-2020-04-02)
-    - [Bug Fixes](#bug-fixes-10)
-    - [Documentation](#documentation-8)
-    - [Features](#features-8)
-    - [BREAKING CHANGES](#breaking-changes)
+  - [Bug Fixes](#bug-fixes-10)
+  - [Documentation](#documentation-8)
+  - [Features](#features-8)
+  - [BREAKING CHANGES](#breaking-changes)
 - [0.36.0-beta.4 (2020-02-14)](#0360-beta4-2020-02-14)
-    - [Bug Fixes](#bug-fixes-11)
-    - [Documentation](#documentation-9)
+  - [Bug Fixes](#bug-fixes-11)
+  - [Documentation](#documentation-9)
 - [0.36.0-beta.1 (2020-02-05)](#0360-beta1-2020-02-05)
-    - [Documentation](#documentation-10)
-    - [Features](#features-9)
-    - [Unclassified](#unclassified-4)
+  - [Documentation](#documentation-10)
+  - [Features](#features-9)
+  - [Unclassified](#unclassified-4)
   - [0.35.5-beta.2 (2020-01-31)](#0355-beta2-2020-01-31)
     - [Unclassified](#unclassified-5)
   - [0.35.5-beta.1 (2020-01-27)](#0355-beta1-2020-01-27)
@@ -75,30 +76,30 @@
   - [0.35.1-beta.1 (2020-01-14)](#0351-beta1-2020-01-14)
     - [Unclassified](#unclassified-9)
 - [0.35.0-beta.1 (2020-01-13)](#0350-beta1-2020-01-13)
-    - [Documentation](#documentation-12)
-    - [Unclassified](#unclassified-10)
+  - [Documentation](#documentation-12)
+  - [Unclassified](#unclassified-10)
 - [0.34.0-beta.1 (2019-12-26)](#0340-beta1-2019-12-26)
-    - [Documentation](#documentation-13)
-    - [Unclassified](#unclassified-11)
+  - [Documentation](#documentation-13)
+  - [Unclassified](#unclassified-11)
   - [0.33.1-beta.1 (2019-12-18)](#0331-beta1-2019-12-18)
     - [Documentation](#documentation-14)
     - [Unclassified](#unclassified-12)
 - [0.33.0-beta.1 (2019-12-16)](#0330-beta1-2019-12-16)
-    - [Documentation](#documentation-15)
-    - [Unclassified](#unclassified-13)
+  - [Documentation](#documentation-15)
+  - [Unclassified](#unclassified-13)
   - [0.32.1-beta.1 (2019-10-30)](#0321-beta1-2019-10-30)
     - [Documentation](#documentation-16)
     - [Unclassified](#unclassified-14)
 - [0.32.0-beta.1 (2019-10-20)](#0320-beta1-2019-10-20)
-    - [Documentation](#documentation-17)
+  - [Documentation](#documentation-17)
 - [0.31.0-beta.1 (2019-10-20)](#0310-beta1-2019-10-20)
-    - [Documentation](#documentation-18)
-    - [Unclassified](#unclassified-15)
+  - [Documentation](#documentation-18)
+  - [Unclassified](#unclassified-15)
 - [0.19.0-beta.1 (2019-09-23)](#0190-beta1-2019-09-23)
-    - [Unclassified](#unclassified-16)
+  - [Unclassified](#unclassified-16)
 - [0.18.0-beta.1 (2019-08-22)](#0180-beta1-2019-08-22)
-    - [Documentation](#documentation-19)
-    - [Unclassified](#unclassified-17)
+  - [Documentation](#documentation-19)
+  - [Unclassified](#unclassified-17)
   - [0.17.4-beta.1 (2019-08-09)](#0174-beta1-2019-08-09)
     - [Documentation](#documentation-20)
     - [Unclassified](#unclassified-18)
@@ -112,30 +113,30 @@
     - [Documentation](#documentation-23)
     - [Unclassified](#unclassified-21)
 - [0.17.0-beta.1 (2019-07-18)](#0170-beta1-2019-07-18)
-    - [Documentation](#documentation-24)
-    - [Unclassified](#unclassified-22)
+  - [Documentation](#documentation-24)
+  - [Unclassified](#unclassified-22)
 - [0.16.0-beta.5 (2019-06-28)](#0160-beta5-2019-06-28)
-    - [Documentation](#documentation-25)
-    - [Unclassified](#unclassified-23)
+  - [Documentation](#documentation-25)
+  - [Unclassified](#unclassified-23)
 - [0.16.0-beta.4 (2019-05-28)](#0160-beta4-2019-05-28)
-    - [Documentation](#documentation-26)
-    - [Unclassified](#unclassified-24)
+  - [Documentation](#documentation-26)
+  - [Unclassified](#unclassified-24)
 - [0.16.0-beta.3 (2019-05-19)](#0160-beta3-2019-05-19)
-    - [Documentation](#documentation-27)
-    - [Unclassified](#unclassified-25)
+  - [Documentation](#documentation-27)
+  - [Unclassified](#unclassified-25)
   - [0.15.2 (2019-05-04)](#0152-2019-05-04)
     - [Documentation](#documentation-28)
     - [Unclassified](#unclassified-26)
   - [0.15.1 (2019-04-29)](#0151-2019-04-29)
     - [Unclassified](#unclassified-27)
 - [0.15.0 (2019-04-29)](#0150-2019-04-29)
-    - [Documentation](#documentation-29)
-    - [Unclassified](#unclassified-28)
+  - [Documentation](#documentation-29)
+  - [Unclassified](#unclassified-28)
   - [0.14.2+oryOS.10 (2018-12-13)](#0142oryos10-2018-12-13)
   - [0.14.1+oryOS.10 (2018-12-13)](#0141oryos10-2018-12-13)
 - [0.14.0+oryOS.10 (2018-12-13)](#0140oryos10-2018-12-13)
-    - [Documentation](#documentation-30)
-    - [Unclassified](#unclassified-29)
+  - [Documentation](#documentation-30)
+  - [Unclassified](#unclassified-29)
   - [0.11.12 (2018-05-07)](#01112-2018-05-07)
     - [Documentation](#documentation-31)
     - [Unclassified](#unclassified-30)
@@ -207,1524 +208,2146 @@
 
 No significant changes have been made for this release.
 
-
 ## [0.38.10-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.9-beta.1...v0.38.10-beta.1) (2021-04-06)
-
 
 ### Documentation
 
-* Add dotnet sdk ([#683](https://github.com/ory/oathkeeper/issues/683)) ([05ae925](https://github.com/ory/oathkeeper/commit/05ae9259414882015f30cc8d5c01e64afb65afbc)):
+- Add dotnet sdk ([#683](https://github.com/ory/oathkeeper/issues/683))
+  ([05ae925](https://github.com/ory/oathkeeper/commit/05ae9259414882015f30cc8d5c01e64afb65afbc)):
 
-    > * docs: add dotnet sdk
-    > 
-    > * docs: add dotnet sdk versioned
-
+  > - docs: add dotnet sdk
+  >
+  > - docs: add dotnet sdk versioned
 
 ### Features
 
-* Add health event manager and rules readiness probe ([#674](https://github.com/ory/oathkeeper/issues/674)) ([01d8588](https://github.com/ory/oathkeeper/commit/01d8588d300976e06ef6358e23099259814e3bf7))
-* Add http method into session.MatchContext ([#676](https://github.com/ory/oathkeeper/issues/676)) ([e15a7a5](https://github.com/ory/oathkeeper/commit/e15a7a57846d1c28f7b7ed7b824e6fc318f9344d)), closes [#625](https://github.com/ory/oathkeeper/issues/625)
-* Add support for requesting an audience to the OAuth2 Introspection pr… ([#678](https://github.com/ory/oathkeeper/issues/678)) ([2405810](https://github.com/ory/oathkeeper/commit/2405810a839b9d3015655ced492097d0f130a06f)), closes [#677](https://github.com/ory/oathkeeper/issues/677)
-* Additional JWT auth debug information ([#681](https://github.com/ory/oathkeeper/issues/681)) ([d08ab50](https://github.com/ory/oathkeeper/commit/d08ab5034b80736701fb38ee1e55d12c63fd06b2)), closes [#668](https://github.com/ory/oathkeeper/issues/668):
+- Add health event manager and rules readiness probe
+  ([#674](https://github.com/ory/oathkeeper/issues/674))
+  ([01d8588](https://github.com/ory/oathkeeper/commit/01d8588d300976e06ef6358e23099259814e3bf7))
+- Add http method into session.MatchContext
+  ([#676](https://github.com/ory/oathkeeper/issues/676))
+  ([e15a7a5](https://github.com/ory/oathkeeper/commit/e15a7a57846d1c28f7b7ed7b824e6fc318f9344d)),
+  closes [#625](https://github.com/ory/oathkeeper/issues/625)
+- Add support for requesting an audience to the OAuth2 Introspection pr…
+  ([#678](https://github.com/ory/oathkeeper/issues/678))
+  ([2405810](https://github.com/ory/oathkeeper/commit/2405810a839b9d3015655ced492097d0f130a06f)),
+  closes [#677](https://github.com/ory/oathkeeper/issues/677)
+- Additional JWT auth debug information
+  ([#681](https://github.com/ory/oathkeeper/issues/681))
+  ([d08ab50](https://github.com/ory/oathkeeper/commit/d08ab5034b80736701fb38ee1e55d12c63fd06b2)),
+  closes [#668](https://github.com/ory/oathkeeper/issues/668):
 
-    > JWT Claims added to error details field. 
-
-
+  > JWT Claims added to error details field.
 
 ## [0.38.9-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.9-beta.1.pre.3...v0.38.9-beta.1) (2021-03-17)
 
 No significant changes have been made for this release.
 
-
 ## [0.38.9-beta.1.pre.3](https://github.com/ory/oathkeeper/compare/v0.38.9-beta.1.pre.2...v0.38.9-beta.1.pre.3) (2021-03-16)
-
 
 ### Bug Fixes
 
-* Make glob patterns match only one path segment. ([#664](https://github.com/ory/oathkeeper/issues/664)) ([c711aac](https://github.com/ory/oathkeeper/commit/c711aacc5fc29664e3825e087557e7baf4e47aa8)), closes [#630](https://github.com/ory/oathkeeper/issues/630):
+- Make glob patterns match only one path segment.
+  ([#664](https://github.com/ory/oathkeeper/issues/664))
+  ([c711aac](https://github.com/ory/oathkeeper/commit/c711aacc5fc29664e3825e087557e7baf4e47aa8)),
+  closes [#630](https://github.com/ory/oathkeeper/issues/630):
 
-    > This makes `/` also a separator as well as the presumably default value of `.`. This allows using <*> for matching only one path segment.
-
-
+  > This makes `/` also a separator as well as the presumably default value of
+  > `.`. This allows using <\*> for matching only one path segment.
 
 ## [0.38.9-beta.1.pre.2](https://github.com/ory/oathkeeper/compare/v0.38.9-beta.1.pre.1...v0.38.9-beta.1.pre.2) (2021-03-15)
 
 No significant changes have been made for this release.
 
-
 ## [0.38.9-beta.1.pre.1](https://github.com/ory/oathkeeper/compare/v0.38.8-beta.1...v0.38.9-beta.1.pre.1) (2021-03-15)
-
 
 ### Bug Fixes
 
-* Resolve goreleaser issues and bump golang ([7291df9](https://github.com/ory/oathkeeper/commit/7291df9f2745b4dfc178d81b65fc837f58b34206))
-
+- Resolve goreleaser issues and bump golang
+  ([7291df9](https://github.com/ory/oathkeeper/commit/7291df9f2745b4dfc178d81b65fc837f58b34206))
 
 ### Unclassified
 
-* Add missing documentation for oauth2_introspection ([#648](https://github.com/ory/oathkeeper/issues/648)) ([34cf38c](https://github.com/ory/oathkeeper/commit/34cf38c0fe431eb375fab4dbfa9cb9098961943d)), closes [#549](https://github.com/ory/oathkeeper/issues/549)
-
-
+- Add missing documentation for oauth2_introspection
+  ([#648](https://github.com/ory/oathkeeper/issues/648))
+  ([34cf38c](https://github.com/ory/oathkeeper/commit/34cf38c0fe431eb375fab4dbfa9cb9098961943d)),
+  closes [#549](https://github.com/ory/oathkeeper/issues/549)
 
 ## [0.38.8-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.7-beta.1...v0.38.8-beta.1) (2021-02-25)
 
-
 ### Bug Fixes
 
-* Ignore cookie auth when no cookies set ([c84d880](https://github.com/ory/oathkeeper/commit/c84d8808805f124bd31c6d8717f36539652fb4e8))
-
+- Ignore cookie auth when no cookies set
+  ([c84d880](https://github.com/ory/oathkeeper/commit/c84d8808805f124bd31c6d8717f36539652fb4e8))
 
 ### Unclassified
 
-* Formatting ([546691b](https://github.com/ory/oathkeeper/commit/546691b61f78361eff33b1c2a3c3435fecaf499f))
-* Add tracing to outbound oauth introspection requests ([daf44cb](https://github.com/ory/oathkeeper/commit/daf44cb22961817f6d9aaddd4ffce64bcee50d70))
-
-
+- Formatting
+  ([546691b](https://github.com/ory/oathkeeper/commit/546691b61f78361eff33b1c2a3c3435fecaf499f))
+- Add tracing to outbound oauth introspection requests
+  ([daf44cb](https://github.com/ory/oathkeeper/commit/daf44cb22961817f6d9aaddd4ffce64bcee50d70))
 
 ## [0.38.7-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.6-beta.1...v0.38.7-beta.1) (2021-02-22)
 
-
 ### Bug Fixes
 
-* Accept lower and uppercase in bearer token handler ([6e46d4a](https://github.com/ory/oathkeeper/commit/6e46d4a3831ae86beb9b8a5850faf20cb5a759e2))
-* Add support for  X-Forwarded-Proto header ([#638](https://github.com/ory/oathkeeper/issues/638)) ([6eb83fd](https://github.com/ory/oathkeeper/commit/6eb83fd03ed46c388dfe4aaeeaa7c331c9d3685d)), closes [#153](https://github.com/ory/oathkeeper/issues/153)
-* Pass context through to external requests ([#627](https://github.com/ory/oathkeeper/issues/627)) ([ee25197](https://github.com/ory/oathkeeper/commit/ee251976537ade1e06399a3d5b2883620e3407eb)):
+- Accept lower and uppercase in bearer token handler
+  ([6e46d4a](https://github.com/ory/oathkeeper/commit/6e46d4a3831ae86beb9b8a5850faf20cb5a759e2))
+- Add support for X-Forwarded-Proto header
+  ([#638](https://github.com/ory/oathkeeper/issues/638))
+  ([6eb83fd](https://github.com/ory/oathkeeper/commit/6eb83fd03ed46c388dfe4aaeeaa7c331c9d3685d)),
+  closes [#153](https://github.com/ory/oathkeeper/issues/153)
+- Pass context through to external requests
+  ([#627](https://github.com/ory/oathkeeper/issues/627))
+  ([ee25197](https://github.com/ory/oathkeeper/commit/ee251976537ade1e06399a3d5b2883620e3407eb)):
 
-    > Enables proper tracing through Jaeger etc
-* Update goreleaser config ([9689f45](https://github.com/ory/oathkeeper/commit/9689f45db1ec0a974a109a6b28314cddaba2b2de))
-* Update log schema ([78e654d](https://github.com/ory/oathkeeper/commit/78e654df3b81d3ab3f8f946033ee5f1fe45afded))
+  > Enables proper tracing through Jaeger etc
 
+- Update goreleaser config
+  ([9689f45](https://github.com/ory/oathkeeper/commit/9689f45db1ec0a974a109a6b28314cddaba2b2de))
+- Update log schema
+  ([78e654d](https://github.com/ory/oathkeeper/commit/78e654df3b81d3ab3f8f946033ee5f1fe45afded))
 
 ### Features
 
-* Bump to go 1.16 ([e74d4a2](https://github.com/ory/oathkeeper/commit/e74d4a21efeac7aa7b6c7ae8e39daab17ef4f470))
-* Resolve go mod issues ([6a3f5d3](https://github.com/ory/oathkeeper/commit/6a3f5d39c2326a49c694624ff2d35b8e3beccc2e))
-
-
+- Bump to go 1.16
+  ([e74d4a2](https://github.com/ory/oathkeeper/commit/e74d4a21efeac7aa7b6c7ae8e39daab17ef4f470))
+- Resolve go mod issues
+  ([6a3f5d3](https://github.com/ory/oathkeeper/commit/6a3f5d39c2326a49c694624ff2d35b8e3beccc2e))
 
 ## [0.38.6-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.5-beta.1...v0.38.6-beta.1) (2021-01-27)
 
-
 ### Documentation
 
-* Add Rust and Dart SDKs ([1524fed](https://github.com/ory/oathkeeper/commit/1524fed70b4b5c8d3ca8d23e5ab46bc32f073d53)):
+- Add Rust and Dart SDKs
+  ([1524fed](https://github.com/ory/oathkeeper/commit/1524fed70b4b5c8d3ca8d23e5ab46bc32f073d53)):
 
-    > We now support for Rust and Dart SDKs!
-* Fix js npm links ([#634](https://github.com/ory/oathkeeper/issues/634)) ([c339fee](https://github.com/ory/oathkeeper/commit/c339fee771877dbc3e362d4656af53fe492cd58e))
-* Rename index documents ([7de0ac3](https://github.com/ory/oathkeeper/commit/7de0ac34f572d6da56cac482eda364514500a866))
+  > We now support for Rust and Dart SDKs!
 
+- Fix js npm links ([#634](https://github.com/ory/oathkeeper/issues/634))
+  ([c339fee](https://github.com/ory/oathkeeper/commit/c339fee771877dbc3e362d4656af53fe492cd58e))
+- Rename index documents
+  ([7de0ac3](https://github.com/ory/oathkeeper/commit/7de0ac34f572d6da56cac482eda364514500a866))
 
 ### Features
 
-* Add bearer_token authenticator ([#613](https://github.com/ory/oathkeeper/issues/613)) ([b623ae7](https://github.com/ory/oathkeeper/commit/b623ae7f68aac948f8e584fb9254e43a7272adf6)):
+- Add bearer_token authenticator
+  ([#613](https://github.com/ory/oathkeeper/issues/613))
+  ([b623ae7](https://github.com/ory/oathkeeper/commit/b623ae7f68aac948f8e584fb9254e43a7272adf6)):
 
-    > Adds a new authenticator to work with Kratos' new API token.
-    > Works the same as the cookie_session authenticator but checks for a
-    > bearer token in the Authorization header (unless overwritten by
-    > token_from)
-
-
+  > Adds a new authenticator to work with Kratos' new API token. Works the same
+  > as the cookie_session authenticator but checks for a bearer token in the
+  > Authorization header (unless overwritten by token_from)
 
 ## [0.38.5-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.4-beta.1...v0.38.5-beta.1) (2020-12-10)
 
-
 ### Bug Fixes
 
-* Check content-length header in lowercase ([#530](https://github.com/ory/oathkeeper/issues/530)) ([a68fc8a](https://github.com/ory/oathkeeper/commit/a68fc8aa3892311960c4e818fa413caf189b9f8d)):
+- Check content-length header in lowercase
+  ([#530](https://github.com/ory/oathkeeper/issues/530))
+  ([a68fc8a](https://github.com/ory/oathkeeper/commit/a68fc8aa3892311960c4e818fa413caf189b9f8d)):
 
-    > Issue #422 didn't fix the problem with the requests' Content-Length
-    > being copied in the responses because the check was case-sensitive and
-    > unit tests didn't cover it.
-* Never construct id token claim templates in parallel ([#552](https://github.com/ory/oathkeeper/issues/552)) ([4f504d9](https://github.com/ory/oathkeeper/commit/4f504d9032a5be9ea6f82c723a655a0f9028c45a)), closes [#551](https://github.com/ory/oathkeeper/issues/551)
-* Remove token_type validation from introspection handler ([#556](https://github.com/ory/oathkeeper/issues/556)) ([b18d90a](https://github.com/ory/oathkeeper/commit/b18d90a94f2016b541164cf30654032628e4bc01)), closes [#553](https://github.com/ory/oathkeeper/issues/553)
-* Support windows file paths ([#557](https://github.com/ory/oathkeeper/issues/557)) ([6a05682](https://github.com/ory/oathkeeper/commit/6a05682dca21181db9e052300edf14fb40815bd3)), closes [#514](https://github.com/ory/oathkeeper/issues/514) [#332](https://github.com/ory/oathkeeper/issues/332)
-* Update dd-trace to fix build ([2e571fa](https://github.com/ory/oathkeeper/commit/2e571fa98880b62a174dbcfcdde2bb1a339cc7a3))
+  > Issue #422 didn't fix the problem with the requests' Content-Length being
+  > copied in the responses because the check was case-sensitive and unit tests
+  > didn't cover it.
 
+- Never construct id token claim templates in parallel
+  ([#552](https://github.com/ory/oathkeeper/issues/552))
+  ([4f504d9](https://github.com/ory/oathkeeper/commit/4f504d9032a5be9ea6f82c723a655a0f9028c45a)),
+  closes [#551](https://github.com/ory/oathkeeper/issues/551)
+- Remove token_type validation from introspection handler
+  ([#556](https://github.com/ory/oathkeeper/issues/556))
+  ([b18d90a](https://github.com/ory/oathkeeper/commit/b18d90a94f2016b541164cf30654032628e4bc01)),
+  closes [#553](https://github.com/ory/oathkeeper/issues/553)
+- Support windows file paths
+  ([#557](https://github.com/ory/oathkeeper/issues/557))
+  ([6a05682](https://github.com/ory/oathkeeper/commit/6a05682dca21181db9e052300edf14fb40815bd3)),
+  closes [#514](https://github.com/ory/oathkeeper/issues/514)
+  [#332](https://github.com/ory/oathkeeper/issues/332)
+- Update dd-trace to fix build
+  ([2e571fa](https://github.com/ory/oathkeeper/commit/2e571fa98880b62a174dbcfcdde2bb1a339cc7a3))
 
 ### Documentation
 
-* Add contributing to sidebar ([#595](https://github.com/ory/oathkeeper/issues/595)) ([a3c9584](https://github.com/ory/oathkeeper/commit/a3c9584e848b3e71b33073c89299bc60c6d0b3ee)):
+- Add contributing to sidebar
+  ([#595](https://github.com/ory/oathkeeper/issues/595))
+  ([a3c9584](https://github.com/ory/oathkeeper/commit/a3c9584e848b3e71b33073c89299bc60c6d0b3ee)):
 
-    > The same change as in https://github.com/ory/hydra/pull/2209
-* Add newsletter to config ([3c02e22](https://github.com/ory/oathkeeper/commit/3c02e22c398b5a573883b6c1cceb05aff15dcbea))
-* Correct sidebar.json ([#524](https://github.com/ory/oathkeeper/issues/524)) ([34e2077](https://github.com/ory/oathkeeper/commit/34e2077e872dcf7b23129623434a8ff0656da9fc))
-* Fix typo ([393af92](https://github.com/ory/oathkeeper/commit/393af92e06f0d562b7e7a7f40c6ff1caeca9523b))
-* Fix typo in API access rules and improve layout ([#599](https://github.com/ory/oathkeeper/issues/599)) ([6a30ce2](https://github.com/ory/oathkeeper/commit/6a30ce2e0df0101ba7449dbadcc68528337c01fa))
-* Fix typo in pipeline/error.md ([#568](https://github.com/ory/oathkeeper/issues/568)) ([5d04c6b](https://github.com/ory/oathkeeper/commit/5d04c6b30ccc1bbb1407f1f82123aa2e82372c36))
-* Resolve list in main docs ([1c2241c](https://github.com/ory/oathkeeper/commit/1c2241c1cbf615a07b483a3bb51fc3be9a50ae40)), closes [#602](https://github.com/ory/oathkeeper/issues/602)
-* Resolve regression issues ([82008b2](https://github.com/ory/oathkeeper/commit/82008b2a6a60583856c436b1adae2f6d306bf836))
+  > The same change as in https://github.com/ory/hydra/pull/2209
 
+- Add newsletter to config
+  ([3c02e22](https://github.com/ory/oathkeeper/commit/3c02e22c398b5a573883b6c1cceb05aff15dcbea))
+- Correct sidebar.json ([#524](https://github.com/ory/oathkeeper/issues/524))
+  ([34e2077](https://github.com/ory/oathkeeper/commit/34e2077e872dcf7b23129623434a8ff0656da9fc))
+- Fix typo
+  ([393af92](https://github.com/ory/oathkeeper/commit/393af92e06f0d562b7e7a7f40c6ff1caeca9523b))
+- Fix typo in API access rules and improve layout
+  ([#599](https://github.com/ory/oathkeeper/issues/599))
+  ([6a30ce2](https://github.com/ory/oathkeeper/commit/6a30ce2e0df0101ba7449dbadcc68528337c01fa))
+- Fix typo in pipeline/error.md
+  ([#568](https://github.com/ory/oathkeeper/issues/568))
+  ([5d04c6b](https://github.com/ory/oathkeeper/commit/5d04c6b30ccc1bbb1407f1f82123aa2e82372c36))
+- Resolve list in main docs
+  ([1c2241c](https://github.com/ory/oathkeeper/commit/1c2241c1cbf615a07b483a3bb51fc3be9a50ae40)),
+  closes [#602](https://github.com/ory/oathkeeper/issues/602)
+- Resolve regression issues
+  ([82008b2](https://github.com/ory/oathkeeper/commit/82008b2a6a60583856c436b1adae2f6d306bf836))
 
 ### Features
 
-* Forward original authorization header when using remote (json) authorizer ([#554](https://github.com/ory/oathkeeper/issues/554)) ([f4f781e](https://github.com/ory/oathkeeper/commit/f4f781e5ec998e3656b6cf3c46c83c0faf6527ef)), closes [#528](https://github.com/ory/oathkeeper/issues/528)
-* Use google/go-cloud to fetch rules and credentials from object storage ([#562](https://github.com/ory/oathkeeper/issues/562)) ([666b951](https://github.com/ory/oathkeeper/commit/666b9514ec37acfe2bb90ce62d5ee845853528fd)), closes [#518](https://github.com/ory/oathkeeper/issues/518) [#518](https://github.com/ory/oathkeeper/issues/518)
-
+- Forward original authorization header when using remote (json) authorizer
+  ([#554](https://github.com/ory/oathkeeper/issues/554))
+  ([f4f781e](https://github.com/ory/oathkeeper/commit/f4f781e5ec998e3656b6cf3c46c83c0faf6527ef)),
+  closes [#528](https://github.com/ory/oathkeeper/issues/528)
+- Use google/go-cloud to fetch rules and credentials from object storage
+  ([#562](https://github.com/ory/oathkeeper/issues/562))
+  ([666b951](https://github.com/ory/oathkeeper/commit/666b9514ec37acfe2bb90ce62d5ee845853528fd)),
+  closes [#518](https://github.com/ory/oathkeeper/issues/518)
+  [#518](https://github.com/ory/oathkeeper/issues/518)
 
 ### Unclassified
 
-* docs. fix typo in list ([335189f](https://github.com/ory/oathkeeper/commit/335189fba1d4c3db841c0cf9c51412adc7bdae01))
-
-
+- docs. fix typo in list
+  ([335189f](https://github.com/ory/oathkeeper/commit/335189fba1d4c3db841c0cf9c51412adc7bdae01))
 
 ## [0.38.4-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.3-beta.1...v0.38.4-beta.1) (2020-09-28)
 
-
 ### Bug Fixes
 
-* Add tests in error_redirect_test.go ([#522](https://github.com/ory/oathkeeper/issues/522)) ([24bdd9b](https://github.com/ory/oathkeeper/commit/24bdd9bdc56a46953a393d503ccfd2416cf11bcf)):
+- Add tests in error_redirect_test.go
+  ([#522](https://github.com/ory/oathkeeper/issues/522))
+  ([24bdd9b](https://github.com/ory/oathkeeper/commit/24bdd9bdc56a46953a393d503ccfd2416cf11bcf)):
 
-    > Increased tests coverage to cover for all the three valid scenarios - http absolute, https absolute, relative. Explicitly checked Location path to ensure that correct uri scheme was returned
-* Deprecated key in goreleaser config ([2a4f901](https://github.com/ory/oathkeeper/commit/2a4f90127e66917dfaa72f8089efa5149631434d))
-* Ignore x/net false positives ([bc8a32c](https://github.com/ory/oathkeeper/commit/bc8a32c9fcf8cbd9fc6b46b9c8d607745fb05a1e))
-* Misleading HTTP status code for oauth2_client_credentials authenticator ([#504](https://github.com/ory/oathkeeper/issues/504)) ([0f65631](https://github.com/ory/oathkeeper/commit/0f65631af61e6a4098745f0149b0154d5dd7386c)), closes [#496](https://github.com/ory/oathkeeper/issues/496)
+  > Increased tests coverage to cover for all the three valid scenarios - http
+  > absolute, https absolute, relative. Explicitly checked Location path to
+  > ensure that correct uri scheme was returned
 
+- Deprecated key in goreleaser config
+  ([2a4f901](https://github.com/ory/oathkeeper/commit/2a4f90127e66917dfaa72f8089efa5149631434d))
+- Ignore x/net false positives
+  ([bc8a32c](https://github.com/ory/oathkeeper/commit/bc8a32c9fcf8cbd9fc6b46b9c8d607745fb05a1e))
+- Misleading HTTP status code for oauth2_client_credentials authenticator
+  ([#504](https://github.com/ory/oathkeeper/issues/504))
+  ([0f65631](https://github.com/ory/oathkeeper/commit/0f65631af61e6a4098745f0149b0154d5dd7386c)),
+  closes [#496](https://github.com/ory/oathkeeper/issues/496)
 
 ### Documentation
 
-* Fix broken links ([dd3bfbe](https://github.com/ory/oathkeeper/commit/dd3bfbe01ed450ff88a492c041affeaaf17027c9))
-* Fix OAuth2 Introspect Authn Config Documentation ([#498](https://github.com/ory/oathkeeper/issues/498)) ([7612e20](https://github.com/ory/oathkeeper/commit/7612e207e96841aad3dcf5806f5af2cc42024075)):
+- Fix broken links
+  ([dd3bfbe](https://github.com/ory/oathkeeper/commit/dd3bfbe01ed450ff88a492c041affeaaf17027c9))
+- Fix OAuth2 Introspect Authn Config Documentation
+  ([#498](https://github.com/ory/oathkeeper/issues/498))
+  ([7612e20](https://github.com/ory/oathkeeper/commit/7612e207e96841aad3dcf5806f5af2cc42024075)):
 
-    > Switch the definitions for the pre-authorisation fields 'scope' and 'token endpoint' in the documentation.
-* Fix sidebar ([28247fc](https://github.com/ory/oathkeeper/commit/28247fcf53ed5c47879ada62456ab39b29c5752a))
-* Guide for integrating with ORY Hydra ([#497](https://github.com/ory/oathkeeper/issues/497)) ([e1b1751](https://github.com/ory/oathkeeper/commit/e1b175183b8ce9e7d2befae3269d2c5cd959e3e0))
-* Move development section ([582a4d0](https://github.com/ory/oathkeeper/commit/582a4d0e880649cc64aa647b2c35e432b3f234e2))
-* Move to json sidebar ([b67230d](https://github.com/ory/oathkeeper/commit/b67230d038ef0b101c6362ab3e1c34a6924cfc96))
-* Remove duplicate template ([01550b4](https://github.com/ory/oathkeeper/commit/01550b4e28b45b4deb1c1a3f685a1962f7633833))
-* Update repository templates ([2aaf766](https://github.com/ory/oathkeeper/commit/2aaf766444cb9ae9b794c9638553a32931276a39))
-* Update repository templates ([#506](https://github.com/ory/oathkeeper/issues/506)) ([cb53d79](https://github.com/ory/oathkeeper/commit/cb53d79f4ee36266ed7d2c5a1de6147884cbb3cf))
+  > Switch the definitions for the pre-authorisation fields 'scope' and 'token
+  > endpoint' in the documentation.
 
+- Fix sidebar
+  ([28247fc](https://github.com/ory/oathkeeper/commit/28247fcf53ed5c47879ada62456ab39b29c5752a))
+- Guide for integrating with ORY Hydra
+  ([#497](https://github.com/ory/oathkeeper/issues/497))
+  ([e1b1751](https://github.com/ory/oathkeeper/commit/e1b175183b8ce9e7d2befae3269d2c5cd959e3e0))
+- Move development section
+  ([582a4d0](https://github.com/ory/oathkeeper/commit/582a4d0e880649cc64aa647b2c35e432b3f234e2))
+- Move to json sidebar
+  ([b67230d](https://github.com/ory/oathkeeper/commit/b67230d038ef0b101c6362ab3e1c34a6924cfc96))
+- Remove duplicate template
+  ([01550b4](https://github.com/ory/oathkeeper/commit/01550b4e28b45b4deb1c1a3f685a1962f7633833))
+- Update repository templates
+  ([2aaf766](https://github.com/ory/oathkeeper/commit/2aaf766444cb9ae9b794c9638553a32931276a39))
+- Update repository templates
+  ([#506](https://github.com/ory/oathkeeper/issues/506))
+  ([cb53d79](https://github.com/ory/oathkeeper/commit/cb53d79f4ee36266ed7d2c5a1de6147884cbb3cf))
 
 ### Features
 
-* Add and automate version schema ([7ab4012](https://github.com/ory/oathkeeper/commit/7ab40128352eb4e6639fe4828da7bdd3690e327e))
-* Add url_param config option to redirect error handler. ([#520](https://github.com/ory/oathkeeper/issues/520)) ([b5bb3bc](https://github.com/ory/oathkeeper/commit/b5bb3bc6b88ea8b26d53f03477fce1b74f113b97)), closes [#511](https://github.com/ory/oathkeeper/issues/511):
+- Add and automate version schema
+  ([7ab4012](https://github.com/ory/oathkeeper/commit/7ab40128352eb4e6639fe4828da7bdd3690e327e))
+- Add url_param config option to redirect error handler.
+  ([#520](https://github.com/ory/oathkeeper/issues/520))
+  ([b5bb3bc](https://github.com/ory/oathkeeper/commit/b5bb3bc6b88ea8b26d53f03477fce1b74f113b97)),
+  closes [#511](https://github.com/ory/oathkeeper/issues/511):
 
-    > This change introduces a url_param config option for redirect error handler.
-    > If it contains a url paramter name, the redirect url will have this parameter
-    > set, containing the current url (from which Oathkeeper has redirected the user).
-    > 
-    > This can be useful in passing the return_to url to Kratos, so user can be
-    > redirected to the page they initially wanted to access after a successfull sign in.
-* Log invalid credentials on info level instead of error/warning ([#517](https://github.com/ory/oathkeeper/issues/517)) ([a372b5f](https://github.com/ory/oathkeeper/commit/a372b5f833305ad85451cfb99b1db9e10ae8b8dc)), closes [#505](https://github.com/ory/oathkeeper/issues/505)
-* Use uri-reference for errors redirect to allow relative urls ([#516](https://github.com/ory/oathkeeper/issues/516)) ([0d39674](https://github.com/ory/oathkeeper/commit/0d3967409786c23de8e97f5c588cc4e9837a1550))
+  > This change introduces a url_param config option for redirect error handler.
+  > If it contains a url paramter name, the redirect url will have this
+  > parameter set, containing the current url (from which Oathkeeper has
+  > redirected the user).
+  >
+  > This can be useful in passing the return_to url to Kratos, so user can be
+  > redirected to the page they initially wanted to access after a successfull
+  > sign in.
 
+- Log invalid credentials on info level instead of error/warning
+  ([#517](https://github.com/ory/oathkeeper/issues/517))
+  ([a372b5f](https://github.com/ory/oathkeeper/commit/a372b5f833305ad85451cfb99b1db9e10ae8b8dc)),
+  closes [#505](https://github.com/ory/oathkeeper/issues/505)
+- Use uri-reference for errors redirect to allow relative urls
+  ([#516](https://github.com/ory/oathkeeper/issues/516))
+  ([0d39674](https://github.com/ory/oathkeeper/commit/0d3967409786c23de8e97f5c588cc4e9837a1550))
 
 ### Unclassified
 
-* Run go format ([2c25a2a](https://github.com/ory/oathkeeper/commit/2c25a2ad18bba7bf72e612b2005f1080e164d0d9))
-
-
+- Run go format
+  ([2c25a2a](https://github.com/ory/oathkeeper/commit/2c25a2ad18bba7bf72e612b2005f1080e164d0d9))
 
 ## [0.38.3-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.2-beta.1...v0.38.3-beta.1) (2020-07-29)
 
-
 ### Bug Fixes
 
-* Matcher.Match panic on nil *url.URL ([#485](https://github.com/ory/oathkeeper/issues/485)) ([ab27dda](https://github.com/ory/oathkeeper/commit/ab27dda253d7c3f8bb9fae45c1f50e86e24e193c)), closes [#484](https://github.com/ory/oathkeeper/issues/484)
-* Remove HTTP method restrictions ([#472](https://github.com/ory/oathkeeper/issues/472)) ([bf8a888](https://github.com/ory/oathkeeper/commit/bf8a88884fa575c6ed397c92598c7436461028c6))
-* Resolve build issues and bump herodot ([f15e38d](https://github.com/ory/oathkeeper/commit/f15e38dc533010babd21aeaa91d48dd4abbbdddc))
-* Use ory-dev instead of swagutil ([#465](https://github.com/ory/oathkeeper/issues/465)) ([3fce382](https://github.com/ory/oathkeeper/commit/3fce382e83c95049b561a97365d0b4cc2f73bc54))
-
+- Matcher.Match panic on nil \*url.URL
+  ([#485](https://github.com/ory/oathkeeper/issues/485))
+  ([ab27dda](https://github.com/ory/oathkeeper/commit/ab27dda253d7c3f8bb9fae45c1f50e86e24e193c)),
+  closes [#484](https://github.com/ory/oathkeeper/issues/484)
+- Remove HTTP method restrictions
+  ([#472](https://github.com/ory/oathkeeper/issues/472))
+  ([bf8a888](https://github.com/ory/oathkeeper/commit/bf8a88884fa575c6ed397c92598c7436461028c6))
+- Resolve build issues and bump herodot
+  ([f15e38d](https://github.com/ory/oathkeeper/commit/f15e38dc533010babd21aeaa91d48dd4abbbdddc))
+- Use ory-dev instead of swagutil
+  ([#465](https://github.com/ory/oathkeeper/issues/465))
+  ([3fce382](https://github.com/ory/oathkeeper/commit/3fce382e83c95049b561a97365d0b4cc2f73bc54))
 
 ### Documentation
 
-* Delete old redirect homepage ([a1a4610](https://github.com/ory/oathkeeper/commit/a1a4610194558f1024d2409c6f1975b72a0f856e))
-* Fix access rule example ([739f179](https://github.com/ory/oathkeeper/commit/739f179ca2ca9d8ca42ca1995b3febac322bbeb2))
-* Fix api access rule example ([#460](https://github.com/ory/oathkeeper/issues/460)) ([c75cd97](https://github.com/ory/oathkeeper/commit/c75cd978899b719edbd8ad80f7c7a48aded20252))
-* Update repository templates ([edffc2e](https://github.com/ory/oathkeeper/commit/edffc2ee354ae4ec26e19e728b9f3117a0ec879c))
-* Update repository templates ([7af8749](https://github.com/ory/oathkeeper/commit/7af8749e949c48f5750950def62290f2694e1b09))
-* Use central banner repo for README ([04fe00c](https://github.com/ory/oathkeeper/commit/04fe00c0cd92c717ea2dc4149450f07206306f51))
-* Use mdx for api reference ([368f073](https://github.com/ory/oathkeeper/commit/368f073a2d91b4fc9677436bcec63c6f339b0c93))
-
+- Delete old redirect homepage
+  ([a1a4610](https://github.com/ory/oathkeeper/commit/a1a4610194558f1024d2409c6f1975b72a0f856e))
+- Fix access rule example
+  ([739f179](https://github.com/ory/oathkeeper/commit/739f179ca2ca9d8ca42ca1995b3febac322bbeb2))
+- Fix api access rule example
+  ([#460](https://github.com/ory/oathkeeper/issues/460))
+  ([c75cd97](https://github.com/ory/oathkeeper/commit/c75cd978899b719edbd8ad80f7c7a48aded20252))
+- Update repository templates
+  ([edffc2e](https://github.com/ory/oathkeeper/commit/edffc2ee354ae4ec26e19e728b9f3117a0ec879c))
+- Update repository templates
+  ([7af8749](https://github.com/ory/oathkeeper/commit/7af8749e949c48f5750950def62290f2694e1b09))
+- Use central banner repo for README
+  ([04fe00c](https://github.com/ory/oathkeeper/commit/04fe00c0cd92c717ea2dc4149450f07206306f51))
+- Use mdx for api reference
+  ([368f073](https://github.com/ory/oathkeeper/commit/368f073a2d91b4fc9677436bcec63c6f339b0c93))
 
 ### Features
 
-* Improve configurability of prometheus metrics ([#450](https://github.com/ory/oathkeeper/issues/450)) ([ddcb226](https://github.com/ory/oathkeeper/commit/ddcb2262e6edc417c69bf2d713fa67f235481d32)), closes [#446](https://github.com/ory/oathkeeper/issues/446)
-* Pass query parameters to the hydrators ([#479](https://github.com/ory/oathkeeper/issues/479)) ([48603a1](https://github.com/ory/oathkeeper/commit/48603a1ac484b6571706021f2667f770604256b6))
-
-
+- Improve configurability of prometheus metrics
+  ([#450](https://github.com/ory/oathkeeper/issues/450))
+  ([ddcb226](https://github.com/ory/oathkeeper/commit/ddcb2262e6edc417c69bf2d713fa67f235481d32)),
+  closes [#446](https://github.com/ory/oathkeeper/issues/446)
+- Pass query parameters to the hydrators
+  ([#479](https://github.com/ory/oathkeeper/issues/479))
+  ([48603a1](https://github.com/ory/oathkeeper/commit/48603a1ac484b6571706021f2667f770604256b6))
 
 ## [0.38.2-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.1-beta.1...v0.38.2-beta.1) (2020-05-25)
 
-
 ### Bug Fixes
 
-* Move prometheus validation stanza to local schema ([#437](https://github.com/ory/oathkeeper/issues/437)) ([dcf3e14](https://github.com/ory/oathkeeper/commit/dcf3e14f2b4e09deb40260303061f27bcb55503c)), closes [#438](https://github.com/ory/oathkeeper/issues/438)
-
+- Move prometheus validation stanza to local schema
+  ([#437](https://github.com/ory/oathkeeper/issues/437))
+  ([dcf3e14](https://github.com/ory/oathkeeper/commit/dcf3e14f2b4e09deb40260303061f27bcb55503c)),
+  closes [#438](https://github.com/ory/oathkeeper/issues/438)
 
 ### Documentation
 
-* Update github templates ([#434](https://github.com/ory/oathkeeper/issues/434)) ([37d34a3](https://github.com/ory/oathkeeper/commit/37d34a3a4f728a5ba39cef6118cd7e9f5e78bcd2))
-
+- Update github templates ([#434](https://github.com/ory/oathkeeper/issues/434))
+  ([37d34a3](https://github.com/ory/oathkeeper/commit/37d34a3a4f728a5ba39cef6118cd7e9f5e78bcd2))
 
 ### Features
 
-* Add configurable timeouts to API server ([#440](https://github.com/ory/oathkeeper/issues/440)) ([0dc6292](https://github.com/ory/oathkeeper/commit/0dc6292eb4784505be5100c6b20ade6235e277ac))
-* Timeout config for oauth2_client_credentials ([#443](https://github.com/ory/oathkeeper/issues/443)) ([2462fa3](https://github.com/ory/oathkeeper/commit/2462fa3f97601009aff9b45c7c288d7a1afdec45)), closes [#442](https://github.com/ory/oathkeeper/issues/442)
-
-
+- Add configurable timeouts to API server
+  ([#440](https://github.com/ory/oathkeeper/issues/440))
+  ([0dc6292](https://github.com/ory/oathkeeper/commit/0dc6292eb4784505be5100c6b20ade6235e277ac))
+- Timeout config for oauth2_client_credentials
+  ([#443](https://github.com/ory/oathkeeper/issues/443))
+  ([2462fa3](https://github.com/ory/oathkeeper/commit/2462fa3f97601009aff9b45c7c288d7a1afdec45)),
+  closes [#442](https://github.com/ory/oathkeeper/issues/442)
 
 ## [0.38.1-beta.1](https://github.com/ory/oathkeeper/compare/v0.38.0-beta.2...v0.38.1-beta.1) (2020-05-08)
 
-
 ### Bug Fixes
 
-* Improve caching strategy and config for hydrator ([#433](https://github.com/ory/oathkeeper/issues/433)) ([0047054](https://github.com/ory/oathkeeper/commit/00470541fb3d5d2672ef068c9e02c20deaac3d0d)):
+- Improve caching strategy and config for hydrator
+  ([#433](https://github.com/ory/oathkeeper/issues/433))
+  ([0047054](https://github.com/ory/oathkeeper/commit/00470541fb3d5d2672ef068c9e02c20deaac3d0d)):
 
-    > To enable the hydrator cache you must now use the `cache.enabled` property. Also, the cache key strategy has been improved.
-
-
+  > To enable the hydrator cache you must now use the `cache.enabled` property.
+  > Also, the cache key strategy has been improved.
 
 # [0.38.0-beta.2](https://github.com/ory/oathkeeper/compare/v0.37.1-beta.1...v0.38.0-beta.2) (2020-05-07)
 
-
 ### Bug Fixes
 
-* Add old schemas to resolve issues with old versions ([b94c391](https://github.com/ory/oathkeeper/commit/b94c391446a694971fa54a53eb08f9d57ad5eb24)), closes [#400](https://github.com/ory/oathkeeper/issues/400)
-* Don't copy the decision endpoint request's Content-Length ([#422](https://github.com/ory/oathkeeper/issues/422)) ([0e99045](https://github.com/ory/oathkeeper/commit/0e990459104c7683764f4ed0e0a6b7162b57cd57)):
+- Add old schemas to resolve issues with old versions
+  ([b94c391](https://github.com/ory/oathkeeper/commit/b94c391446a694971fa54a53eb08f9d57ad5eb24)),
+  closes [#400](https://github.com/ory/oathkeeper/issues/400)
+- Don't copy the decision endpoint request's Content-Length
+  ([#422](https://github.com/ory/oathkeeper/issues/422))
+  ([0e99045](https://github.com/ory/oathkeeper/commit/0e990459104c7683764f4ed0e0a6b7162b57cd57)):
 
-    > We currently copy all original request headers send to the decission
-    > endpoint back. This can include the Content-Length header which
-    > describes the request body or response. Including the original
-    > request Content-Length causes issues for the decission endpoint
-    > client if the response body doesn't match the exact size.
-    > 
-    > This change makes sure the Content-Length doesn't get included in
-    > the response body and adds a test to prevent future regressions.
-* Respect retry in token introspection ([#410](https://github.com/ory/oathkeeper/issues/410)) ([88f7b69](https://github.com/ory/oathkeeper/commit/88f7b69c9ff252ddc3dbe960155883ec98115fd0))
-* Update install.sh script ([#429](https://github.com/ory/oathkeeper/issues/429)) ([2d2eded](https://github.com/ory/oathkeeper/commit/2d2eded4075c2649e449d80dbb871b0da739a9ac))
-* Use pipe to pass body remote authorizer ([#426](https://github.com/ory/oathkeeper/issues/426)) ([1a44087](https://github.com/ory/oathkeeper/commit/1a44087f424d8a01437769c6bce177eab36c195f)):
+  > We currently copy all original request headers send to the decission
+  > endpoint back. This can include the Content-Length header which describes
+  > the request body or response. Including the original request Content-Length
+  > causes issues for the decission endpoint client if the response body doesn't
+  > match the exact size.
+  >
+  > This change makes sure the Content-Length doesn't get included in the
+  > response body and adds a test to prevent future regressions.
 
-    > Resolves flaky tests.
-* Use semver-regex replacer func ([a13cdf5](https://github.com/ory/oathkeeper/commit/a13cdf5d9a518e3095545e30d15c7c4b7859752b))
+- Respect retry in token introspection
+  ([#410](https://github.com/ory/oathkeeper/issues/410))
+  ([88f7b69](https://github.com/ory/oathkeeper/commit/88f7b69c9ff252ddc3dbe960155883ec98115fd0))
+- Update install.sh script
+  ([#429](https://github.com/ory/oathkeeper/issues/429))
+  ([2d2eded](https://github.com/ory/oathkeeper/commit/2d2eded4075c2649e449d80dbb871b0da739a9ac))
+- Use pipe to pass body remote authorizer
+  ([#426](https://github.com/ory/oathkeeper/issues/426))
+  ([1a44087](https://github.com/ory/oathkeeper/commit/1a44087f424d8a01437769c6bce177eab36c195f)):
 
+  > Resolves flaky tests.
+
+- Use semver-regex replacer func
+  ([a13cdf5](https://github.com/ory/oathkeeper/commit/a13cdf5d9a518e3095545e30d15c7c4b7859752b))
 
 ### Code Refactoring
 
-* Move docs to this repository ([#396](https://github.com/ory/oathkeeper/issues/396)) ([11cb851](https://github.com/ory/oathkeeper/commit/11cb851a7cc42120c2d890fbeefcba55d6ff0e5a))
-
+- Move docs to this repository
+  ([#396](https://github.com/ory/oathkeeper/issues/396))
+  ([11cb851](https://github.com/ory/oathkeeper/commit/11cb851a7cc42120c2d890fbeefcba55d6ff0e5a))
 
 ### Documentation
 
-* Add `authentication_handler_no_match` to error example ([ad182f4](https://github.com/ory/oathkeeper/commit/ad182f4af9723aff79c227431045444140c24f25))
-* Add missing import ([b76ee9c](https://github.com/ory/oathkeeper/commit/b76ee9c8b6cb07adf7b9cdd421712dfdcb5f8340))
-* Regenerate and update changelog ([7121f65](https://github.com/ory/oathkeeper/commit/7121f6514a0ba0d61831792972ed833117911551))
-* Regenerate and update changelog ([6fd7d66](https://github.com/ory/oathkeeper/commit/6fd7d667e3c7738bc7a4ab82c490a6d7343e85bd))
-* Regenerate and update changelog ([531200c](https://github.com/ory/oathkeeper/commit/531200cecae0bb8853ff9d5d557cb9176137545b))
-* Regenerate and update changelog ([cf8ad0c](https://github.com/ory/oathkeeper/commit/cf8ad0c635042de54590030387220c1a16b9268c))
-* Update github templates ([#407](https://github.com/ory/oathkeeper/issues/407)) ([9979d77](https://github.com/ory/oathkeeper/commit/9979d77d7eda95a2438f3f5cc9b85d3d0aa2857c))
-* Update github templates ([#409](https://github.com/ory/oathkeeper/issues/409)) ([f92a029](https://github.com/ory/oathkeeper/commit/f92a0294d8d365fddbb67caa0367daa78f7b25e9))
-* Update github templates ([#412](https://github.com/ory/oathkeeper/issues/412)) ([884c113](https://github.com/ory/oathkeeper/commit/884c113f2bb8698a2d24399d048faf5018846e54))
-* Update github templates ([#413](https://github.com/ory/oathkeeper/issues/413)) ([6d7cba7](https://github.com/ory/oathkeeper/commit/6d7cba76e893d51db71687b2981837a333d71666))
-* Update github templates ([#413](https://github.com/ory/oathkeeper/issues/413)) ([d692fbf](https://github.com/ory/oathkeeper/commit/d692fbfb9bcba77c32a94b530e82fbd5e2b61856))
-* Update linux install guide ([#414](https://github.com/ory/oathkeeper/issues/414)) ([a0e2cc0](https://github.com/ory/oathkeeper/commit/a0e2cc0ea324d908a8741df75e3259e30a302dbb))
-* Updates issue and pull request templates ([#392](https://github.com/ory/oathkeeper/issues/392)) ([3724ebc](https://github.com/ory/oathkeeper/commit/3724ebc63a85050525d86d81a70eeadccac72c1a))
-* Updates issue and pull request templates ([#393](https://github.com/ory/oathkeeper/issues/393)) ([a4ade5c](https://github.com/ory/oathkeeper/commit/a4ade5ca29a9ce24a3ffb6c9705c4723e67f9619))
-* Updates issue and pull request templates ([#394](https://github.com/ory/oathkeeper/issues/394)) ([0ef037a](https://github.com/ory/oathkeeper/commit/0ef037abcec226039eb1a69dfc442df53d430ce1))
-* Updates issue and pull request templates ([#395](https://github.com/ory/oathkeeper/issues/395)) ([ecab261](https://github.com/ory/oathkeeper/commit/ecab26119e32fa7c6947a7da17f2095292d02f2d))
-* Use correct headline for cc handler ([#420](https://github.com/ory/oathkeeper/issues/420)) ([1401610](https://github.com/ory/oathkeeper/commit/1401610dffc7bef5823199059a4d9fc25cbde264))
-
+- Add `authentication_handler_no_match` to error example
+  ([ad182f4](https://github.com/ory/oathkeeper/commit/ad182f4af9723aff79c227431045444140c24f25))
+- Add missing import
+  ([b76ee9c](https://github.com/ory/oathkeeper/commit/b76ee9c8b6cb07adf7b9cdd421712dfdcb5f8340))
+- Regenerate and update changelog
+  ([7121f65](https://github.com/ory/oathkeeper/commit/7121f6514a0ba0d61831792972ed833117911551))
+- Regenerate and update changelog
+  ([6fd7d66](https://github.com/ory/oathkeeper/commit/6fd7d667e3c7738bc7a4ab82c490a6d7343e85bd))
+- Regenerate and update changelog
+  ([531200c](https://github.com/ory/oathkeeper/commit/531200cecae0bb8853ff9d5d557cb9176137545b))
+- Regenerate and update changelog
+  ([cf8ad0c](https://github.com/ory/oathkeeper/commit/cf8ad0c635042de54590030387220c1a16b9268c))
+- Update github templates ([#407](https://github.com/ory/oathkeeper/issues/407))
+  ([9979d77](https://github.com/ory/oathkeeper/commit/9979d77d7eda95a2438f3f5cc9b85d3d0aa2857c))
+- Update github templates ([#409](https://github.com/ory/oathkeeper/issues/409))
+  ([f92a029](https://github.com/ory/oathkeeper/commit/f92a0294d8d365fddbb67caa0367daa78f7b25e9))
+- Update github templates ([#412](https://github.com/ory/oathkeeper/issues/412))
+  ([884c113](https://github.com/ory/oathkeeper/commit/884c113f2bb8698a2d24399d048faf5018846e54))
+- Update github templates ([#413](https://github.com/ory/oathkeeper/issues/413))
+  ([6d7cba7](https://github.com/ory/oathkeeper/commit/6d7cba76e893d51db71687b2981837a333d71666))
+- Update github templates ([#413](https://github.com/ory/oathkeeper/issues/413))
+  ([d692fbf](https://github.com/ory/oathkeeper/commit/d692fbfb9bcba77c32a94b530e82fbd5e2b61856))
+- Update linux install guide
+  ([#414](https://github.com/ory/oathkeeper/issues/414))
+  ([a0e2cc0](https://github.com/ory/oathkeeper/commit/a0e2cc0ea324d908a8741df75e3259e30a302dbb))
+- Updates issue and pull request templates
+  ([#392](https://github.com/ory/oathkeeper/issues/392))
+  ([3724ebc](https://github.com/ory/oathkeeper/commit/3724ebc63a85050525d86d81a70eeadccac72c1a))
+- Updates issue and pull request templates
+  ([#393](https://github.com/ory/oathkeeper/issues/393))
+  ([a4ade5c](https://github.com/ory/oathkeeper/commit/a4ade5ca29a9ce24a3ffb6c9705c4723e67f9619))
+- Updates issue and pull request templates
+  ([#394](https://github.com/ory/oathkeeper/issues/394))
+  ([0ef037a](https://github.com/ory/oathkeeper/commit/0ef037abcec226039eb1a69dfc442df53d430ce1))
+- Updates issue and pull request templates
+  ([#395](https://github.com/ory/oathkeeper/issues/395))
+  ([ecab261](https://github.com/ory/oathkeeper/commit/ecab26119e32fa7c6947a7da17f2095292d02f2d))
+- Use correct headline for cc handler
+  ([#420](https://github.com/ory/oathkeeper/issues/420))
+  ([1401610](https://github.com/ory/oathkeeper/commit/1401610dffc7bef5823199059a4d9fc25cbde264))
 
 ### Features
 
-* Add cache to hydrator ([#418](https://github.com/ory/oathkeeper/issues/418)) ([1ae6e7a](https://github.com/ory/oathkeeper/commit/1ae6e7a958d602533f54cada5d231bcf1bace093)), closes [#417](https://github.com/ory/oathkeeper/issues/417):
+- Add cache to hydrator ([#418](https://github.com/ory/oathkeeper/issues/418))
+  ([1ae6e7a](https://github.com/ory/oathkeeper/commit/1ae6e7a958d602533f54cada5d231bcf1bace093)),
+  closes [#417](https://github.com/ory/oathkeeper/issues/417):
 
-    > This patch introduces new configuration parameters that allow the hydrator mutator to cache requests.
-* Add new remote authorizer that uses request body and headers ([#416](https://github.com/ory/oathkeeper/issues/416)) ([3a20637](https://github.com/ory/oathkeeper/commit/3a206376c0ec4d72d5d6ec66c2d738199a24e0c6)):
+  > This patch introduces new configuration parameters that allow the hydrator
+  > mutator to cache requests.
 
-    > This pull request implements a new authorizer that sends the original request body as body to the remote endpoint. This allows the remote endpoint to take the body into account in its decision.
-    > 
-    > The current remote_json authorizer does not have the ability to send
-    > the request body of the request to authorize. This means this cannot
-    > be taken into account while checking permissions.
-    > 
-    > Providing the request body as part of the JSON payload won't always
-    > work as JSON cannot handle binary data.
-* Add prometheus docs ([#427](https://github.com/ory/oathkeeper/issues/427)) ([117ee6a](https://github.com/ory/oathkeeper/commit/117ee6a4c53035651f41a5bb4a9afe3c8b0c7438))
-* Add prometheus endpoint providing basic request metrics ([#404](https://github.com/ory/oathkeeper/issues/404)) ([fdaed46](https://github.com/ory/oathkeeper/commit/fdaed46bcffbbdf593e94bc1784df88809e63fcd)):
+- Add new remote authorizer that uses request body and headers
+  ([#416](https://github.com/ory/oathkeeper/issues/416))
+  ([3a20637](https://github.com/ory/oathkeeper/commit/3a206376c0ec4d72d5d6ec66c2d738199a24e0c6)):
 
-    > This patch adds basic prometheus metrics. The prometheus metrics are exposed at the default prometheus exporter port 9000 and is configurable with:
-    > 
-    > ```
-    >  serve:
-    >    prometheus:
-    >      port: 9000
-    >      host: localhost
-    >      metrics_path: /metrics
-    > ```
-* Oauth2_introspect cache introspection results ([#424](https://github.com/ory/oathkeeper/issues/424)) ([d4557ae](https://github.com/ory/oathkeeper/commit/d4557aeac69e84d36dfc2a1ab97c61188c93457f)), closes [#293](https://github.com/ory/oathkeeper/issues/293)
+  > This pull request implements a new authorizer that sends the original
+  > request body as body to the remote endpoint. This allows the remote endpoint
+  > to take the body into account in its decision.
+  >
+  > The current remote_json authorizer does not have the ability to send the
+  > request body of the request to authorize. This means this cannot be taken
+  > into account while checking permissions.
+  >
+  > Providing the request body as part of the JSON payload won't always work as
+  > JSON cannot handle binary data.
 
+- Add prometheus docs ([#427](https://github.com/ory/oathkeeper/issues/427))
+  ([117ee6a](https://github.com/ory/oathkeeper/commit/117ee6a4c53035651f41a5bb4a9afe3c8b0c7438))
+- Add prometheus endpoint providing basic request metrics
+  ([#404](https://github.com/ory/oathkeeper/issues/404))
+  ([fdaed46](https://github.com/ory/oathkeeper/commit/fdaed46bcffbbdf593e94bc1784df88809e63fcd)):
 
+  > This patch adds basic prometheus metrics. The prometheus metrics are exposed
+  > at the default prometheus exporter port 9000 and is configurable with:
+  >
+  > ```
+  >  serve:
+  >    prometheus:
+  >      port: 9000
+  >      host: localhost
+  >      metrics_path: /metrics
+  > ```
+
+- Oauth2_introspect cache introspection results
+  ([#424](https://github.com/ory/oathkeeper/issues/424))
+  ([d4557ae](https://github.com/ory/oathkeeper/commit/d4557aeac69e84d36dfc2a1ab97c61188c93457f)),
+  closes [#293](https://github.com/ory/oathkeeper/issues/293)
 
 ## [0.37.1-beta.1](https://github.com/ory/oathkeeper/compare/v0.37.0-beta.1...v0.37.1-beta.1) (2020-04-03)
 
-
 ### Documentation
 
-* Regenerate and update changelog ([4e251e9](https://github.com/ory/oathkeeper/commit/4e251e904a4028a01687b0155108cc9c315e6941))
-
-
+- Regenerate and update changelog
+  ([4e251e9](https://github.com/ory/oathkeeper/commit/4e251e904a4028a01687b0155108cc9c315e6941))
 
 # [0.37.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.36.0-beta.4...v0.37.0-beta.1) (2020-04-02)
 
-
 ### Bug Fixes
 
-* Add rule id to malformed configuration log error ([#386](https://github.com/ory/oathkeeper/issues/386)) ([7688a8d](https://github.com/ory/oathkeeper/commit/7688a8dc4dc0ebd5bd173d77bc7cd8cacc8e50e2))
-* Disable test that fails with low cache hit rate ([#372](https://github.com/ory/oathkeeper/issues/372)) ([5414dda](https://github.com/ory/oathkeeper/commit/5414ddadb0b210d3a90b69183449ba7d5723ba6c)), closes [#371](https://github.com/ory/oathkeeper/issues/371)
-* Improve id_token performance with caching ([#367](https://github.com/ory/oathkeeper/issues/367)) ([47e9fee](https://github.com/ory/oathkeeper/commit/47e9feefcea2d3508932ef3b323709b0bfa0d707)), closes [#364](https://github.com/ory/oathkeeper/issues/364)
-* Load config file only in serve command ([#365](https://github.com/ory/oathkeeper/issues/365)) ([68c8546](https://github.com/ory/oathkeeper/commit/68c85469b4523e5accf3de8e97b97b87416875d3))
-* Replace segment with our own sqa endpoint ([#385](https://github.com/ory/oathkeeper/issues/385)) ([8f63eda](https://github.com/ory/oathkeeper/commit/8f63eda6370fb389307cd8b313437292965a2107))
-* SendOAuth2 introspection scope only when strategy is none ([#379](https://github.com/ory/oathkeeper/issues/379)) ([5e0c8dc](https://github.com/ory/oathkeeper/commit/5e0c8dcdc4a64662f59372a488ec633bcdbc0d85)), closes [#377](https://github.com/ory/oathkeeper/issues/377):
+- Add rule id to malformed configuration log error
+  ([#386](https://github.com/ory/oathkeeper/issues/386))
+  ([7688a8d](https://github.com/ory/oathkeeper/commit/7688a8dc4dc0ebd5bd173d77bc7cd8cacc8e50e2))
+- Disable test that fails with low cache hit rate
+  ([#372](https://github.com/ory/oathkeeper/issues/372))
+  ([5414dda](https://github.com/ory/oathkeeper/commit/5414ddadb0b210d3a90b69183449ba7d5723ba6c)),
+  closes [#371](https://github.com/ory/oathkeeper/issues/371)
+- Improve id_token performance with caching
+  ([#367](https://github.com/ory/oathkeeper/issues/367))
+  ([47e9fee](https://github.com/ory/oathkeeper/commit/47e9feefcea2d3508932ef3b323709b0bfa0d707)),
+  closes [#364](https://github.com/ory/oathkeeper/issues/364)
+- Load config file only in serve command
+  ([#365](https://github.com/ory/oathkeeper/issues/365))
+  ([68c8546](https://github.com/ory/oathkeeper/commit/68c85469b4523e5accf3de8e97b97b87416875d3))
+- Replace segment with our own sqa endpoint
+  ([#385](https://github.com/ory/oathkeeper/issues/385))
+  ([8f63eda](https://github.com/ory/oathkeeper/commit/8f63eda6370fb389307cd8b313437292965a2107))
+- SendOAuth2 introspection scope only when strategy is none
+  ([#379](https://github.com/ory/oathkeeper/issues/379))
+  ([5e0c8dc](https://github.com/ory/oathkeeper/commit/5e0c8dcdc4a64662f59372a488ec633bcdbc0d85)),
+  closes [#377](https://github.com/ory/oathkeeper/issues/377):
 
-    > This patch removes the `scope` key from the OAuth2 Introspection request body when a scope strategy other than `none` is set for the OAuth2 Introspection handler. If the scope strategy is `none`, the `scope` key is included in the body.
-* Token expiration error in tests ([#390](https://github.com/ory/oathkeeper/issues/390)) ([9c07a73](https://github.com/ory/oathkeeper/commit/9c07a7349cdf560c0ba29a637aaec93021757d27))
-* **docker:** Improve docker-compose example ([#325](https://github.com/ory/oathkeeper/issues/325)) ([1247381](https://github.com/ory/oathkeeper/commit/12473815dad3fcbc57ea102dd982170960adb9f6)), closes [#324](https://github.com/ory/oathkeeper/issues/324):
+  > This patch removes the `scope` key from the OAuth2 Introspection request
+  > body when a scope strategy other than `none` is set for the OAuth2
+  > Introspection handler. If the scope strategy is `none`, the `scope` key is
+  > included in the body.
 
-    > Add a new file 'Dockerfile-dc' which will primarily be used by Docker Compose to
-    > build docker images. Unlike the existing Dockerfile which depends on the Makefile
-    > to build the binary, this Dockerfile copies the source code and builds the
-    > binary.
-    > 
-    > Oathkeeper has gone through a couple of changes since the initial draft of the
-    > docker compose file, considering these changes and the newly introduced
-    > Dockerfile in the previous commit, make these changes to the docker-compose.yml:
-    > 1. Bump the version of the compose file to 3.
-    > 2. Remove the need for the postgres database app, since Oathkeeper no longer needs a
-    > database.
-    > 3. Remove the need for the migration app, since we no longer need to migrate since
-    > there is no database and the option is deprecated.
-    > 4. Use the newly defined Dockerfile 'Dockerfile-dc'.
-    > 5. We now serve both API and PROXY from the same app, so we don't need two
-    > instances of the app.
-    > 6. Add sample config, rules and JWK files to `.docker_compose`, mount this via a
-    > volume mount.
+- Token expiration error in tests
+  ([#390](https://github.com/ory/oathkeeper/issues/390))
+  ([9c07a73](https://github.com/ory/oathkeeper/commit/9c07a7349cdf560c0ba29a637aaec93021757d27))
+- **docker:** Improve docker-compose example
+  ([#325](https://github.com/ory/oathkeeper/issues/325))
+  ([1247381](https://github.com/ory/oathkeeper/commit/12473815dad3fcbc57ea102dd982170960adb9f6)),
+  closes [#324](https://github.com/ory/oathkeeper/issues/324):
 
+  > Add a new file 'Dockerfile-dc' which will primarily be used by Docker
+  > Compose to build docker images. Unlike the existing Dockerfile which depends
+  > on the Makefile to build the binary, this Dockerfile copies the source code
+  > and builds the binary.
+  >
+  > Oathkeeper has gone through a couple of changes since the initial draft of
+  > the docker compose file, considering these changes and the newly introduced
+  > Dockerfile in the previous commit, make these changes to the
+  > docker-compose.yml:
+  >
+  > 1. Bump the version of the compose file to 3.
+  > 2. Remove the need for the postgres database app, since Oathkeeper no longer
+  >    needs a database.
+  > 3. Remove the need for the migration app, since we no longer need to migrate
+  >    since there is no database and the option is deprecated.
+  > 4. Use the newly defined Dockerfile 'Dockerfile-dc'.
+  > 5. We now serve both API and PROXY from the same app, so we don't need two
+  >    instances of the app.
+  > 6. Add sample config, rules and JWK files to `.docker_compose`, mount this
+  >    via a volume mount.
 
 ### Documentation
 
-* Change link to Developer Install Guide ([#369](https://github.com/ory/oathkeeper/issues/369)) ([f7fe46f](https://github.com/ory/oathkeeper/commit/f7fe46f9e183c53b5af71592c05cacf6b7584a2c)):
+- Change link to Developer Install Guide
+  ([#369](https://github.com/ory/oathkeeper/issues/369))
+  ([f7fe46f](https://github.com/ory/oathkeeper/commit/f7fe46f9e183c53b5af71592c05cacf6b7584a2c)):
 
-    > Changing the link to the Developer Documentation - it was pointing to Keto and not to Oathkeeper.
-* Document v0.36 and v0.37 ([a176c73](https://github.com/ory/oathkeeper/commit/a176c7301baddbec572e3451830ee1f32dc55c75))
-* Fix examples for some JSON Schema config keys ([#363](https://github.com/ory/oathkeeper/issues/363)) ([aeeb353](https://github.com/ory/oathkeeper/commit/aeeb35399588422ea25780406f1726cad5082315))
-* Regenerate and update changelog ([9417e2c](https://github.com/ory/oathkeeper/commit/9417e2c213a5e9394d88638dc24e36dc2d9b3387))
-* Regenerate and update changelog ([b817037](https://github.com/ory/oathkeeper/commit/b817037fea1131e20fbd829927af00f2a27b951d))
-* Regenerate and update changelog ([33a5524](https://github.com/ory/oathkeeper/commit/33a55240803c6615e8550de371b60d040ae9f2fe))
-* Regenerate and update changelog ([888b7a6](https://github.com/ory/oathkeeper/commit/888b7a6f2255a2e1457fc88712ad4d80b87000ba))
-* Regenerate and update changelog ([36faa3b](https://github.com/ory/oathkeeper/commit/36faa3bbc4a0befd59a61c25664b184fa07baaeb))
-* Regenerate and update changelog ([32b6059](https://github.com/ory/oathkeeper/commit/32b605921b88e163299e47847099ab985e3cbfcd))
-* Regenerate and update changelog ([ba4de09](https://github.com/ory/oathkeeper/commit/ba4de09211f249b6a719308ec5b1ea803642aa20))
-* Regenerate and update changelog ([a76f749](https://github.com/ory/oathkeeper/commit/a76f749dfe5c6ad988da6ba0b2ac4be5a22b0f9d))
-* Regenerate and update changelog ([1789d00](https://github.com/ory/oathkeeper/commit/1789d003699c7140e29b1a1a967f6ccd3b1e6916))
-* Regenerate and update changelog ([0dfc608](https://github.com/ory/oathkeeper/commit/0dfc6081c1da853477737a3ec41a9ac8e51faebc))
-* Regenerate and update changelog ([b23c79a](https://github.com/ory/oathkeeper/commit/b23c79ac318bd394eaf3c48f8d3e6c157a234df9))
-* Regenerate and update changelog ([2117171](https://github.com/ory/oathkeeper/commit/2117171a17b345fb62f9234d3a5443728dca5315))
-* Regenerate and update changelog ([38c9e19](https://github.com/ory/oathkeeper/commit/38c9e19a4b5fe708c60fc694e6ca526d201872eb))
-* Regenerate and update changelog ([e3eda75](https://github.com/ory/oathkeeper/commit/e3eda753c3696345f030c4311b66f29296e4183c))
-* Regenerate and update changelog ([e7d70f7](https://github.com/ory/oathkeeper/commit/e7d70f71bd1d803f4b1e58149875becb8abfa9ad))
-* Regenerate and update changelog ([874b7a9](https://github.com/ory/oathkeeper/commit/874b7a9cb03d28cc40a8f7e242158414075f0961))
-* Regenerate and update changelog ([6b1d94b](https://github.com/ory/oathkeeper/commit/6b1d94b7c3eeae9c69154b85ecdcff7759fd98a9))
-* Regenerate and update changelog ([cb38415](https://github.com/ory/oathkeeper/commit/cb384152a82830f14768d2e0ec30cc8f65c8583c))
-* Regenerate and update changelog ([bec6af0](https://github.com/ory/oathkeeper/commit/bec6af0a9b78a880296fce59eb150ac21ee3d13b))
-* Update forum and chat links ([d9eed10](https://github.com/ory/oathkeeper/commit/d9eed10abd43eb41362fcc0f36e47a6f88658835))
-* Update README.md ([#375](https://github.com/ory/oathkeeper/issues/375)) ([313d2fe](https://github.com/ory/oathkeeper/commit/313d2fe99f699c441e6f8e24abb096e239a17f83)), closes [#374](https://github.com/ory/oathkeeper/issues/374):
+  > Changing the link to the Developer Documentation - it was pointing to Keto
+  > and not to Oathkeeper.
 
-    > Fixed link to Envoy configuration page and added link to AWS API Gateway.
-* Updates issue and pull request templates ([#382](https://github.com/ory/oathkeeper/issues/382)) ([484c406](https://github.com/ory/oathkeeper/commit/484c406785c2633feee3cb9179a94147085cadd6))
+- Document v0.36 and v0.37
+  ([a176c73](https://github.com/ory/oathkeeper/commit/a176c7301baddbec572e3451830ee1f32dc55c75))
+- Fix examples for some JSON Schema config keys
+  ([#363](https://github.com/ory/oathkeeper/issues/363))
+  ([aeeb353](https://github.com/ory/oathkeeper/commit/aeeb35399588422ea25780406f1726cad5082315))
+- Regenerate and update changelog
+  ([9417e2c](https://github.com/ory/oathkeeper/commit/9417e2c213a5e9394d88638dc24e36dc2d9b3387))
+- Regenerate and update changelog
+  ([b817037](https://github.com/ory/oathkeeper/commit/b817037fea1131e20fbd829927af00f2a27b951d))
+- Regenerate and update changelog
+  ([33a5524](https://github.com/ory/oathkeeper/commit/33a55240803c6615e8550de371b60d040ae9f2fe))
+- Regenerate and update changelog
+  ([888b7a6](https://github.com/ory/oathkeeper/commit/888b7a6f2255a2e1457fc88712ad4d80b87000ba))
+- Regenerate and update changelog
+  ([36faa3b](https://github.com/ory/oathkeeper/commit/36faa3bbc4a0befd59a61c25664b184fa07baaeb))
+- Regenerate and update changelog
+  ([32b6059](https://github.com/ory/oathkeeper/commit/32b605921b88e163299e47847099ab985e3cbfcd))
+- Regenerate and update changelog
+  ([ba4de09](https://github.com/ory/oathkeeper/commit/ba4de09211f249b6a719308ec5b1ea803642aa20))
+- Regenerate and update changelog
+  ([a76f749](https://github.com/ory/oathkeeper/commit/a76f749dfe5c6ad988da6ba0b2ac4be5a22b0f9d))
+- Regenerate and update changelog
+  ([1789d00](https://github.com/ory/oathkeeper/commit/1789d003699c7140e29b1a1a967f6ccd3b1e6916))
+- Regenerate and update changelog
+  ([0dfc608](https://github.com/ory/oathkeeper/commit/0dfc6081c1da853477737a3ec41a9ac8e51faebc))
+- Regenerate and update changelog
+  ([b23c79a](https://github.com/ory/oathkeeper/commit/b23c79ac318bd394eaf3c48f8d3e6c157a234df9))
+- Regenerate and update changelog
+  ([2117171](https://github.com/ory/oathkeeper/commit/2117171a17b345fb62f9234d3a5443728dca5315))
+- Regenerate and update changelog
+  ([38c9e19](https://github.com/ory/oathkeeper/commit/38c9e19a4b5fe708c60fc694e6ca526d201872eb))
+- Regenerate and update changelog
+  ([e3eda75](https://github.com/ory/oathkeeper/commit/e3eda753c3696345f030c4311b66f29296e4183c))
+- Regenerate and update changelog
+  ([e7d70f7](https://github.com/ory/oathkeeper/commit/e7d70f71bd1d803f4b1e58149875becb8abfa9ad))
+- Regenerate and update changelog
+  ([874b7a9](https://github.com/ory/oathkeeper/commit/874b7a9cb03d28cc40a8f7e242158414075f0961))
+- Regenerate and update changelog
+  ([6b1d94b](https://github.com/ory/oathkeeper/commit/6b1d94b7c3eeae9c69154b85ecdcff7759fd98a9))
+- Regenerate and update changelog
+  ([cb38415](https://github.com/ory/oathkeeper/commit/cb384152a82830f14768d2e0ec30cc8f65c8583c))
+- Regenerate and update changelog
+  ([bec6af0](https://github.com/ory/oathkeeper/commit/bec6af0a9b78a880296fce59eb150ac21ee3d13b))
+- Update forum and chat links
+  ([d9eed10](https://github.com/ory/oathkeeper/commit/d9eed10abd43eb41362fcc0f36e47a6f88658835))
+- Update README.md ([#375](https://github.com/ory/oathkeeper/issues/375))
+  ([313d2fe](https://github.com/ory/oathkeeper/commit/313d2fe99f699c441e6f8e24abb096e239a17f83)),
+  closes [#374](https://github.com/ory/oathkeeper/issues/374):
 
+  > Fixed link to Envoy configuration page and added link to AWS API Gateway.
+
+- Updates issue and pull request templates
+  ([#382](https://github.com/ory/oathkeeper/issues/382))
+  ([484c406](https://github.com/ory/oathkeeper/commit/484c406785c2633feee3cb9179a94147085cadd6))
 
 ### Features
 
-* **authz:** Add remote_json authorizer ([#389](https://github.com/ory/oathkeeper/issues/389)) ([45b9f8b](https://github.com/ory/oathkeeper/commit/45b9f8b981f0227a92ff5c4001061e86afc0701f)), closes [/github.com/ory/docs/commit/07a229701835d75e9c2e4b939badb2d5b96ae6aa#diff-c400219db6c7e4b6abab71839d9d294eR272](https://github.com//github.com/ory/docs/commit/07a229701835d75e9c2e4b939badb2d5b96ae6aa/issues/diff-c400219db6c7e4b6abab71839d9d294eR272) [#201](https://github.com/ory/oathkeeper/issues/201)
-* Add MatchContext in the AuthenticationSession ([#358](https://github.com/ory/oathkeeper/issues/358)) ([a421293](https://github.com/ory/oathkeeper/commit/a421293a05afaca2ac3695940bc72b4b9f7a1b68))
-* Enable OpenTracing ([#376](https://github.com/ory/oathkeeper/issues/376)) ([cb0f3f2](https://github.com/ory/oathkeeper/commit/cb0f3f23bbf32f04855eff497c36553fc30c7364))
-* **authn:** Make oauth2_intsropsection configurable timeout ([#370](https://github.com/ory/oathkeeper/issues/370)) ([0a39511](https://github.com/ory/oathkeeper/commit/0a395115123e34be0dbb47608a96dad2dca5e60c))
-
+- **authz:** Add remote_json authorizer
+  ([#389](https://github.com/ory/oathkeeper/issues/389))
+  ([45b9f8b](https://github.com/ory/oathkeeper/commit/45b9f8b981f0227a92ff5c4001061e86afc0701f)),
+  closes
+  [/github.com/ory/docs/commit/07a229701835d75e9c2e4b939badb2d5b96ae6aa#diff-c400219db6c7e4b6abab71839d9d294eR272](https://github.com//github.com/ory/docs/commit/07a229701835d75e9c2e4b939badb2d5b96ae6aa/issues/diff-c400219db6c7e4b6abab71839d9d294eR272)
+  [#201](https://github.com/ory/oathkeeper/issues/201)
+- Add MatchContext in the AuthenticationSession
+  ([#358](https://github.com/ory/oathkeeper/issues/358))
+  ([a421293](https://github.com/ory/oathkeeper/commit/a421293a05afaca2ac3695940bc72b4b9f7a1b68))
+- Enable OpenTracing ([#376](https://github.com/ory/oathkeeper/issues/376))
+  ([cb0f3f2](https://github.com/ory/oathkeeper/commit/cb0f3f23bbf32f04855eff497c36553fc30c7364))
+- **authn:** Make oauth2_intsropsection configurable timeout
+  ([#370](https://github.com/ory/oathkeeper/issues/370))
+  ([0a39511](https://github.com/ory/oathkeeper/commit/0a395115123e34be0dbb47608a96dad2dca5e60c))
 
 ### BREAKING CHANGES
 
-* This feature allows to use the regex capture groups from the URL matcher to be used in several places, including the ID Token generator and elsewhere. To get this working, existing `keto_engine_acp_ory` authorizers are no longer able to use regex substition in the form of `my:action:$1` but instead must use the new format which is `{{ printIndex .MatchContext.RegexpCaptureGroups 0}}` (notice that the index changed by *-1*). A rule migrator exists which makes old rules compatible with the new format, if a version string is given. More details on the rule migration can be found here: https://github.com/ory/oathkeeper/pull/358/commits/fd16ceb230a1b14ebb01a147d2d70acce77f9fbd#diff-6177fb19f1b7d7bc392f5062b838df15
-
-
+- This feature allows to use the regex capture groups from the URL matcher to be
+  used in several places, including the ID Token generator and elsewhere. To get
+  this working, existing `keto_engine_acp_ory` authorizers are no longer able to
+  use regex substition in the form of `my:action:$1` but instead must use the
+  new format which is `{{ printIndex .MatchContext.RegexpCaptureGroups 0}}`
+  (notice that the index changed by _-1_). A rule migrator exists which makes
+  old rules compatible with the new format, if a version string is given. More
+  details on the rule migration can be found here:
+  https://github.com/ory/oathkeeper/pull/358/commits/fd16ceb230a1b14ebb01a147d2d70acce77f9fbd#diff-6177fb19f1b7d7bc392f5062b838df15
 
 # [0.36.0-beta.4](https://github.com/ory/oathkeeper/compare/v0.36.0-beta.3...v0.36.0-beta.4) (2020-02-14)
 
-
 ### Bug Fixes
 
-* **goreleaser:** Update brew section ([46fb3da](https://github.com/ory/oathkeeper/commit/46fb3da4fc4ba78b109ba740fb6bb8309a8be0f5))
-
+- **goreleaser:** Update brew section
+  ([46fb3da](https://github.com/ory/oathkeeper/commit/46fb3da4fc4ba78b109ba740fb6bb8309a8be0f5))
 
 ### Documentation
 
-* Regenerate and update changelog ([95a7c09](https://github.com/ory/oathkeeper/commit/95a7c091165b8a9acebedb197208fadc04585d4a))
-
-
+- Regenerate and update changelog
+  ([95a7c09](https://github.com/ory/oathkeeper/commit/95a7c091165b8a9acebedb197208fadc04585d4a))
 
 # [0.36.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.35.5-beta.2...v0.36.0-beta.1) (2020-02-05)
 
-
 ### Documentation
 
-* Prepare ecosystem automation ([81ea56b](https://github.com/ory/oathkeeper/commit/81ea56b46da543c02c5977b27ec3671b5bcc4abe))
-* Regenerate and update changelog ([b71e48c](https://github.com/ory/oathkeeper/commit/b71e48c473bd428286473f8d8472f74187377eb2))
-* Regenerate and update changelog ([4f22e42](https://github.com/ory/oathkeeper/commit/4f22e42e1577c92b8005887dfc1a2dc48a5d392d))
-* Regenerate and update changelog ([23e053f](https://github.com/ory/oathkeeper/commit/23e053fb289e663ae00bdbf9201c2ad1a245226b))
-* Updates issue and pull request templates ([#355](https://github.com/ory/oathkeeper/issues/355)) ([f9251ed](https://github.com/ory/oathkeeper/commit/f9251edeb0d3e482acf278040f95c3f49db5a100))
-
+- Prepare ecosystem automation
+  ([81ea56b](https://github.com/ory/oathkeeper/commit/81ea56b46da543c02c5977b27ec3671b5bcc4abe))
+- Regenerate and update changelog
+  ([b71e48c](https://github.com/ory/oathkeeper/commit/b71e48c473bd428286473f8d8472f74187377eb2))
+- Regenerate and update changelog
+  ([4f22e42](https://github.com/ory/oathkeeper/commit/4f22e42e1577c92b8005887dfc1a2dc48a5d392d))
+- Regenerate and update changelog
+  ([23e053f](https://github.com/ory/oathkeeper/commit/23e053fb289e663ae00bdbf9201c2ad1a245226b))
+- Updates issue and pull request templates
+  ([#355](https://github.com/ory/oathkeeper/issues/355))
+  ([f9251ed](https://github.com/ory/oathkeeper/commit/f9251edeb0d3e482acf278040f95c3f49db5a100))
 
 ### Features
 
-* **ci:** Add nancy vuln scanner ([#354](https://github.com/ory/oathkeeper/issues/354)) ([de36e40](https://github.com/ory/oathkeeper/commit/de36e401134f09762d5815e3fe37d9cb16dd8d81))
-* **rule:** Add glob matching strategy ([#334](https://github.com/ory/oathkeeper/issues/334)) ([5f983ab](https://github.com/ory/oathkeeper/commit/5f983ab118ce784a49a38e6024b99b8791907d4b)), closes [#321](https://github.com/ory/oathkeeper/issues/321):
+- **ci:** Add nancy vuln scanner
+  ([#354](https://github.com/ory/oathkeeper/issues/354))
+  ([de36e40](https://github.com/ory/oathkeeper/commit/de36e401134f09762d5815e3fe37d9cb16dd8d81))
+- **rule:** Add glob matching strategy
+  ([#334](https://github.com/ory/oathkeeper/issues/334))
+  ([5f983ab](https://github.com/ory/oathkeeper/commit/5f983ab118ce784a49a38e6024b99b8791907d4b)),
+  closes [#321](https://github.com/ory/oathkeeper/issues/321):
 
-    > This patch adds the ability to choose a matching strategy and adds a glob-based matching strategy to the available options (regex is still the default).
-
+  > This patch adds the ability to choose a matching strategy and adds a
+  > glob-based matching strategy to the available options (regex is still the
+  > default).
 
 ### Unclassified
 
-* Update CHANGELOG [ci skip] ([8278b9d](https://github.com/ory/oathkeeper/commit/8278b9db8a43c57d4169e232cb9f25ef9257dd8c))
-* Update CHANGELOG [ci skip] ([17f78b7](https://github.com/ory/oathkeeper/commit/17f78b7cdf739f66de3de66199c00e82ff974826))
-* Update CHANGELOG [ci skip] ([d6f6925](https://github.com/ory/oathkeeper/commit/d6f69257b86e249c70a2e808524d43da11315a59))
-* Update CHANGELOG [ci skip] ([0e109ce](https://github.com/ory/oathkeeper/commit/0e109cee1222e8277157807d14f8b9ae7c1120d9))
-
-
+- Update CHANGELOG [ci skip]
+  ([8278b9d](https://github.com/ory/oathkeeper/commit/8278b9db8a43c57d4169e232cb9f25ef9257dd8c))
+- Update CHANGELOG [ci skip]
+  ([17f78b7](https://github.com/ory/oathkeeper/commit/17f78b7cdf739f66de3de66199c00e82ff974826))
+- Update CHANGELOG [ci skip]
+  ([d6f6925](https://github.com/ory/oathkeeper/commit/d6f69257b86e249c70a2e808524d43da11315a59))
+- Update CHANGELOG [ci skip]
+  ([0e109ce](https://github.com/ory/oathkeeper/commit/0e109cee1222e8277157807d14f8b9ae7c1120d9))
 
 ## [0.35.5-beta.2](https://github.com/ory/oathkeeper/compare/v0.35.5-beta.1...v0.35.5-beta.2) (2020-01-31)
 
-
 ### Unclassified
 
-* Update README.md ([a40c613](https://github.com/ory/oathkeeper/commit/a40c613582add4742e245516f5b4fdef31be7cb0))
-* Update CHANGELOG [ci skip] ([963d60d](https://github.com/ory/oathkeeper/commit/963d60d802a56b87390bfdb10632b7e5754398aa))
-
-
+- Update README.md
+  ([a40c613](https://github.com/ory/oathkeeper/commit/a40c613582add4742e245516f5b4fdef31be7cb0))
+- Update CHANGELOG [ci skip]
+  ([963d60d](https://github.com/ory/oathkeeper/commit/963d60d802a56b87390bfdb10632b7e5754398aa))
 
 ## [0.35.5-beta.1](https://github.com/ory/oathkeeper/compare/v0.35.4-beta.1...v0.35.5-beta.1) (2020-01-27)
 
-
 ### Unclassified
 
-* Hash enabled check to further improve performance (#353) ([19099cb](https://github.com/ory/oathkeeper/commit/19099cb86ea236ef503c1274393dd17fd11041ae)), closes [#353](https://github.com/ory/oathkeeper/issues/353)
-* Update CHANGELOG [ci skip] ([6afdeae](https://github.com/ory/oathkeeper/commit/6afdeae82260db0905f2e14a36ff23da59bdb29f))
-* Update CHANGELOG [ci skip] ([3226ae6](https://github.com/ory/oathkeeper/commit/3226ae6d69837ae64d357e92236153c32c19e2cf))
-
-
+- Hash enabled check to further improve performance (#353)
+  ([19099cb](https://github.com/ory/oathkeeper/commit/19099cb86ea236ef503c1274393dd17fd11041ae)),
+  closes [#353](https://github.com/ory/oathkeeper/issues/353)
+- Update CHANGELOG [ci skip]
+  ([6afdeae](https://github.com/ory/oathkeeper/commit/6afdeae82260db0905f2e14a36ff23da59bdb29f))
+- Update CHANGELOG [ci skip]
+  ([3226ae6](https://github.com/ory/oathkeeper/commit/3226ae6d69837ae64d357e92236153c32c19e2cf))
 
 ## [0.35.4-beta.1](https://github.com/ory/oathkeeper/compare/v0.35.3-beta.1...v0.35.4-beta.1) (2020-01-26)
 
-
 ### Unclassified
 
-* Update release pipeline and tests (#351) ([c7d81a9](https://github.com/ory/oathkeeper/commit/c7d81a99243a2adb1387ada12550303c76ae9768)), closes [#351](https://github.com/ory/oathkeeper/issues/351)
-
-
+- Update release pipeline and tests (#351)
+  ([c7d81a9](https://github.com/ory/oathkeeper/commit/c7d81a99243a2adb1387ada12550303c76ae9768)),
+  closes [#351](https://github.com/ory/oathkeeper/issues/351)
 
 ## [0.35.3-beta.1](https://github.com/ory/oathkeeper/compare/v0.35.1-beta.1...v0.35.3-beta.1) (2020-01-26)
 
-
 ### Documentation
 
-* Updates issue and pull request templates ([#341](https://github.com/ory/oathkeeper/issues/341)) ([eca2652](https://github.com/ory/oathkeeper/commit/eca26527f64cb80b8df2df96910a33f993d9af37))
-
+- Updates issue and pull request templates
+  ([#341](https://github.com/ory/oathkeeper/issues/341))
+  ([eca2652](https://github.com/ory/oathkeeper/commit/eca26527f64cb80b8df2df96910a33f993d9af37))
 
 ### Unclassified
 
-* Update CHANGELOG [ci skip] ([518b765](https://github.com/ory/oathkeeper/commit/518b76578519786921ef0d209f3f83dcfd6f217b))
-* Update SDK ([5e619a0](https://github.com/ory/oathkeeper/commit/5e619a03687cbfe71b559d8945062a3fa4a5e4f3))
-* Cache pipeline config and improve request latency ([#348](https://github.com/ory/oathkeeper/issues/348)) ([95673ed](https://github.com/ory/oathkeeper/commit/95673eddf02968250359067a3fe887adb46c2be6)), closes [#346](https://github.com/ory/oathkeeper/issues/346)
-* Update CHANGELOG [ci skip] ([495adcf](https://github.com/ory/oathkeeper/commit/495adcf2af7c2f161c9845cb358ef33f9afb42f3))
-* Use integer instead of number in config JSON schema ([280b42f](https://github.com/ory/oathkeeper/commit/280b42fdedc0305b40398a2a213848d64d52e6c0))
-* Update CHANGELOG [ci skip] ([b72965f](https://github.com/ory/oathkeeper/commit/b72965fce04941733f45277777349cfad6f41062))
-* Update SDK ([aedabd9](https://github.com/ory/oathkeeper/commit/aedabd9834bb3a316b211f82cc4d9d9f90ab3bd6))
-* Set min/max for port range in config JSON Schema (#345) ([d7d696f](https://github.com/ory/oathkeeper/commit/d7d696f62e91cf9d0300a1af8e2fd70676164ec6)), closes [#345](https://github.com/ory/oathkeeper/issues/345)
-* Update CHANGELOG [ci skip] ([8e4d58c](https://github.com/ory/oathkeeper/commit/8e4d58ce809dd10e98a3ad3530cdd81b24a967f0))
-* Fix profiling env variable not being picked up (#343) ([29b0cf1](https://github.com/ory/oathkeeper/commit/29b0cf14de575434ce94def5e6031b76e28042de)), closes [#343](https://github.com/ory/oathkeeper/issues/343)
-* Update CHANGELOG [ci skip] ([e7a5d89](https://github.com/ory/oathkeeper/commit/e7a5d8928d9ef4def4bf53063c24b27d07e08946))
-* Update CHANGELOG [ci skip] ([abc00d4](https://github.com/ory/oathkeeper/commit/abc00d46ec26debe6983f11e3a013865c969e6e6))
-* Update SDK ([a237c29](https://github.com/ory/oathkeeper/commit/a237c2975efc34fc63a2fdb302b1086d072d2146))
-* Update broken links in README ([78e498c](https://github.com/ory/oathkeeper/commit/78e498c0eb24380671364d333447abd0f25de1e8))
-
-
+- Update CHANGELOG [ci skip]
+  ([518b765](https://github.com/ory/oathkeeper/commit/518b76578519786921ef0d209f3f83dcfd6f217b))
+- Update SDK
+  ([5e619a0](https://github.com/ory/oathkeeper/commit/5e619a03687cbfe71b559d8945062a3fa4a5e4f3))
+- Cache pipeline config and improve request latency
+  ([#348](https://github.com/ory/oathkeeper/issues/348))
+  ([95673ed](https://github.com/ory/oathkeeper/commit/95673eddf02968250359067a3fe887adb46c2be6)),
+  closes [#346](https://github.com/ory/oathkeeper/issues/346)
+- Update CHANGELOG [ci skip]
+  ([495adcf](https://github.com/ory/oathkeeper/commit/495adcf2af7c2f161c9845cb358ef33f9afb42f3))
+- Use integer instead of number in config JSON schema
+  ([280b42f](https://github.com/ory/oathkeeper/commit/280b42fdedc0305b40398a2a213848d64d52e6c0))
+- Update CHANGELOG [ci skip]
+  ([b72965f](https://github.com/ory/oathkeeper/commit/b72965fce04941733f45277777349cfad6f41062))
+- Update SDK
+  ([aedabd9](https://github.com/ory/oathkeeper/commit/aedabd9834bb3a316b211f82cc4d9d9f90ab3bd6))
+- Set min/max for port range in config JSON Schema (#345)
+  ([d7d696f](https://github.com/ory/oathkeeper/commit/d7d696f62e91cf9d0300a1af8e2fd70676164ec6)),
+  closes [#345](https://github.com/ory/oathkeeper/issues/345)
+- Update CHANGELOG [ci skip]
+  ([8e4d58c](https://github.com/ory/oathkeeper/commit/8e4d58ce809dd10e98a3ad3530cdd81b24a967f0))
+- Fix profiling env variable not being picked up (#343)
+  ([29b0cf1](https://github.com/ory/oathkeeper/commit/29b0cf14de575434ce94def5e6031b76e28042de)),
+  closes [#343](https://github.com/ory/oathkeeper/issues/343)
+- Update CHANGELOG [ci skip]
+  ([e7a5d89](https://github.com/ory/oathkeeper/commit/e7a5d8928d9ef4def4bf53063c24b27d07e08946))
+- Update CHANGELOG [ci skip]
+  ([abc00d4](https://github.com/ory/oathkeeper/commit/abc00d46ec26debe6983f11e3a013865c969e6e6))
+- Update SDK
+  ([a237c29](https://github.com/ory/oathkeeper/commit/a237c2975efc34fc63a2fdb302b1086d072d2146))
+- Update broken links in README
+  ([78e498c](https://github.com/ory/oathkeeper/commit/78e498c0eb24380671364d333447abd0f25de1e8))
 
 ## [0.35.1-beta.1](https://github.com/ory/oathkeeper/compare/v0.35.0-beta.1...v0.35.1-beta.1) (2020-01-14)
 
-
 ### Unclassified
 
-* Update CHANGELOG [ci skip] ([63b0076](https://github.com/ory/oathkeeper/commit/63b0076a264537ffd22f6f787c508598306c8661))
-
-
+- Update CHANGELOG [ci skip]
+  ([63b0076](https://github.com/ory/oathkeeper/commit/63b0076a264537ffd22f6f787c508598306c8661))
 
 # [0.35.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.35.0-alpha.1...v0.35.0-beta.1) (2020-01-13)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.34.0-beta.1 [ci skip] ([a8a62b4](https://github.com/ory/oathkeeper/commit/a8a62b4b4ba2d6fe2cb319ccbff4ed8634086238))
-* Incorporates changes from version v0.34.0-beta.1-2-g7516eed [ci skip] ([eb82132](https://github.com/ory/oathkeeper/commit/eb82132ac36413d9ef151a3d6958f3baa6324a7d))
-* Incorporates changes from version v0.34.0-beta.1-4-gee2b9e7 [ci skip] ([d084c39](https://github.com/ory/oathkeeper/commit/d084c396d28a13f9fa845acb7190f21e705c9b71))
-* Incorporates changes from version v0.34.0-beta.1-6-g6723fb8 [ci skip] ([ebe89ab](https://github.com/ory/oathkeeper/commit/ebe89ab65d035b0ff2e4ad9c70c59fe36a180635))
-
+- Incorporates changes from version v0.34.0-beta.1 [ci skip]
+  ([a8a62b4](https://github.com/ory/oathkeeper/commit/a8a62b4b4ba2d6fe2cb319ccbff4ed8634086238))
+- Incorporates changes from version v0.34.0-beta.1-2-g7516eed [ci skip]
+  ([eb82132](https://github.com/ory/oathkeeper/commit/eb82132ac36413d9ef151a3d6958f3baa6324a7d))
+- Incorporates changes from version v0.34.0-beta.1-4-gee2b9e7 [ci skip]
+  ([d084c39](https://github.com/ory/oathkeeper/commit/d084c396d28a13f9fa845acb7190f21e705c9b71))
+- Incorporates changes from version v0.34.0-beta.1-6-g6723fb8 [ci skip]
+  ([ebe89ab](https://github.com/ory/oathkeeper/commit/ebe89ab65d035b0ff2e4ad9c70c59fe36a180635))
 
 ### Unclassified
 
-* Update CHANGELOG [ci skip] ([f0e8ecf](https://github.com/ory/oathkeeper/commit/f0e8ecfc416d342985436b61a20e3d52c642e280))
-* Update SDK ([6a0a0f8](https://github.com/ory/oathkeeper/commit/6a0a0f81bcda1417f7530fe85cd01c2862956328))
-* Update upgrade guide (#337) ([99e9877](https://github.com/ory/oathkeeper/commit/99e98770dd764005e1967daf739dd23974384d19)), closes [#337](https://github.com/ory/oathkeeper/issues/337)
-* Update CHANGELOG [ci skip] ([2e13a05](https://github.com/ory/oathkeeper/commit/2e13a057da6fc626e9e856548746174c3ef7c2e7))
-* Remove superfluous version from workflows ([55037fa](https://github.com/ory/oathkeeper/commit/55037fa0341a35992285d53be398ccf239b2fb58))
-* Update CHANGELOG [ci skip] ([dfbc231](https://github.com/ory/oathkeeper/commit/dfbc231b8e2370089b2605a76252333b488bbc37))
-* Update SDK ([65222d5](https://github.com/ory/oathkeeper/commit/65222d55494b8b3a91e6c0cbe43a2d922f7c753b))
-* Move to new SDK pipeline (#333) ([6940dc8](https://github.com/ory/oathkeeper/commit/6940dc8de74de9c8be9f872df7cf3bc4bc079aa9)), closes [#333](https://github.com/ory/oathkeeper/issues/333)
-* authn/cookie_session: Add subject_from modifier (#336) ([6723fb8](https://github.com/ory/oathkeeper/commit/6723fb834c386b72e9525d2dfd661e684bd915d3)), closes [#336](https://github.com/ory/oathkeeper/issues/336):
+- Update CHANGELOG [ci skip]
+  ([f0e8ecf](https://github.com/ory/oathkeeper/commit/f0e8ecfc416d342985436b61a20e3d52c642e280))
+- Update SDK
+  ([6a0a0f8](https://github.com/ory/oathkeeper/commit/6a0a0f81bcda1417f7530fe85cd01c2862956328))
+- Update upgrade guide (#337)
+  ([99e9877](https://github.com/ory/oathkeeper/commit/99e98770dd764005e1967daf739dd23974384d19)),
+  closes [#337](https://github.com/ory/oathkeeper/issues/337)
+- Update CHANGELOG [ci skip]
+  ([2e13a05](https://github.com/ory/oathkeeper/commit/2e13a057da6fc626e9e856548746174c3ef7c2e7))
+- Remove superfluous version from workflows
+  ([55037fa](https://github.com/ory/oathkeeper/commit/55037fa0341a35992285d53be398ccf239b2fb58))
+- Update CHANGELOG [ci skip]
+  ([dfbc231](https://github.com/ory/oathkeeper/commit/dfbc231b8e2370089b2605a76252333b488bbc37))
+- Update SDK
+  ([65222d5](https://github.com/ory/oathkeeper/commit/65222d55494b8b3a91e6c0cbe43a2d922f7c753b))
+- Move to new SDK pipeline (#333)
+  ([6940dc8](https://github.com/ory/oathkeeper/commit/6940dc8de74de9c8be9f872df7cf3bc4bc079aa9)),
+  closes [#333](https://github.com/ory/oathkeeper/issues/333)
+- authn/cookie_session: Add subject_from modifier (#336)
+  ([6723fb8](https://github.com/ory/oathkeeper/commit/6723fb834c386b72e9525d2dfd661e684bd915d3)),
+  closes [#336](https://github.com/ory/oathkeeper/issues/336):
 
-    > The subject_from modifier is a GJSON path that points to the `subject` field. Useful if the upstream API does not return a `{"subject": "..."}` format.
-    > 
-    > 
-* authn/cookie_session: Add extra_from modifier (#335) ([ee2b9e7](https://github.com/ory/oathkeeper/commit/ee2b9e743f4f6c56563d791947ffb592cc13394e)), closes [#335](https://github.com/ory/oathkeeper/issues/335):
+  > The subject_from modifier is a GJSON path that points to the `subject`
+  > field. Useful if the upstream API does not return a `{"subject": "..."}`
+  > format.
 
-    > The extra_from modifier is a GJSON path that points to the extra field. Useful if the upstream API does not return a `{"subject": "...", "extra": "..."}` format.
-* pipeline/authn: Add tests for cookie sources in jwt and oauth2_intro (#330) (#331) ([7516eed](https://github.com/ory/oathkeeper/commit/7516eedc1ea97242a18225365898e0cbeafcffbf)), closes [#330](https://github.com/ory/oathkeeper/issues/330) [#331](https://github.com/ory/oathkeeper/issues/331) [#330](https://github.com/ory/oathkeeper/issues/330):
+- authn/cookie_session: Add extra_from modifier (#335)
+  ([ee2b9e7](https://github.com/ory/oathkeeper/commit/ee2b9e743f4f6c56563d791947ffb592cc13394e)),
+  closes [#335](https://github.com/ory/oathkeeper/issues/335):
 
-    > Also updates the schemas to add missing cookie config element.
+  > The extra_from modifier is a GJSON path that points to the extra field.
+  > Useful if the upstream API does not return a
+  > `{"subject": "...", "extra": "..."}` format.
 
+- pipeline/authn: Add tests for cookie sources in jwt and oauth2_intro (#330)
+  (#331)
+  ([7516eed](https://github.com/ory/oathkeeper/commit/7516eedc1ea97242a18225365898e0cbeafcffbf)),
+  closes [#330](https://github.com/ory/oathkeeper/issues/330)
+  [#331](https://github.com/ory/oathkeeper/issues/331)
+  [#330](https://github.com/ory/oathkeeper/issues/330):
 
+  > Also updates the schemas to add missing cookie config element.
 
 # [0.34.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.33.1-beta.1...v0.34.0-beta.1) (2019-12-26)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.33.1-beta.1 [ci skip] ([6681754](https://github.com/ory/oathkeeper/commit/66817540313ec989ceb359927dafe3c8252849c2))
-* Incorporates changes from version v0.33.1-beta.1-2-g4033321 [ci skip] ([2764758](https://github.com/ory/oathkeeper/commit/2764758dfc2d86ed6ff2163fbf0f7e28383fa5da))
-* Incorporates changes from version v0.33.1-beta.1-4-g7e6f636 [ci skip] ([66ae8c8](https://github.com/ory/oathkeeper/commit/66ae8c81ec4e631eb3e243eebafbfe4d7436eccf))
-
+- Incorporates changes from version v0.33.1-beta.1 [ci skip]
+  ([6681754](https://github.com/ory/oathkeeper/commit/66817540313ec989ceb359927dafe3c8252849c2))
+- Incorporates changes from version v0.33.1-beta.1-2-g4033321 [ci skip]
+  ([2764758](https://github.com/ory/oathkeeper/commit/2764758dfc2d86ed6ff2163fbf0f7e28383fa5da))
+- Incorporates changes from version v0.33.1-beta.1-4-g7e6f636 [ci skip]
+  ([66ae8c8](https://github.com/ory/oathkeeper/commit/66ae8c81ec4e631eb3e243eebafbfe4d7436eccf))
 
 ### Unclassified
 
-* Prepare v0.34.0-beta.1+oryOS.14 release ([96f77b2](https://github.com/ory/oathkeeper/commit/96f77b24d8adb160d5c2c3db2f2432e206b99c77))
-* pipe/err: Improve IP and MIME matching (#323) ([7e6f636](https://github.com/ory/oathkeeper/commit/7e6f6369f4acc33211d78f2acb1036c610286c2c)), closes [#323](https://github.com/ory/oathkeeper/issues/323):
+- Prepare v0.34.0-beta.1+oryOS.14 release
+  ([96f77b2](https://github.com/ory/oathkeeper/commit/96f77b24d8adb160d5c2c3db2f2432e206b99c77))
+- pipe/err: Improve IP and MIME matching (#323)
+  ([7e6f636](https://github.com/ory/oathkeeper/commit/7e6f6369f4acc33211d78f2acb1036c610286c2c)),
+  closes [#323](https://github.com/ory/oathkeeper/issues/323):
 
-    > Previously, MIME matching respected the request's wildcards which lead to multiple handlers feeling responsible for a particular request. Now, wildcards coming from the HTTP Request itself are interpreted literally.
-    > 
-    > Additionally, ORY Oathkeeper respected the X-Forwarded-For HTTP Header for matching remote IP addresses. This behavior is now turned off by default because clients were able to fake this header otherwise. It can explicitly be turned on by setting `config.when.#.request.remote_ip.RespectForwardedForHeader: true`.
-    > 
-    > 
-* Add customizable error handlers (#322) ([4033321](https://github.com/ory/oathkeeper/commit/4033321b13671de8d0d5a42846a4e19d6065db62)), closes [#322](https://github.com/ory/oathkeeper/issues/322) [#204](https://github.com/ory/oathkeeper/issues/204) [#252](https://github.com/ory/oathkeeper/issues/252) [#119](https://github.com/ory/oathkeeper/issues/119):
+  > Previously, MIME matching respected the request's wildcards which lead to
+  > multiple handlers feeling responsible for a particular request. Now,
+  > wildcards coming from the HTTP Request itself are interpreted literally.
+  >
+  > Additionally, ORY Oathkeeper respected the X-Forwarded-For HTTP Header for
+  > matching remote IP addresses. This behavior is now turned off by default
+  > because clients were able to fake this header otherwise. It can explicitly
+  > be turned on by setting
+  > `config.when.#.request.remote_ip.RespectForwardedForHeader: true`.
 
-    > This patch adds a new feature called error handlers. It allows to define the error handling logic globally and per rule. It is now possible, for example, to return a JSON response for `Accept: application/json` requests and a HTTP Redirect response for requests that are coming from a user.
-    > 
-    > This also resolves several issues, as noted below:
+- Add customizable error handlers (#322)
+  ([4033321](https://github.com/ory/oathkeeper/commit/4033321b13671de8d0d5a42846a4e19d6065db62)),
+  closes [#322](https://github.com/ory/oathkeeper/issues/322)
+  [#204](https://github.com/ory/oathkeeper/issues/204)
+  [#252](https://github.com/ory/oathkeeper/issues/252)
+  [#119](https://github.com/ory/oathkeeper/issues/119):
 
-
+  > This patch adds a new feature called error handlers. It allows to define the
+  > error handling logic globally and per rule. It is now possible, for example,
+  > to return a JSON response for `Accept: application/json` requests and a HTTP
+  > Redirect response for requests that are coming from a user.
+  >
+  > This also resolves several issues, as noted below:
 
 ## [0.33.1-beta.1](https://github.com/ory/oathkeeper/compare/v0.33.0-beta.1...v0.33.1-beta.1) (2019-12-18)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.33.0-beta.1 [ci skip] ([a178031](https://github.com/ory/oathkeeper/commit/a178031f000a405a7962046e0e8582c309ac8989))
-* Incorporates changes from version v0.33.0-beta.1-10-g3e7936a [ci skip] ([083b7eb](https://github.com/ory/oathkeeper/commit/083b7eb35a7d26762bbf930b03969297ac931805))
-* Incorporates changes from version v0.33.0-beta.1-12-g0dd3fe3 [ci skip] ([82c5253](https://github.com/ory/oathkeeper/commit/82c525324490f1d9e073ff8af60abdbfbb722c30))
-* Incorporates changes from version v0.33.0-beta.1-6-gf60f525 [ci skip] ([9870722](https://github.com/ory/oathkeeper/commit/987072248ad8e5e0ae0179d684f3f9f5b8124fbc))
-* Incorporates changes from version v0.33.0-beta.1-8-g815951b [ci skip] ([d77b225](https://github.com/ory/oathkeeper/commit/d77b225555356e4a2010eb6d707bf718c1620956))
-
+- Incorporates changes from version v0.33.0-beta.1 [ci skip]
+  ([a178031](https://github.com/ory/oathkeeper/commit/a178031f000a405a7962046e0e8582c309ac8989))
+- Incorporates changes from version v0.33.0-beta.1-10-g3e7936a [ci skip]
+  ([083b7eb](https://github.com/ory/oathkeeper/commit/083b7eb35a7d26762bbf930b03969297ac931805))
+- Incorporates changes from version v0.33.0-beta.1-12-g0dd3fe3 [ci skip]
+  ([82c5253](https://github.com/ory/oathkeeper/commit/82c525324490f1d9e073ff8af60abdbfbb722c30))
+- Incorporates changes from version v0.33.0-beta.1-6-gf60f525 [ci skip]
+  ([9870722](https://github.com/ory/oathkeeper/commit/987072248ad8e5e0ae0179d684f3f9f5b8124fbc))
+- Incorporates changes from version v0.33.0-beta.1-8-g815951b [ci skip]
+  ([d77b225](https://github.com/ory/oathkeeper/commit/d77b225555356e4a2010eb6d707bf718c1620956))
 
 ### Unclassified
 
-* Add health check commands ([#319](https://github.com/ory/oathkeeper/issues/319)) ([0dd3fe3](https://github.com/ory/oathkeeper/commit/0dd3fe32a4c76b3b2c14a17108521eb51e5e4ff0))
-* Properly merge env vars into pipeline configs (#320) ([3e7936a](https://github.com/ory/oathkeeper/commit/3e7936a41150f367003c81c208910fdb77f556d9)), closes [#320](https://github.com/ory/oathkeeper/issues/320) [#305](https://github.com/ory/oathkeeper/issues/305) [#317](https://github.com/ory/oathkeeper/issues/317):
+- Add health check commands
+  ([#319](https://github.com/ory/oathkeeper/issues/319))
+  ([0dd3fe3](https://github.com/ory/oathkeeper/commit/0dd3fe32a4c76b3b2c14a17108521eb51e5e4ff0))
+- Properly merge env vars into pipeline configs (#320)
+  ([3e7936a](https://github.com/ory/oathkeeper/commit/3e7936a41150f367003c81c208910fdb77f556d9)),
+  closes [#320](https://github.com/ory/oathkeeper/issues/320)
+  [#305](https://github.com/ory/oathkeeper/issues/305)
+  [#317](https://github.com/ory/oathkeeper/issues/317):
 
-    > Previously, some keys did not respect the values set in the environment variables.
-* Add alpine-based Docker image (#318) ([815951b](https://github.com/ory/oathkeeper/commit/815951bb039937acc7be3f8b1b2bb06fe9ecac90)), closes [#318](https://github.com/ory/oathkeeper/issues/318) [#312](https://github.com/ory/oathkeeper/issues/312)
-* Add more details to decision logging (#316) ([f60f525](https://github.com/ory/oathkeeper/commit/f60f52538ff6e66ea98afc89c6c6557ab8c5f93f)), closes [#316](https://github.com/ory/oathkeeper/issues/316) [#244](https://github.com/ory/oathkeeper/issues/244) [#242](https://github.com/ory/oathkeeper/issues/242):
+  > Previously, some keys did not respect the values set in the environment
+  > variables.
 
-    > Adds details such as the HTTP Method, User Agent, Subject, and other information to the logging output of both the reverse proxy and the decision API.
-* Health endpoints now emit TRACE logs ([#314](https://github.com/ory/oathkeeper/issues/314)) ([9036f8e](https://github.com/ory/oathkeeper/commit/9036f8eec3f264f7bcae46b44286367b8521802a)), closes [#283](https://github.com/ory/oathkeeper/issues/283):
+- Add alpine-based Docker image (#318)
+  ([815951b](https://github.com/ory/oathkeeper/commit/815951bb039937acc7be3f8b1b2bb06fe9ecac90)),
+  closes [#318](https://github.com/ory/oathkeeper/issues/318)
+  [#312](https://github.com/ory/oathkeeper/issues/312)
+- Add more details to decision logging (#316)
+  ([f60f525](https://github.com/ory/oathkeeper/commit/f60f52538ff6e66ea98afc89c6c6557ab8c5f93f)),
+  closes [#316](https://github.com/ory/oathkeeper/issues/316)
+  [#244](https://github.com/ory/oathkeeper/issues/244)
+  [#242](https://github.com/ory/oathkeeper/issues/242):
 
-    > Remove health endpoints from the logs to make monitoring easier. Setting `log_level` to `trace` will show these calls.
-* Improve session endpoint debugability ([#315](https://github.com/ory/oathkeeper/issues/315)) ([2718639](https://github.com/ory/oathkeeper/commit/27186396ccff4ee3a7f8f0a4c703263fcc55afae)), closes [#300](https://github.com/ory/oathkeeper/issues/300)
-* Resolve matcher cache ([#313](https://github.com/ory/oathkeeper/issues/313)) ([1519632](https://github.com/ory/oathkeeper/commit/15196326d2436c2d849d955bf5050766ae6dff0c)), closes [#291](https://github.com/ory/oathkeeper/issues/291):
+  > Adds details such as the HTTP Method, User Agent, Subject, and other
+  > information to the logging output of both the reverse proxy and the decision
+  > API.
 
-    > A bug caused the rule matcher to not cache the regular expression result.
-* Use bearer splitting when header is set to Authorization ([#311](https://github.com/ory/oathkeeper/issues/311)) ([464fa31](https://github.com/ory/oathkeeper/commit/464fa319e84953835b71e16360bab3016b8bfc64)), closes [#308](https://github.com/ory/oathkeeper/issues/308)
+- Health endpoints now emit TRACE logs
+  ([#314](https://github.com/ory/oathkeeper/issues/314))
+  ([9036f8e](https://github.com/ory/oathkeeper/commit/9036f8eec3f264f7bcae46b44286367b8521802a)),
+  closes [#283](https://github.com/ory/oathkeeper/issues/283):
 
+  > Remove health endpoints from the logs to make monitoring easier. Setting
+  > `log_level` to `trace` will show these calls.
 
+- Improve session endpoint debugability
+  ([#315](https://github.com/ory/oathkeeper/issues/315))
+  ([2718639](https://github.com/ory/oathkeeper/commit/27186396ccff4ee3a7f8f0a4c703263fcc55afae)),
+  closes [#300](https://github.com/ory/oathkeeper/issues/300)
+- Resolve matcher cache ([#313](https://github.com/ory/oathkeeper/issues/313))
+  ([1519632](https://github.com/ory/oathkeeper/commit/15196326d2436c2d849d955bf5050766ae6dff0c)),
+  closes [#291](https://github.com/ory/oathkeeper/issues/291):
+
+  > A bug caused the rule matcher to not cache the regular expression result.
+
+- Use bearer splitting when header is set to Authorization
+  ([#311](https://github.com/ory/oathkeeper/issues/311))
+  ([464fa31](https://github.com/ory/oathkeeper/commit/464fa319e84953835b71e16360bab3016b8bfc64)),
+  closes [#308](https://github.com/ory/oathkeeper/issues/308)
 
 # [0.33.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.32.1-beta.1...v0.33.0-beta.1) (2019-12-16)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.32.1-beta.1 [ci skip] ([98c9bf8](https://github.com/ory/oathkeeper/commit/98c9bf8c92e068bac2f0e9148fd9fc357aadd78f))
-* Incorporates changes from version v0.32.1-beta.1-5-gf028719 [ci skip] ([9f9c00c](https://github.com/ory/oathkeeper/commit/9f9c00cba904da0cdee4d97f5e3cad48160d75a0))
-
+- Incorporates changes from version v0.32.1-beta.1 [ci skip]
+  ([98c9bf8](https://github.com/ory/oathkeeper/commit/98c9bf8c92e068bac2f0e9148fd9fc357aadd78f))
+- Incorporates changes from version v0.32.1-beta.1-5-gf028719 [ci skip]
+  ([9f9c00c](https://github.com/ory/oathkeeper/commit/9f9c00cba904da0cdee4d97f5e3cad48160d75a0))
 
 ### Unclassified
 
-* pipeline/mutator: Refactor hydrator retry config  (#287) ([2a97e05](https://github.com/ory/oathkeeper/commit/2a97e051a98da588aa8125bc0c6681e2d39c48ef)), closes [#287](https://github.com/ory/oathkeeper/issues/287)
-* Update README banner (#307) ([f028719](https://github.com/ory/oathkeeper/commit/f028719f054e314045f9830c016bfbde5bf04110)), closes [#307](https://github.com/ory/oathkeeper/issues/307)
-* Add cookie as an option for oauth2_introspection authenticator (#301) ([e3fa55a](https://github.com/ory/oathkeeper/commit/e3fa55a77f020fcdb55a8b363b2196570f080d16)), closes [#301](https://github.com/ory/oathkeeper/issues/301)
-* Add preserve_path option for cookie session to not override the path in the request (#297) ([7e86b78](https://github.com/ory/oathkeeper/commit/7e86b78355447cfbbfd83d04dcc2bf7c942dfc67)), closes [#297](https://github.com/ory/oathkeeper/issues/297)
-* Allow specifying additional headers for the oauth introspection request (#302) ([b1e5cea](https://github.com/ory/oathkeeper/commit/b1e5cea5245c07142b6b34f2660ed41e6239b79f)), closes [#302](https://github.com/ory/oathkeeper/issues/302)
-
-
+- pipeline/mutator: Refactor hydrator retry config (#287)
+  ([2a97e05](https://github.com/ory/oathkeeper/commit/2a97e051a98da588aa8125bc0c6681e2d39c48ef)),
+  closes [#287](https://github.com/ory/oathkeeper/issues/287)
+- Update README banner (#307)
+  ([f028719](https://github.com/ory/oathkeeper/commit/f028719f054e314045f9830c016bfbde5bf04110)),
+  closes [#307](https://github.com/ory/oathkeeper/issues/307)
+- Add cookie as an option for oauth2_introspection authenticator (#301)
+  ([e3fa55a](https://github.com/ory/oathkeeper/commit/e3fa55a77f020fcdb55a8b363b2196570f080d16)),
+  closes [#301](https://github.com/ory/oathkeeper/issues/301)
+- Add preserve_path option for cookie session to not override the path in the
+  request (#297)
+  ([7e86b78](https://github.com/ory/oathkeeper/commit/7e86b78355447cfbbfd83d04dcc2bf7c942dfc67)),
+  closes [#297](https://github.com/ory/oathkeeper/issues/297)
+- Allow specifying additional headers for the oauth introspection request (#302)
+  ([b1e5cea](https://github.com/ory/oathkeeper/commit/b1e5cea5245c07142b6b34f2660ed41e6239b79f)),
+  closes [#302](https://github.com/ory/oathkeeper/issues/302)
 
 ## [0.32.1-beta.1](https://github.com/ory/oathkeeper/compare/v0.32.0-beta.1...v0.32.1-beta.1) (2019-10-30)
 
-
 ### Documentation
 
-* Add notes for 0.32.0 ([40e3b89](https://github.com/ory/oathkeeper/commit/40e3b891b99a41bee4b7be1a2cf7463bfb64f8db))
-* Incorporates changes from version v0.32.0-beta.1 [ci skip] ([f3a0e53](https://github.com/ory/oathkeeper/commit/f3a0e53762d31a1f7155ef75f08d7853aa6ec524))
-* Incorporates changes from version v0.32.0-beta.1-11-g7892d2f [ci skip] ([c41ecd4](https://github.com/ory/oathkeeper/commit/c41ecd4cbb23abc6b4264596ddd7881bf3c81845))
-* Incorporates changes from version v0.32.0-beta.1-13-g1910bbe [ci skip] ([d45e1a0](https://github.com/ory/oathkeeper/commit/d45e1a0e9507dc87f3681bc05b125ceb237b2713))
-* Incorporates changes from version v0.32.0-beta.1-3-g8cf6868 [ci skip] ([2c8fbf7](https://github.com/ory/oathkeeper/commit/2c8fbf7a2f74455690bcca4426bfff430e3068f4))
-* Incorporates changes from version v0.32.0-beta.1-9-g08d42da [ci skip] ([6ce3344](https://github.com/ory/oathkeeper/commit/6ce33442285c18b9a31103d32e095d9dad12228c))
-
+- Add notes for 0.32.0
+  ([40e3b89](https://github.com/ory/oathkeeper/commit/40e3b891b99a41bee4b7be1a2cf7463bfb64f8db))
+- Incorporates changes from version v0.32.0-beta.1 [ci skip]
+  ([f3a0e53](https://github.com/ory/oathkeeper/commit/f3a0e53762d31a1f7155ef75f08d7853aa6ec524))
+- Incorporates changes from version v0.32.0-beta.1-11-g7892d2f [ci skip]
+  ([c41ecd4](https://github.com/ory/oathkeeper/commit/c41ecd4cbb23abc6b4264596ddd7881bf3c81845))
+- Incorporates changes from version v0.32.0-beta.1-13-g1910bbe [ci skip]
+  ([d45e1a0](https://github.com/ory/oathkeeper/commit/d45e1a0e9507dc87f3681bc05b125ceb237b2713))
+- Incorporates changes from version v0.32.0-beta.1-3-g8cf6868 [ci skip]
+  ([2c8fbf7](https://github.com/ory/oathkeeper/commit/2c8fbf7a2f74455690bcca4426bfff430e3068f4))
+- Incorporates changes from version v0.32.0-beta.1-9-g08d42da [ci skip]
+  ([6ce3344](https://github.com/ory/oathkeeper/commit/6ce33442285c18b9a31103d32e095d9dad12228c))
 
 ### Unclassified
 
-* pipeline/authz: Add Content-Type header in the call to Keto (#290) ([1910bbe](https://github.com/ory/oathkeeper/commit/1910bbedc215c2b18c018cf9a5d5f86b6b3411c3)), closes [#290](https://github.com/ory/oathkeeper/issues/290)
-* Revert incorrect license changes ([7892d2f](https://github.com/ory/oathkeeper/commit/7892d2f4024525c5e3f20e6237b18d0fbe36200d))
-* Revert readme changes to last working version ([08d42da](https://github.com/ory/oathkeeper/commit/08d42dac81a8d71f3b7ab926a8b09abe7b305b5e))
-* Remove obsolete section from README ([aa8deef](https://github.com/ory/oathkeeper/commit/aa8deefc02848a4c90bf06365b7a37d71eb9c72f))
-* Fix broken readme headlines ([2e8109a](https://github.com/ory/oathkeeper/commit/2e8109a4fa1b53e83e86897de6890c910d4b77ff))
-* Auto-kill test runner after 10 retries (#286) ([eaad598](https://github.com/ory/oathkeeper/commit/eaad59866349bebdeaed72e068a9ce6752b25cef)), closes [#286](https://github.com/ory/oathkeeper/issues/286)
-* Update ory/x/viperx dependency ([#285](https://github.com/ory/oathkeeper/issues/285)) ([0ef3bce](https://github.com/ory/oathkeeper/commit/0ef3bce92a3c17a6cffc794f2b08859f0852ee5d)), closes [#276](https://github.com/ory/oathkeeper/issues/276) [#270](https://github.com/ory/oathkeeper/issues/270) [#279](https://github.com/ory/oathkeeper/issues/279) [#280](https://github.com/ory/oathkeeper/issues/280):
+- pipeline/authz: Add Content-Type header in the call to Keto (#290)
+  ([1910bbe](https://github.com/ory/oathkeeper/commit/1910bbedc215c2b18c018cf9a5d5f86b6b3411c3)),
+  closes [#290](https://github.com/ory/oathkeeper/issues/290)
+- Revert incorrect license changes
+  ([7892d2f](https://github.com/ory/oathkeeper/commit/7892d2f4024525c5e3f20e6237b18d0fbe36200d))
+- Revert readme changes to last working version
+  ([08d42da](https://github.com/ory/oathkeeper/commit/08d42dac81a8d71f3b7ab926a8b09abe7b305b5e))
+- Remove obsolete section from README
+  ([aa8deef](https://github.com/ory/oathkeeper/commit/aa8deefc02848a4c90bf06365b7a37d71eb9c72f))
+- Fix broken readme headlines
+  ([2e8109a](https://github.com/ory/oathkeeper/commit/2e8109a4fa1b53e83e86897de6890c910d4b77ff))
+- Auto-kill test runner after 10 retries (#286)
+  ([eaad598](https://github.com/ory/oathkeeper/commit/eaad59866349bebdeaed72e068a9ce6752b25cef)),
+  closes [#286](https://github.com/ory/oathkeeper/issues/286)
+- Update ory/x/viperx dependency
+  ([#285](https://github.com/ory/oathkeeper/issues/285))
+  ([0ef3bce](https://github.com/ory/oathkeeper/commit/0ef3bce92a3c17a6cffc794f2b08859f0852ee5d)),
+  closes [#276](https://github.com/ory/oathkeeper/issues/276)
+  [#270](https://github.com/ory/oathkeeper/issues/270)
+  [#279](https://github.com/ory/oathkeeper/issues/279)
+  [#280](https://github.com/ory/oathkeeper/issues/280):
 
-    > This patch automatically binds environment variables to configuration keys. This patch resolves several issues:
-* Dereference config schema and resolve issues (#282) ([8cf6868](https://github.com/ory/oathkeeper/commit/8cf6868b3e925e686769d43c912d5e52c6589a9b)), closes [#282](https://github.com/ory/oathkeeper/issues/282) [ory/docs#217](https://github.com/ory/docs/issues/217) [#234](https://github.com/ory/oathkeeper/issues/234) [#281](https://github.com/ory/oathkeeper/issues/281)
+  > This patch automatically binds environment variables to configuration keys.
+  > This patch resolves several issues:
 
-
+- Dereference config schema and resolve issues (#282)
+  ([8cf6868](https://github.com/ory/oathkeeper/commit/8cf6868b3e925e686769d43c912d5e52c6589a9b)),
+  closes [#282](https://github.com/ory/oathkeeper/issues/282)
+  [ory/docs#217](https://github.com/ory/docs/issues/217)
+  [#234](https://github.com/ory/oathkeeper/issues/234)
+  [#281](https://github.com/ory/oathkeeper/issues/281)
 
 # [0.32.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.31.0-beta.1...v0.32.0-beta.1) (2019-10-20)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.31.0-beta.1 [ci skip] ([dafc870](https://github.com/ory/oathkeeper/commit/dafc870943720f04f5ac06a139bf5e126a83afa8))
-
-
+- Incorporates changes from version v0.31.0-beta.1 [ci skip]
+  ([dafc870](https://github.com/ory/oathkeeper/commit/dafc870943720f04f5ac06a139bf5e126a83afa8))
 
 # [0.31.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.19.0-beta.1...v0.31.0-beta.1) (2019-10-20)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.19.1-beta.1-2-g41869a9 [ci skip] ([a44846b](https://github.com/ory/oathkeeper/commit/a44846b1e6c8cbdb76162b3128c2aa4ff79d3375))
-* Incorporates changes from version v0.20.0-beta.1 [ci skip] ([aaf801b](https://github.com/ory/oathkeeper/commit/aaf801bb1cebe9d4a6c5062b5a0e10c9737b091b))
-* Incorporates changes from version v0.30.0-beta.1 [ci skip] ([ebd198a](https://github.com/ory/oathkeeper/commit/ebd198a908bcbc77f734e93a181209fec66e7736))
-
+- Incorporates changes from version v0.19.1-beta.1-2-g41869a9 [ci skip]
+  ([a44846b](https://github.com/ory/oathkeeper/commit/a44846b1e6c8cbdb76162b3128c2aa4ff79d3375))
+- Incorporates changes from version v0.20.0-beta.1 [ci skip]
+  ([aaf801b](https://github.com/ory/oathkeeper/commit/aaf801bb1cebe9d4a6c5062b5a0e10c9737b091b))
+- Incorporates changes from version v0.30.0-beta.1 [ci skip]
+  ([ebd198a](https://github.com/ory/oathkeeper/commit/ebd198a908bcbc77f734e93a181209fec66e7736))
 
 ### Unclassified
 
-* pipeline/authn: Add token_from config to introspection and jwt (#271) ([fc85ac8](https://github.com/ory/oathkeeper/commit/fc85ac854c3fb4cdd96bbae650f7355400431eac)), closes [#271](https://github.com/ory/oathkeeper/issues/271) [#257](https://github.com/ory/oathkeeper/issues/257):
+- pipeline/authn: Add token_from config to introspection and jwt (#271)
+  ([fc85ac8](https://github.com/ory/oathkeeper/commit/fc85ac854c3fb4cdd96bbae650f7355400431eac)),
+  closes [#271](https://github.com/ory/oathkeeper/issues/271)
+  [#257](https://github.com/ory/oathkeeper/issues/257):
 
-    > Add additional optional configuration to jwt and oauth2_introspection authenticators allowing to set from where (which header or query parameter) the token should be received. The configuration is a token_from field in per-rule-configuration, as described in a linked issue.
-* Add migration capabilities ([#268](https://github.com/ory/oathkeeper/issues/268)) ([bc74e72](https://github.com/ory/oathkeeper/commit/bc74e726712c77955d2013979770c2724af17f20)), closes [#266](https://github.com/ory/oathkeeper/issues/266):
+  > Add additional optional configuration to jwt and oauth2_introspection
+  > authenticators allowing to set from where (which header or query parameter)
+  > the token should be received. The configuration is a token_from field in
+  > per-rule-configuration, as described in a linked issue.
 
-    > Adds the ability to modify rules with backwards compatibility.
-* Force auth style in oauth2 client credentials authn ([#267](https://github.com/ory/oathkeeper/issues/267)) ([97d7890](https://github.com/ory/oathkeeper/commit/97d789097b47b50117421f8f4ebd32182de4195c)), closes [#260](https://github.com/ory/oathkeeper/issues/260)
-* Update UPGRADE.md ([4e4bd93](https://github.com/ory/oathkeeper/commit/4e4bd93695a14b453a895fd2c20eca416307dcee))
-* Update upgrade instructions ([7483d1c](https://github.com/ory/oathkeeper/commit/7483d1cf9344058ddc12efabdb00f5b5b8b41f48))
-* Change error code from 403 to 401 ([#259](https://github.com/ory/oathkeeper/issues/259)) ([c17e564](https://github.com/ory/oathkeeper/commit/c17e564cc2427a0ab1f7d2eb2d2b7cb95e34f88b)), closes [#256](https://github.com/ory/oathkeeper/issues/256)
+- Add migration capabilities
+  ([#268](https://github.com/ory/oathkeeper/issues/268))
+  ([bc74e72](https://github.com/ory/oathkeeper/commit/bc74e726712c77955d2013979770c2724af17f20)),
+  closes [#266](https://github.com/ory/oathkeeper/issues/266):
 
+  > Adds the ability to modify rules with backwards compatibility.
 
+- Force auth style in oauth2 client credentials authn
+  ([#267](https://github.com/ory/oathkeeper/issues/267))
+  ([97d7890](https://github.com/ory/oathkeeper/commit/97d789097b47b50117421f8f4ebd32182de4195c)),
+  closes [#260](https://github.com/ory/oathkeeper/issues/260)
+- Update UPGRADE.md
+  ([4e4bd93](https://github.com/ory/oathkeeper/commit/4e4bd93695a14b453a895fd2c20eca416307dcee))
+- Update upgrade instructions
+  ([7483d1c](https://github.com/ory/oathkeeper/commit/7483d1cf9344058ddc12efabdb00f5b5b8b41f48))
+- Change error code from 403 to 401
+  ([#259](https://github.com/ory/oathkeeper/issues/259))
+  ([c17e564](https://github.com/ory/oathkeeper/commit/c17e564cc2427a0ab1f7d2eb2d2b7cb95e34f88b)),
+  closes [#256](https://github.com/ory/oathkeeper/issues/256)
 
 # [0.19.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.18.0-beta.1...v0.19.0-beta.1) (2019-09-23)
 
-
 ### Unclassified
 
-* Fix id_token schema reference URL ([72a2333](https://github.com/ory/oathkeeper/commit/72a23333d67f01d2474603f6ba9e5b1e97605a95))
-* Resolve broken tests (#262) ([bc67cc1](https://github.com/ory/oathkeeper/commit/bc67cc18b4e32331f86bc8b10f1947a812be6b7e)), closes [#262](https://github.com/ory/oathkeeper/issues/262)
-* Homogenize configuration management (#258) ([89709aa](https://github.com/ory/oathkeeper/commit/89709aabfe002fc5ae2e76016fc45a13d74f3d8b)), closes [#258](https://github.com/ory/oathkeeper/issues/258)
-* Fix #250: Ignore query parameters to build payload for Keto engine (#251) ([d0fc7f4](https://github.com/ory/oathkeeper/commit/d0fc7f4c6a9377ff3f2466d5860c12247202e646)), closes [#250](https://github.com/ory/oathkeeper/issues/250) [#251](https://github.com/ory/oathkeeper/issues/251)
-
-
+- Fix id_token schema reference URL
+  ([72a2333](https://github.com/ory/oathkeeper/commit/72a23333d67f01d2474603f6ba9e5b1e97605a95))
+- Resolve broken tests (#262)
+  ([bc67cc1](https://github.com/ory/oathkeeper/commit/bc67cc18b4e32331f86bc8b10f1947a812be6b7e)),
+  closes [#262](https://github.com/ory/oathkeeper/issues/262)
+- Homogenize configuration management (#258)
+  ([89709aa](https://github.com/ory/oathkeeper/commit/89709aabfe002fc5ae2e76016fc45a13d74f3d8b)),
+  closes [#258](https://github.com/ory/oathkeeper/issues/258)
+- Fix #250: Ignore query parameters to build payload for Keto engine (#251)
+  ([d0fc7f4](https://github.com/ory/oathkeeper/commit/d0fc7f4c6a9377ff3f2466d5860c12247202e646)),
+  closes [#250](https://github.com/ory/oathkeeper/issues/250)
+  [#251](https://github.com/ory/oathkeeper/issues/251)
 
 # [0.18.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.17.4-beta.1...v0.18.0-beta.1) (2019-08-22)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.17.4-beta.1 ([370eb37](https://github.com/ory/oathkeeper/commit/370eb3745630631e96ff6c0de61ab86b2832a3f5))
-* Incorporates changes from version v0.17.5-beta.1 ([f7beddc](https://github.com/ory/oathkeeper/commit/f7beddccfcc0bfb52805382278758e347cc1dc2c))
-* Updates issue and pull request templates ([#237](https://github.com/ory/oathkeeper/issues/237)) ([6181ee5](https://github.com/ory/oathkeeper/commit/6181ee5c14fbcc1b3b844d9f301a5df90dcf6a8b))
-* Updates issue and pull request templates ([#238](https://github.com/ory/oathkeeper/issues/238)) ([6f83cda](https://github.com/ory/oathkeeper/commit/6f83cda6ce855ed09ec3f553eaaf644e0d853634))
-* Updates issue and pull request templates ([#239](https://github.com/ory/oathkeeper/issues/239)) ([2e0b3ef](https://github.com/ory/oathkeeper/commit/2e0b3ef28bf3b2e8c6225d5e407a3f9b1487ccea))
-* Updates issue and pull request templates ([#245](https://github.com/ory/oathkeeper/issues/245)) ([f140837](https://github.com/ory/oathkeeper/commit/f140837a7181f3e2c0a209e6dd47a534be08c1f8))
-
+- Incorporates changes from version v0.17.4-beta.1
+  ([370eb37](https://github.com/ory/oathkeeper/commit/370eb3745630631e96ff6c0de61ab86b2832a3f5))
+- Incorporates changes from version v0.17.5-beta.1
+  ([f7beddc](https://github.com/ory/oathkeeper/commit/f7beddccfcc0bfb52805382278758e347cc1dc2c))
+- Updates issue and pull request templates
+  ([#237](https://github.com/ory/oathkeeper/issues/237))
+  ([6181ee5](https://github.com/ory/oathkeeper/commit/6181ee5c14fbcc1b3b844d9f301a5df90dcf6a8b))
+- Updates issue and pull request templates
+  ([#238](https://github.com/ory/oathkeeper/issues/238))
+  ([6f83cda](https://github.com/ory/oathkeeper/commit/6f83cda6ce855ed09ec3f553eaaf644e0d853634))
+- Updates issue and pull request templates
+  ([#239](https://github.com/ory/oathkeeper/issues/239))
+  ([2e0b3ef](https://github.com/ory/oathkeeper/commit/2e0b3ef28bf3b2e8c6225d5e407a3f9b1487ccea))
+- Updates issue and pull request templates
+  ([#245](https://github.com/ory/oathkeeper/issues/245))
+  ([f140837](https://github.com/ory/oathkeeper/commit/f140837a7181f3e2c0a209e6dd47a534be08c1f8))
 
 ### Unclassified
 
-* mutator/id_token: Add claim templating (#246) ([591f524](https://github.com/ory/oathkeeper/commit/591f5249f3d8ba314cf7e914926bfbd0300e7589)), closes [#246](https://github.com/ory/oathkeeper/issues/246)
-* Add mutator for modifying authenticationSession with external API (#240) ([b38b0f4](https://github.com/ory/oathkeeper/commit/b38b0f4d4cd5148ebe0858558f410b4f0c367be1)), closes [#240](https://github.com/ory/oathkeeper/issues/240)
-* Support multiple mutators per access rule (#233) ([d21179d](https://github.com/ory/oathkeeper/commit/d21179dd25543662075be402f6e24e1ee20d2754)), closes [#233](https://github.com/ory/oathkeeper/issues/233) [#233](https://github.com/ory/oathkeeper/issues/233)
-* Add adopters placeholder ([#236](https://github.com/ory/oathkeeper/issues/236)) ([302c7b8](https://github.com/ory/oathkeeper/commit/302c7b8cec0479db2735440ef336c11ca92675ff))
-
-
+- mutator/id_token: Add claim templating (#246)
+  ([591f524](https://github.com/ory/oathkeeper/commit/591f5249f3d8ba314cf7e914926bfbd0300e7589)),
+  closes [#246](https://github.com/ory/oathkeeper/issues/246)
+- Add mutator for modifying authenticationSession with external API (#240)
+  ([b38b0f4](https://github.com/ory/oathkeeper/commit/b38b0f4d4cd5148ebe0858558f410b4f0c367be1)),
+  closes [#240](https://github.com/ory/oathkeeper/issues/240)
+- Support multiple mutators per access rule (#233)
+  ([d21179d](https://github.com/ory/oathkeeper/commit/d21179dd25543662075be402f6e24e1ee20d2754)),
+  closes [#233](https://github.com/ory/oathkeeper/issues/233)
+  [#233](https://github.com/ory/oathkeeper/issues/233)
+- Add adopters placeholder
+  ([#236](https://github.com/ory/oathkeeper/issues/236))
+  ([302c7b8](https://github.com/ory/oathkeeper/commit/302c7b8cec0479db2735440ef336c11ca92675ff))
 
 ## [0.17.4-beta.1](https://github.com/ory/oathkeeper/compare/v0.17.3-beta.1...v0.17.4-beta.1) (2019-08-09)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.17.3-beta.1 ([b271ff2](https://github.com/ory/oathkeeper/commit/b271ff21644f9e3fd0605cc50978d0c5e2e883e3))
-* Updates issue and pull request templates ([#232](https://github.com/ory/oathkeeper/issues/232)) ([00c08ba](https://github.com/ory/oathkeeper/commit/00c08ba9c4d2ce6b910b151d79eaccbf6d9c0710))
-
+- Incorporates changes from version v0.17.3-beta.1
+  ([b271ff2](https://github.com/ory/oathkeeper/commit/b271ff21644f9e3fd0605cc50978d0c5e2e883e3))
+- Updates issue and pull request templates
+  ([#232](https://github.com/ory/oathkeeper/issues/232))
+  ([00c08ba](https://github.com/ory/oathkeeper/commit/00c08ba9c4d2ce6b910b151d79eaccbf6d9c0710))
 
 ### Unclassified
 
-* Add sprig template library (#235) ([c85c540](https://github.com/ory/oathkeeper/commit/c85c5400000f1c534b99db292273f71c427d368e)), closes [#235](https://github.com/ory/oathkeeper/issues/235)
-
-
+- Add sprig template library (#235)
+  ([c85c540](https://github.com/ory/oathkeeper/commit/c85c5400000f1c534b99db292273f71c427d368e)),
+  closes [#235](https://github.com/ory/oathkeeper/issues/235)
 
 ## [0.17.3-beta.1](https://github.com/ory/oathkeeper/compare/v0.17.2-beta.1...v0.17.3-beta.1) (2019-08-03)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.17.2-beta.1 ([e652c3f](https://github.com/ory/oathkeeper/commit/e652c3fac276f73278ac8e3bf4a75b3789420da7))
-
+- Incorporates changes from version v0.17.2-beta.1
+  ([e652c3f](https://github.com/ory/oathkeeper/commit/e652c3fac276f73278ac8e3bf4a75b3789420da7))
 
 ### Unclassified
 
-* Resolve k8s configmap reload issue ([#231](https://github.com/ory/oathkeeper/issues/231)) ([c04547e](https://github.com/ory/oathkeeper/commit/c04547e7bda2396c997252dd7ca3e588897b7779))
-* Move back to scratch Docker image ([3fa8a50](https://github.com/ory/oathkeeper/commit/3fa8a5078759869c3a3a0521f17b80f246fdd7f4))
-
-
+- Resolve k8s configmap reload issue
+  ([#231](https://github.com/ory/oathkeeper/issues/231))
+  ([c04547e](https://github.com/ory/oathkeeper/commit/c04547e7bda2396c997252dd7ca3e588897b7779))
+- Move back to scratch Docker image
+  ([3fa8a50](https://github.com/ory/oathkeeper/commit/3fa8a5078759869c3a3a0521f17b80f246fdd7f4))
 
 ## [0.17.2-beta.1](https://github.com/ory/oathkeeper/compare/v0.17.1-beta.1...v0.17.2-beta.1) (2019-08-02)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.17.1-beta.1 ([64d180f](https://github.com/ory/oathkeeper/commit/64d180fd7f41febd4f15a35bd8ee625adc854256))
-* Updates issue and pull request templates ([#226](https://github.com/ory/oathkeeper/issues/226)) ([007d491](https://github.com/ory/oathkeeper/commit/007d491dfd204b4dcf175906319db667b10fff1e))
-
+- Incorporates changes from version v0.17.1-beta.1
+  ([64d180f](https://github.com/ory/oathkeeper/commit/64d180fd7f41febd4f15a35bd8ee625adc854256))
+- Updates issue and pull request templates
+  ([#226](https://github.com/ory/oathkeeper/issues/226))
+  ([007d491](https://github.com/ory/oathkeeper/commit/007d491dfd204b4dcf175906319db667b10fff1e))
 
 ### Unclassified
 
-* Support kubernetes configmap reloading ([#230](https://github.com/ory/oathkeeper/issues/230)) ([92b769b](https://github.com/ory/oathkeeper/commit/92b769bfdf4d5fd7902e1b5ae1dc63d11de4e0f1))
-
-
+- Support kubernetes configmap reloading
+  ([#230](https://github.com/ory/oathkeeper/issues/230))
+  ([92b769b](https://github.com/ory/oathkeeper/commit/92b769bfdf4d5fd7902e1b5ae1dc63d11de4e0f1))
 
 ## [0.17.1-beta.1](https://github.com/ory/oathkeeper/compare/v0.17.0-beta.1...v0.17.1-beta.1) (2019-07-23)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.17.0-beta.1 ([8f4a518](https://github.com/ory/oathkeeper/commit/8f4a51808f4614a666fdaa0043b73105a55af54d))
-
+- Incorporates changes from version v0.17.0-beta.1
+  ([8f4a518](https://github.com/ory/oathkeeper/commit/8f4a51808f4614a666fdaa0043b73105a55af54d))
 
 ### Unclassified
 
-* Fix panic on send on closed channel ([#225](https://github.com/ory/oathkeeper/issues/225)) ([2112ab6](https://github.com/ory/oathkeeper/commit/2112ab6b325aef71963de9d448dbf15ce09bd5fe)), closes [#224](https://github.com/ory/oathkeeper/issues/224)
-
-
+- Fix panic on send on closed channel
+  ([#225](https://github.com/ory/oathkeeper/issues/225))
+  ([2112ab6](https://github.com/ory/oathkeeper/commit/2112ab6b325aef71963de9d448dbf15ce09bd5fe)),
+  closes [#224](https://github.com/ory/oathkeeper/issues/224)
 
 # [0.17.0-beta.1](https://github.com/ory/oathkeeper/compare/v0.16.0-beta.5...v0.17.0-beta.1) (2019-07-18)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.16.0-beta.5 ([a8afc3b](https://github.com/ory/oathkeeper/commit/a8afc3b559905d8807519e3ed04fd39a654fa73d))
-* Update upgrade guide ([a8ccb05](https://github.com/ory/oathkeeper/commit/a8ccb0541f9f0e8b707b418bb6698ed18bdadf0b))
-* Update upgrade guide ([f727efe](https://github.com/ory/oathkeeper/commit/f727efe438bafbfb8f404ae1dd98b062d1ad804b))
-
+- Incorporates changes from version v0.16.0-beta.5
+  ([a8afc3b](https://github.com/ory/oathkeeper/commit/a8afc3b559905d8807519e3ed04fd39a654fa73d))
+- Update upgrade guide
+  ([a8ccb05](https://github.com/ory/oathkeeper/commit/a8ccb0541f9f0e8b707b418bb6698ed18bdadf0b))
+- Update upgrade guide
+  ([f727efe](https://github.com/ory/oathkeeper/commit/f727efe438bafbfb8f404ae1dd98b062d1ad804b))
 
 ### Unclassified
 
-* Fix broken reload tests ([d6059b7](https://github.com/ory/oathkeeper/commit/d6059b711aa921fd012ce71eb11e370f174596f6))
-* Remove useless function ([3521a3d](https://github.com/ory/oathkeeper/commit/3521a3d9a606b92c7bf9c74828185934b2cba9c5))
-* Validate configuration with JSON Schema ([997427d](https://github.com/ory/oathkeeper/commit/997427dc03c7efee476f145677b73a42bbc63c89))
-* Do not fatal when immutable value is changed ([717d7f7](https://github.com/ory/oathkeeper/commit/717d7f748abe61014653f3c6519c4aef019d1969))
-* Watch configuration and access rule changes (#217) ([a078e89](https://github.com/ory/oathkeeper/commit/a078e891e2fe97bdb6ce8a2264f629a179c9116e)), closes [#217](https://github.com/ory/oathkeeper/issues/217):
+- Fix broken reload tests
+  ([d6059b7](https://github.com/ory/oathkeeper/commit/d6059b711aa921fd012ce71eb11e370f174596f6))
+- Remove useless function
+  ([3521a3d](https://github.com/ory/oathkeeper/commit/3521a3d9a606b92c7bf9c74828185934b2cba9c5))
+- Validate configuration with JSON Schema
+  ([997427d](https://github.com/ory/oathkeeper/commit/997427dc03c7efee476f145677b73a42bbc63c89))
+- Do not fatal when immutable value is changed
+  ([717d7f7](https://github.com/ory/oathkeeper/commit/717d7f748abe61014653f3c6519c4aef019d1969))
+- Watch configuration and access rule changes (#217)
+  ([a078e89](https://github.com/ory/oathkeeper/commit/a078e891e2fe97bdb6ce8a2264f629a179c9116e)),
+  closes [#217](https://github.com/ory/oathkeeper/issues/217):
 
-    > This patch allows oathkeeper to re-load any changes made to the configuraiton file and/or the access
-    > rules to be reloaded without a restart.
-    > 
-    > Some configuration keys like serve.*, log.*, profiling however require a restart.
-* Create FUNDING.yml ([d7da8e2](https://github.com/ory/oathkeeper/commit/d7da8e296205e183140c18ba3cc6269334476a2b))
-* Add support for rules in YAML format (#213) ([67face6](https://github.com/ory/oathkeeper/commit/67face611b9f19ed9b6606931c9b7a82df769154)), closes [#213](https://github.com/ory/oathkeeper/issues/213):
+  > This patch allows oathkeeper to re-load any changes made to the
+  > configuraiton file and/or the access rules to be reloaded without a restart.
+  >
+  > Some configuration keys like serve._, log._, profiling however require a
+  > restart.
 
-    > This commit adds support for defining access rules in YAML format, in
-    > addition to existing JSON format.
+- Create FUNDING.yml
+  ([d7da8e2](https://github.com/ory/oathkeeper/commit/d7da8e296205e183140c18ba3cc6269334476a2b))
+- Add support for rules in YAML format (#213)
+  ([67face6](https://github.com/ory/oathkeeper/commit/67face611b9f19ed9b6606931c9b7a82df769154)),
+  closes [#213](https://github.com/ory/oathkeeper/issues/213):
 
-
+  > This commit adds support for defining access rules in YAML format, in
+  > addition to existing JSON format.
 
 # [0.16.0-beta.5](https://github.com/ory/oathkeeper/compare/v0.16.0-beta.4...v0.16.0-beta.5) (2019-06-28)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.16.0-beta.4 ([1e03ee2](https://github.com/ory/oathkeeper/commit/1e03ee24b466b01fe4f81e5a4fda8ab42f9a0615))
-
+- Incorporates changes from version v0.16.0-beta.4
+  ([1e03ee2](https://github.com/ory/oathkeeper/commit/1e03ee24b466b01fe4f81e5a4fda8ab42f9a0615))
 
 ### Unclassified
 
-* Add cookie session authenticator ([#211](https://github.com/ory/oathkeeper/issues/211)) ([f8a66b7](https://github.com/ory/oathkeeper/commit/f8a66b77f99420fa4ac6693967af1906ae962489))
-* Add description into the name of subtest (#212) ([230c332](https://github.com/ory/oathkeeper/commit/230c332f5972e2bbf5a81a31c4ceafdfbf541d75)), closes [#212](https://github.com/ory/oathkeeper/issues/212)
-* Use non-root user in image ([#209](https://github.com/ory/oathkeeper/issues/209)) ([2215126](https://github.com/ory/oathkeeper/commit/221512635125eb61943f6dfd93b69defa61d9ce3))
-* Remove binary license (#208) ([3460d65](https://github.com/ory/oathkeeper/commit/3460d65249783ea1eb6558fbe75cec4c72105f5c)), closes [#208](https://github.com/ory/oathkeeper/issues/208)
-* Update config.yaml (#204) ([effe9c0](https://github.com/ory/oathkeeper/commit/effe9c025c3a25edf88bc3791ec27cb01e128a1a)), closes [#204](https://github.com/ory/oathkeeper/issues/204):
+- Add cookie session authenticator
+  ([#211](https://github.com/ory/oathkeeper/issues/211))
+  ([f8a66b7](https://github.com/ory/oathkeeper/commit/f8a66b77f99420fa4ac6693967af1906ae962489))
+- Add description into the name of subtest (#212)
+  ([230c332](https://github.com/ory/oathkeeper/commit/230c332f5972e2bbf5a81a31c4ceafdfbf541d75)),
+  closes [#212](https://github.com/ory/oathkeeper/issues/212)
+- Use non-root user in image
+  ([#209](https://github.com/ory/oathkeeper/issues/209))
+  ([2215126](https://github.com/ory/oathkeeper/commit/221512635125eb61943f6dfd93b69defa61d9ce3))
+- Remove binary license (#208)
+  ([3460d65](https://github.com/ory/oathkeeper/commit/3460d65249783ea1eb6558fbe75cec4c72105f5c)),
+  closes [#208](https://github.com/ory/oathkeeper/issues/208)
+- Update config.yaml (#204)
+  ([effe9c0](https://github.com/ory/oathkeeper/commit/effe9c025c3a25edf88bc3791ec27cb01e128a1a)),
+  closes [#204](https://github.com/ory/oathkeeper/issues/204):
 
-    > There's no DSN in oathkeeper
-
-
+  > There's no DSN in oathkeeper
 
 # [0.16.0-beta.4](https://github.com/ory/oathkeeper/compare/v0.16.0-beta.3...v0.16.0-beta.4) (2019-05-28)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.16.0-beta.3 ([d777ecf](https://github.com/ory/oathkeeper/commit/d777ecf59192d14a432a024d5a3451b47f6cff4e))
-* Updates issue and pull request templates ([#196](https://github.com/ory/oathkeeper/issues/196)) ([74fa27b](https://github.com/ory/oathkeeper/commit/74fa27ba9b110d8b4bd8afe09d77c5c602187a5c))
-* Updates issue and pull request templates ([#197](https://github.com/ory/oathkeeper/issues/197)) ([31d057c](https://github.com/ory/oathkeeper/commit/31d057cf37816fb20436f464f96ee2c5fd32d7e7))
-* Updates issue and pull request templates ([#198](https://github.com/ory/oathkeeper/issues/198)) ([244810a](https://github.com/ory/oathkeeper/commit/244810aabfc2259e756963791855cde1006fe16f))
-
+- Incorporates changes from version v0.16.0-beta.3
+  ([d777ecf](https://github.com/ory/oathkeeper/commit/d777ecf59192d14a432a024d5a3451b47f6cff4e))
+- Updates issue and pull request templates
+  ([#196](https://github.com/ory/oathkeeper/issues/196))
+  ([74fa27b](https://github.com/ory/oathkeeper/commit/74fa27ba9b110d8b4bd8afe09d77c5c602187a5c))
+- Updates issue and pull request templates
+  ([#197](https://github.com/ory/oathkeeper/issues/197))
+  ([31d057c](https://github.com/ory/oathkeeper/commit/31d057cf37816fb20436f464f96ee2c5fd32d7e7))
+- Updates issue and pull request templates
+  ([#198](https://github.com/ory/oathkeeper/issues/198))
+  ([244810a](https://github.com/ory/oathkeeper/commit/244810aabfc2259e756963791855cde1006fe16f))
 
 ### Unclassified
 
-* Properly declare negroni middleware ([#200](https://github.com/ory/oathkeeper/issues/200)) ([9d3dc54](https://github.com/ory/oathkeeper/commit/9d3dc54e1350fa74fb126cc4761462e83d86548f)), closes [#199](https://github.com/ory/oathkeeper/issues/199):
+- Properly declare negroni middleware
+  ([#200](https://github.com/ory/oathkeeper/issues/200))
+  ([9d3dc54](https://github.com/ory/oathkeeper/commit/9d3dc54e1350fa74fb126cc4761462e83d86548f)),
+  closes [#199](https://github.com/ory/oathkeeper/issues/199):
 
-    > Previously, negroni.With was mistakenly used to add middleware onto the stack.
-    > The proper method however is negroni.Use.
-    > 
-    > This patch fixes the use of negroni.With and resolves issues around
-    > logging and the decisions endpoint.
-
-
+  > Previously, negroni.With was mistakenly used to add middleware onto the
+  > stack. The proper method however is negroni.Use.
+  >
+  > This patch fixes the use of negroni.With and resolves issues around logging
+  > and the decisions endpoint.
 
 # [0.16.0-beta.3](https://github.com/ory/oathkeeper/compare/v0.15.2...v0.16.0-beta.3) (2019-05-19)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.15.2 ([7ceabe9](https://github.com/ory/oathkeeper/commit/7ceabe98498e1dd9f8c3c452f5d0f9ab366a3c07))
-* Rename config.yml -> config.yaml ([4faecbe](https://github.com/ory/oathkeeper/commit/4faecbea5683e18522697f5c2b1ccc76fbf4c762))
-* Updates issue and pull request templates ([#189](https://github.com/ory/oathkeeper/issues/189)) ([367a48d](https://github.com/ory/oathkeeper/commit/367a48dba6693db44a17179dcf0f0e7c624be7a7))
-
+- Incorporates changes from version v0.15.2
+  ([7ceabe9](https://github.com/ory/oathkeeper/commit/7ceabe98498e1dd9f8c3c452f5d0f9ab366a3c07))
+- Rename config.yml -> config.yaml
+  ([4faecbe](https://github.com/ory/oathkeeper/commit/4faecbea5683e18522697f5c2b1ccc76fbf4c762))
+- Updates issue and pull request templates
+  ([#189](https://github.com/ory/oathkeeper/issues/189))
+  ([367a48d](https://github.com/ory/oathkeeper/commit/367a48dba6693db44a17179dcf0f0e7c624be7a7))
 
 ### Unclassified
 
-* Reduce deployment complexity and refactor internals (#185) ([6b509ad](https://github.com/ory/oathkeeper/commit/6b509ad5e3ce109521de80540bd0c762b7ecd8d2)), closes [#185](https://github.com/ory/oathkeeper/issues/185) [#178](https://github.com/ory/oathkeeper/issues/178) [#177](https://github.com/ory/oathkeeper/issues/177) [#174](https://github.com/ory/oathkeeper/issues/174) [#168](https://github.com/ory/oathkeeper/issues/168) [#164](https://github.com/ory/oathkeeper/issues/164) [#141](https://github.com/ory/oathkeeper/issues/141) [#140](https://github.com/ory/oathkeeper/issues/140) [#136](https://github.com/ory/oathkeeper/issues/136) [#122](https://github.com/ory/oathkeeper/issues/122)
-* Resolve issue with install.sh script (#187) ([d31d5be](https://github.com/ory/oathkeeper/commit/d31d5bea5085355960cc051c4bb6b6232a77ac75)), closes [#187](https://github.com/ory/oathkeeper/issues/187)
-
-
+- Reduce deployment complexity and refactor internals (#185)
+  ([6b509ad](https://github.com/ory/oathkeeper/commit/6b509ad5e3ce109521de80540bd0c762b7ecd8d2)),
+  closes [#185](https://github.com/ory/oathkeeper/issues/185)
+  [#178](https://github.com/ory/oathkeeper/issues/178)
+  [#177](https://github.com/ory/oathkeeper/issues/177)
+  [#174](https://github.com/ory/oathkeeper/issues/174)
+  [#168](https://github.com/ory/oathkeeper/issues/168)
+  [#164](https://github.com/ory/oathkeeper/issues/164)
+  [#141](https://github.com/ory/oathkeeper/issues/141)
+  [#140](https://github.com/ory/oathkeeper/issues/140)
+  [#136](https://github.com/ory/oathkeeper/issues/136)
+  [#122](https://github.com/ory/oathkeeper/issues/122)
+- Resolve issue with install.sh script (#187)
+  ([d31d5be](https://github.com/ory/oathkeeper/commit/d31d5bea5085355960cc051c4bb6b6232a77ac75)),
+  closes [#187](https://github.com/ory/oathkeeper/issues/187)
 
 ## [0.15.2](https://github.com/ory/oathkeeper/compare/v0.15.1...v0.15.2) (2019-05-04)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.15.1 ([5c34958](https://github.com/ory/oathkeeper/commit/5c34958ff00a56f9a5784bfb01b6b200fcbd91d1))
-
+- Incorporates changes from version v0.15.1
+  ([5c34958](https://github.com/ory/oathkeeper/commit/5c34958ff00a56f9a5784bfb01b6b200fcbd91d1))
 
 ### Unclassified
 
-* cmd/client: Use json rawmessage for arbtrary payloads (#184) ([a55e4d1](https://github.com/ory/oathkeeper/commit/a55e4d1267dcb2975a5e4b4ab4248bdf7adc00b0)), closes [#184](https://github.com/ory/oathkeeper/issues/184) [#182](https://github.com/ory/oathkeeper/issues/182)
-
-
+- cmd/client: Use json rawmessage for arbtrary payloads (#184)
+  ([a55e4d1](https://github.com/ory/oathkeeper/commit/a55e4d1267dcb2975a5e4b4ab4248bdf7adc00b0)),
+  closes [#184](https://github.com/ory/oathkeeper/issues/184)
+  [#182](https://github.com/ory/oathkeeper/issues/182)
 
 ## [0.15.1](https://github.com/ory/oathkeeper/compare/v0.15.0...v0.15.1) (2019-04-29)
 
-
 ### Unclassified
 
-* Add go.sum ([#180](https://github.com/ory/oathkeeper/issues/180)) ([fc261f0](https://github.com/ory/oathkeeper/commit/fc261f0a340b3bcca56519c2da3042e614f8b6a3))
-
-
+- Add go.sum ([#180](https://github.com/ory/oathkeeper/issues/180))
+  ([fc261f0](https://github.com/ory/oathkeeper/commit/fc261f0a340b3bcca56519c2da3042e614f8b6a3))
 
 # [0.15.0](https://github.com/ory/oathkeeper/compare/v0.14.2+oryOS.10...v0.15.0) (2019-04-29)
 
-
 ### Documentation
 
-* Incorporates changes from version v0.0.0-testrelease.3 ([44649b6](https://github.com/ory/oathkeeper/commit/44649b6302057cb64c9585b862043fe4568d4432))
-* Incorporates changes from version v0.14.2+oryOS.10 ([2d9899a](https://github.com/ory/oathkeeper/commit/2d9899a38b927ff367931c024a10bfdc3230e9a3))
-* Update patrons ([f423666](https://github.com/ory/oathkeeper/commit/f423666df6e067ed563a853c3187afb1859dc36c))
-* Update README building-from-source part with the gomodule way ([#152](https://github.com/ory/oathkeeper/issues/152)) ([9d653f5](https://github.com/ory/oathkeeper/commit/9d653f5364cfabdd03a6a39b0883d70b9783fb01)), closes [#149](https://github.com/ory/oathkeeper/issues/149)
-
+- Incorporates changes from version v0.0.0-testrelease.3
+  ([44649b6](https://github.com/ory/oathkeeper/commit/44649b6302057cb64c9585b862043fe4568d4432))
+- Incorporates changes from version v0.14.2+oryOS.10
+  ([2d9899a](https://github.com/ory/oathkeeper/commit/2d9899a38b927ff367931c024a10bfdc3230e9a3))
+- Update patrons
+  ([f423666](https://github.com/ory/oathkeeper/commit/f423666df6e067ed563a853c3187afb1859dc36c))
+- Update README building-from-source part with the gomodule way
+  ([#152](https://github.com/ory/oathkeeper/issues/152))
+  ([9d653f5](https://github.com/ory/oathkeeper/commit/9d653f5364cfabdd03a6a39b0883d70b9783fb01)),
+  closes [#149](https://github.com/ory/oathkeeper/issues/149)
 
 ### Unclassified
 
-* Remove full tag from build pipeline ([#179](https://github.com/ory/oathkeeper/issues/179)) ([e2edbf8](https://github.com/ory/oathkeeper/commit/e2edbf8628fd7592730dbb320760e514982e049d))
-* Remove sdk dependencies to keto/hydra ([#173](https://github.com/ory/oathkeeper/issues/173)) ([b538e3c](https://github.com/ory/oathkeeper/commit/b538e3c8fdd52be1e61ed88502fce1de7737d4a9)):
+- Remove full tag from build pipeline
+  ([#179](https://github.com/ory/oathkeeper/issues/179))
+  ([e2edbf8](https://github.com/ory/oathkeeper/commit/e2edbf8628fd7592730dbb320760e514982e049d))
+- Remove sdk dependencies to keto/hydra
+  ([#173](https://github.com/ory/oathkeeper/issues/173))
+  ([b538e3c](https://github.com/ory/oathkeeper/commit/b538e3c8fdd52be1e61ed88502fce1de7737d4a9)):
 
-    > This patch replaces code-generated SDKs with raw http.Client calls which reduces dependencies and makes future changes to the keto/hydra SDK easier to adopt to.
-    > 
-    > 
-* Update CHANGELOG.md ([cbccbe2](https://github.com/ory/oathkeeper/commit/cbccbe2f4786f90208dfa93a8b8b47027ca11548))
-* Ensure rule matcher is locked before updating ([#159](https://github.com/ory/oathkeeper/issues/159)) ([6fb7151](https://github.com/ory/oathkeeper/commit/6fb715161370382b384ab2e0cb7ec64ca425f16a)):
+  > This patch replaces code-generated SDKs with raw http.Client calls which
+  > reduces dependencies and makes future changes to the keto/hydra SDK easier
+  > to adopt to.
 
-    > Lock CachedMatcher before rules are updated when HTTPMatcher refreshes to avoid concurrent map iteration and map write errors.
-    > 
-    > 
-* Improve debugability of JWT authenticator ([#156](https://github.com/ory/oathkeeper/issues/156)) ([8441bd5](https://github.com/ory/oathkeeper/commit/8441bd52dc567de04b8b4eb9b4655aaf45b90f03))
-* Move to go-swagger SDK code generation ([#170](https://github.com/ory/oathkeeper/issues/170)) ([38c52a3](https://github.com/ory/oathkeeper/commit/38c52a3cc3a24b1d77d7f07d012be561d018b5ec)), closes [#165](https://github.com/ory/oathkeeper/issues/165)
-* Remove vendored dependencies after sdk generation ([7c33ca8](https://github.com/ory/oathkeeper/commit/7c33ca89781a225ab43b4d663b30c154a24a7e0a))
-* Set request headers for credential issuers ([#169](https://github.com/ory/oathkeeper/issues/169)) ([4fc579c](https://github.com/ory/oathkeeper/commit/4fc579cd677b71f6083fd3edaad741a7979e629a)), closes [#120](https://github.com/ory/oathkeeper/issues/120) [#133](https://github.com/ory/oathkeeper/issues/133)
-* Update Dockerfile build instructions ([ec40cc4](https://github.com/ory/oathkeeper/commit/ec40cc4cfa1716adff9cb4cd8c604aa6f4aa9e91))
-* Upgrade dependencies ([#163](https://github.com/ory/oathkeeper/issues/163)) ([f9fdefb](https://github.com/ory/oathkeeper/commit/f9fdefb5dfe9dbff38f0ae96f82e42fea24d1c93))
-* Use scp,scope,scopes in jwt authenticator ([#162](https://github.com/ory/oathkeeper/issues/162)) ([eebc2f4](https://github.com/ory/oathkeeper/commit/eebc2f44e3e42b7af653f91d9345111e0a280401)), closes [#138](https://github.com/ory/oathkeeper/issues/138):
+- Update CHANGELOG.md
+  ([cbccbe2](https://github.com/ory/oathkeeper/commit/cbccbe2f4786f90208dfa93a8b8b47027ca11548))
+- Ensure rule matcher is locked before updating
+  ([#159](https://github.com/ory/oathkeeper/issues/159))
+  ([6fb7151](https://github.com/ory/oathkeeper/commit/6fb715161370382b384ab2e0cb7ec64ca425f16a)):
 
-    > Previously, the JWT authenticator only used the "scope" claim to retrieve scope values from a JWT. Now, "scp", "scope", "scopes" are supported as string arrays and strings separated by spaces.
+  > Lock CachedMatcher before rules are updated when HTTPMatcher refreshes to
+  > avoid concurrent map iteration and map write errors.
 
+- Improve debugability of JWT authenticator
+  ([#156](https://github.com/ory/oathkeeper/issues/156))
+  ([8441bd5](https://github.com/ory/oathkeeper/commit/8441bd52dc567de04b8b4eb9b4655aaf45b90f03))
+- Move to go-swagger SDK code generation
+  ([#170](https://github.com/ory/oathkeeper/issues/170))
+  ([38c52a3](https://github.com/ory/oathkeeper/commit/38c52a3cc3a24b1d77d7f07d012be561d018b5ec)),
+  closes [#165](https://github.com/ory/oathkeeper/issues/165)
+- Remove vendored dependencies after sdk generation
+  ([7c33ca8](https://github.com/ory/oathkeeper/commit/7c33ca89781a225ab43b4d663b30c154a24a7e0a))
+- Set request headers for credential issuers
+  ([#169](https://github.com/ory/oathkeeper/issues/169))
+  ([4fc579c](https://github.com/ory/oathkeeper/commit/4fc579cd677b71f6083fd3edaad741a7979e629a)),
+  closes [#120](https://github.com/ory/oathkeeper/issues/120)
+  [#133](https://github.com/ory/oathkeeper/issues/133)
+- Update Dockerfile build instructions
+  ([ec40cc4](https://github.com/ory/oathkeeper/commit/ec40cc4cfa1716adff9cb4cd8c604aa6f4aa9e91))
+- Upgrade dependencies ([#163](https://github.com/ory/oathkeeper/issues/163))
+  ([f9fdefb](https://github.com/ory/oathkeeper/commit/f9fdefb5dfe9dbff38f0ae96f82e42fea24d1c93))
+- Use scp,scope,scopes in jwt authenticator
+  ([#162](https://github.com/ory/oathkeeper/issues/162))
+  ([eebc2f4](https://github.com/ory/oathkeeper/commit/eebc2f44e3e42b7af653f91d9345111e0a280401)),
+  closes [#138](https://github.com/ory/oathkeeper/issues/138):
 
+  > Previously, the JWT authenticator only used the "scope" claim to retrieve
+  > scope values from a JWT. Now, "scp", "scope", "scopes" are supported as
+  > string arrays and strings separated by spaces.
 
 ## [0.14.2+oryOS.10](https://github.com/ory/oathkeeper/compare/v0.14.1+oryOS.10...v0.14.2+oryOS.10) (2018-12-13)
 
 No significant changes have been made for this release.
 
-
 ## [0.14.1+oryOS.10](https://github.com/ory/oathkeeper/compare/v0.14.0+oryOS.10...v0.14.1+oryOS.10) (2018-12-13)
 
 No significant changes have been made for this release.
 
-
 # [0.14.0+oryOS.10](https://github.com/ory/oathkeeper/compare/v0.11.12...v0.14.0+oryOS.10) (2018-12-13)
-
 
 ### Documentation
 
-* Adds gh templates & code of conduct ([#78](https://github.com/ory/oathkeeper/issues/78)) ([02361aa](https://github.com/ory/oathkeeper/commit/02361aa7a3499c78b480ca43cf29636a17391215))
-* Adds link to examples repository ([#79](https://github.com/ory/oathkeeper/issues/79)) ([bfe96e9](https://github.com/ory/oathkeeper/commit/bfe96e9a47b1c49be631f5286ed05d4377fba684))
-* Align changelog, upgrade with new versions ([#143](https://github.com/ory/oathkeeper/issues/143)) ([751dfa3](https://github.com/ory/oathkeeper/commit/751dfa3abacb122f0b5599800025366dec7d9b5c))
-* Clarify beyondcorp ([3647958](https://github.com/ory/oathkeeper/commit/3647958a415bd4c1abb106d0a765f2186e54ad60))
-* Clarify breaking change policy ([6e6bb7e](https://github.com/ory/oathkeeper/commit/6e6bb7e42ad8e84eb4cf5b8dfd3b27845748cbc0))
-* Fix broken link ([#87](https://github.com/ory/oathkeeper/issues/87)) ([828b33e](https://github.com/ory/oathkeeper/commit/828b33e94d2fadb0b371d5ae326a6dac855047a6))
-* Fix proxy help command description ([#142](https://github.com/ory/oathkeeper/issues/142)) ([c836cb0](https://github.com/ory/oathkeeper/commit/c836cb0e1785bc4da602b1c820a6d6a54e7043e0))
-* Fix typo in README. ([#118](https://github.com/ory/oathkeeper/issues/118)) ([3d33fcc](https://github.com/ory/oathkeeper/commit/3d33fcc85b248a7f0f9f7d1295459b5541927d81))
-* Grammatical fix in stability sentence ([#86](https://github.com/ory/oathkeeper/issues/86)) ([ff0604d](https://github.com/ory/oathkeeper/commit/ff0604df82361b2f6dee6f2945a03b2b6b117056))
-* Improve some docs and update SDK ([#135](https://github.com/ory/oathkeeper/issues/135)) ([9a6901d](https://github.com/ory/oathkeeper/commit/9a6901dc52b3ae9a1aabf692903b1d4922869308))
-* Incorporates changes from version v0.11.12-1-gace7f34 ([3a6450c](https://github.com/ory/oathkeeper/commit/3a6450c89b335465cf5bd3aa87e64a0e11eeefc3))
-* Incorporates changes from version v0.11.12-10-g57ac174 ([c594b7e](https://github.com/ory/oathkeeper/commit/c594b7e91e71f8fa4d2532667a5ab3eae49d53bf))
-* Incorporates changes from version v0.11.12-13-gd00dfed ([7c221fa](https://github.com/ory/oathkeeper/commit/7c221fa7d67c382f0277dc0fb94d0529dabe8ac2))
-* Incorporates changes from version v0.11.12-15-g6604045 ([2a594f4](https://github.com/ory/oathkeeper/commit/2a594f416a1dbf9391b543efbbdc6004a58524d0))
-* Incorporates changes from version v0.11.12-3-g7acfbca ([ac34a58](https://github.com/ory/oathkeeper/commit/ac34a58a4444e09a36c74ed23730dbc41cd656be))
-* Incorporates changes from version v0.11.12-6-g181e9ac ([01dda53](https://github.com/ory/oathkeeper/commit/01dda53f32ec7a1bfa9d43cc4df2a8778f5b8cc7))
-* Incorporates changes from version v1.0.0-beta.1 ([788e96b](https://github.com/ory/oathkeeper/commit/788e96b65dbb9765839f4f1e1e1a79cb401652b6))
-* Incorporates changes from version v1.0.0-beta.2-1-gd6eb440 ([579f7a7](https://github.com/ory/oathkeeper/commit/579f7a7c3c71b3a388f01e78e224026bf7c2ca08))
-* Incorporates changes from version v1.0.0-beta.2-10-gef6e889 ([38cfb31](https://github.com/ory/oathkeeper/commit/38cfb31f4608320daec4ceab12a51d493db772ed))
-* Incorporates changes from version v1.0.0-beta.2-12-g9b6c0df ([82ac9b2](https://github.com/ory/oathkeeper/commit/82ac9b295c376cdae107fa3646cee9614a2e3410))
-* Incorporates changes from version v1.0.0-beta.2-6-ged2f983 ([d9737c8](https://github.com/ory/oathkeeper/commit/d9737c8cc84a43b260c0acd98a5b77cd1082423d))
-* Incorporates changes from version v1.0.0-beta.2-8-g5495d4a ([546828d](https://github.com/ory/oathkeeper/commit/546828df624d959684302ce503b5ac09c2c52cf2))
-* Incorporates changes from version v1.0.0-beta.3-3-g3c0c862 ([e1127a8](https://github.com/ory/oathkeeper/commit/e1127a8322e24a366653e149b1d6209ab0b7d6af))
-* Incorporates changes from version v1.0.0-beta.4-1-g643dbea ([5c40f97](https://github.com/ory/oathkeeper/commit/5c40f97ec8c213ba8ed7bb8366204f53f5b9fae1))
-* Incorporates changes from version v1.0.0-beta.4-12-gbfe96e9 ([756178a](https://github.com/ory/oathkeeper/commit/756178a18d9d7b2ac9749ab09844e9cf37ccf98c))
-* Incorporates changes from version v1.0.0-beta.4-17-gfa5388c ([3d5df8b](https://github.com/ory/oathkeeper/commit/3d5df8b1162466453234bb4537e9d8538081352c))
-* Incorporates changes from version v1.0.0-beta.4-19-g6d647d7 ([b5539f4](https://github.com/ory/oathkeeper/commit/b5539f4157725c0620011f9bd0f8d67ba58741a5))
-* Incorporates changes from version v1.0.0-beta.4-3-g951da25 ([8931b39](https://github.com/ory/oathkeeper/commit/8931b39ee0ab2efd0ed38da87c888a33081ad817))
-* Incorporates changes from version v1.0.0-beta.4-5-g83b591d ([4f2c64b](https://github.com/ory/oathkeeper/commit/4f2c64b42d3b4cada98687ad3285b5ba9d3732ee))
-* Incorporates changes from version v1.0.0-beta.4-7-gf450697 ([8f904d2](https://github.com/ory/oathkeeper/commit/8f904d22a56410eabe6d9af7f87624a61a7f1a76))
-* Incorporates changes from version v1.0.0-beta.4-9-g02361aa ([5b34e91](https://github.com/ory/oathkeeper/commit/5b34e91cfffeef0787054ab92c0cf944c5653f15))
-* Incorporates changes from version v1.0.0-beta.5-1-g3647958 ([2bcfb39](https://github.com/ory/oathkeeper/commit/2bcfb3917118a71247c241ff2a99282a11154ee9))
-* Incorporates changes from version v1.0.0-beta.6-1-gff0604d ([0c69154](https://github.com/ory/oathkeeper/commit/0c69154cffcc6e6a5b3114276c228fd19f0450e7))
-* Incorporates changes from version v1.0.0-beta.6-3-g828b33e ([c53f5b2](https://github.com/ory/oathkeeper/commit/c53f5b2aa40c78e36402679c34bbd9f898a4296a))
-* Incorporates changes from version v1.0.0-beta.8 ([92c09fb](https://github.com/ory/oathkeeper/commit/92c09fb28552949cd034ed5555c87dfda91407a3))
-* Incorporates changes from version v1.0.0-beta.9 ([b9127f6](https://github.com/ory/oathkeeper/commit/b9127f60de1d96e95310731b88b77b7b443f0d2e))
-* Update documentation links ([#144](https://github.com/ory/oathkeeper/issues/144)) ([84131d2](https://github.com/ory/oathkeeper/commit/84131d2201192c92eebcf1f03dd89f417402c985))
-* Update link to security console ([26fdda1](https://github.com/ory/oathkeeper/commit/26fdda126a9b322e5310a2a3a3ed83949f640d2c))
-* Update migration guide ([b2e6d67](https://github.com/ory/oathkeeper/commit/b2e6d6783aa869dad52e30203fa7d2510ae556ef))
-* Updates copyright notice ([e58535d](https://github.com/ory/oathkeeper/commit/e58535d7bdc5f4b6dd8e293741e53cdd8767c61c))
-* Updates issue and pull request templates ([#126](https://github.com/ory/oathkeeper/issues/126)) ([5991a92](https://github.com/ory/oathkeeper/commit/5991a922a3fd39bb5704b16116325487b73f2868))
-* Updates issue and pull request templates ([#127](https://github.com/ory/oathkeeper/issues/127)) ([e4d0e26](https://github.com/ory/oathkeeper/commit/e4d0e2691618c104c5fe749267a02538bcb35465))
-* Updates link to open collective ([25e0dee](https://github.com/ory/oathkeeper/commit/25e0dee9b0f5ad1d45adc47d0b4e923e045d023f))
-* Updates links to docs ([9dca7c0](https://github.com/ory/oathkeeper/commit/9dca7c0829fc6ac669c621295423e9054989e14f))
-* Updates links to docs ([57ac174](https://github.com/ory/oathkeeper/commit/57ac17475350d713711256e772ffd875772e59b2))
-* Updates newsletter link in README ([97f1dea](https://github.com/ory/oathkeeper/commit/97f1dea021559a43302ffe32e16cd8ee585a0656))
-* Updates readme TOC ([3c0c862](https://github.com/ory/oathkeeper/commit/3c0c8626889f39b223a558e40baf21acc7819f8c))
-* Updates README.md ([1387f9f](https://github.com/ory/oathkeeper/commit/1387f9f2fb57de5c7d23d857575fd54b9bbd824f))
-* Updates TOC ([9b6c0df](https://github.com/ory/oathkeeper/commit/9b6c0dfd8d3548aef356c0d6d700d9805866d22b))
-* Updates upgrade.me ([0118f9f](https://github.com/ory/oathkeeper/commit/0118f9ffbb171876dad21a894f1c99a9c51c6d26))
-
+- Adds gh templates & code of conduct
+  ([#78](https://github.com/ory/oathkeeper/issues/78))
+  ([02361aa](https://github.com/ory/oathkeeper/commit/02361aa7a3499c78b480ca43cf29636a17391215))
+- Adds link to examples repository
+  ([#79](https://github.com/ory/oathkeeper/issues/79))
+  ([bfe96e9](https://github.com/ory/oathkeeper/commit/bfe96e9a47b1c49be631f5286ed05d4377fba684))
+- Align changelog, upgrade with new versions
+  ([#143](https://github.com/ory/oathkeeper/issues/143))
+  ([751dfa3](https://github.com/ory/oathkeeper/commit/751dfa3abacb122f0b5599800025366dec7d9b5c))
+- Clarify beyondcorp
+  ([3647958](https://github.com/ory/oathkeeper/commit/3647958a415bd4c1abb106d0a765f2186e54ad60))
+- Clarify breaking change policy
+  ([6e6bb7e](https://github.com/ory/oathkeeper/commit/6e6bb7e42ad8e84eb4cf5b8dfd3b27845748cbc0))
+- Fix broken link ([#87](https://github.com/ory/oathkeeper/issues/87))
+  ([828b33e](https://github.com/ory/oathkeeper/commit/828b33e94d2fadb0b371d5ae326a6dac855047a6))
+- Fix proxy help command description
+  ([#142](https://github.com/ory/oathkeeper/issues/142))
+  ([c836cb0](https://github.com/ory/oathkeeper/commit/c836cb0e1785bc4da602b1c820a6d6a54e7043e0))
+- Fix typo in README. ([#118](https://github.com/ory/oathkeeper/issues/118))
+  ([3d33fcc](https://github.com/ory/oathkeeper/commit/3d33fcc85b248a7f0f9f7d1295459b5541927d81))
+- Grammatical fix in stability sentence
+  ([#86](https://github.com/ory/oathkeeper/issues/86))
+  ([ff0604d](https://github.com/ory/oathkeeper/commit/ff0604df82361b2f6dee6f2945a03b2b6b117056))
+- Improve some docs and update SDK
+  ([#135](https://github.com/ory/oathkeeper/issues/135))
+  ([9a6901d](https://github.com/ory/oathkeeper/commit/9a6901dc52b3ae9a1aabf692903b1d4922869308))
+- Incorporates changes from version v0.11.12-1-gace7f34
+  ([3a6450c](https://github.com/ory/oathkeeper/commit/3a6450c89b335465cf5bd3aa87e64a0e11eeefc3))
+- Incorporates changes from version v0.11.12-10-g57ac174
+  ([c594b7e](https://github.com/ory/oathkeeper/commit/c594b7e91e71f8fa4d2532667a5ab3eae49d53bf))
+- Incorporates changes from version v0.11.12-13-gd00dfed
+  ([7c221fa](https://github.com/ory/oathkeeper/commit/7c221fa7d67c382f0277dc0fb94d0529dabe8ac2))
+- Incorporates changes from version v0.11.12-15-g6604045
+  ([2a594f4](https://github.com/ory/oathkeeper/commit/2a594f416a1dbf9391b543efbbdc6004a58524d0))
+- Incorporates changes from version v0.11.12-3-g7acfbca
+  ([ac34a58](https://github.com/ory/oathkeeper/commit/ac34a58a4444e09a36c74ed23730dbc41cd656be))
+- Incorporates changes from version v0.11.12-6-g181e9ac
+  ([01dda53](https://github.com/ory/oathkeeper/commit/01dda53f32ec7a1bfa9d43cc4df2a8778f5b8cc7))
+- Incorporates changes from version v1.0.0-beta.1
+  ([788e96b](https://github.com/ory/oathkeeper/commit/788e96b65dbb9765839f4f1e1e1a79cb401652b6))
+- Incorporates changes from version v1.0.0-beta.2-1-gd6eb440
+  ([579f7a7](https://github.com/ory/oathkeeper/commit/579f7a7c3c71b3a388f01e78e224026bf7c2ca08))
+- Incorporates changes from version v1.0.0-beta.2-10-gef6e889
+  ([38cfb31](https://github.com/ory/oathkeeper/commit/38cfb31f4608320daec4ceab12a51d493db772ed))
+- Incorporates changes from version v1.0.0-beta.2-12-g9b6c0df
+  ([82ac9b2](https://github.com/ory/oathkeeper/commit/82ac9b295c376cdae107fa3646cee9614a2e3410))
+- Incorporates changes from version v1.0.0-beta.2-6-ged2f983
+  ([d9737c8](https://github.com/ory/oathkeeper/commit/d9737c8cc84a43b260c0acd98a5b77cd1082423d))
+- Incorporates changes from version v1.0.0-beta.2-8-g5495d4a
+  ([546828d](https://github.com/ory/oathkeeper/commit/546828df624d959684302ce503b5ac09c2c52cf2))
+- Incorporates changes from version v1.0.0-beta.3-3-g3c0c862
+  ([e1127a8](https://github.com/ory/oathkeeper/commit/e1127a8322e24a366653e149b1d6209ab0b7d6af))
+- Incorporates changes from version v1.0.0-beta.4-1-g643dbea
+  ([5c40f97](https://github.com/ory/oathkeeper/commit/5c40f97ec8c213ba8ed7bb8366204f53f5b9fae1))
+- Incorporates changes from version v1.0.0-beta.4-12-gbfe96e9
+  ([756178a](https://github.com/ory/oathkeeper/commit/756178a18d9d7b2ac9749ab09844e9cf37ccf98c))
+- Incorporates changes from version v1.0.0-beta.4-17-gfa5388c
+  ([3d5df8b](https://github.com/ory/oathkeeper/commit/3d5df8b1162466453234bb4537e9d8538081352c))
+- Incorporates changes from version v1.0.0-beta.4-19-g6d647d7
+  ([b5539f4](https://github.com/ory/oathkeeper/commit/b5539f4157725c0620011f9bd0f8d67ba58741a5))
+- Incorporates changes from version v1.0.0-beta.4-3-g951da25
+  ([8931b39](https://github.com/ory/oathkeeper/commit/8931b39ee0ab2efd0ed38da87c888a33081ad817))
+- Incorporates changes from version v1.0.0-beta.4-5-g83b591d
+  ([4f2c64b](https://github.com/ory/oathkeeper/commit/4f2c64b42d3b4cada98687ad3285b5ba9d3732ee))
+- Incorporates changes from version v1.0.0-beta.4-7-gf450697
+  ([8f904d2](https://github.com/ory/oathkeeper/commit/8f904d22a56410eabe6d9af7f87624a61a7f1a76))
+- Incorporates changes from version v1.0.0-beta.4-9-g02361aa
+  ([5b34e91](https://github.com/ory/oathkeeper/commit/5b34e91cfffeef0787054ab92c0cf944c5653f15))
+- Incorporates changes from version v1.0.0-beta.5-1-g3647958
+  ([2bcfb39](https://github.com/ory/oathkeeper/commit/2bcfb3917118a71247c241ff2a99282a11154ee9))
+- Incorporates changes from version v1.0.0-beta.6-1-gff0604d
+  ([0c69154](https://github.com/ory/oathkeeper/commit/0c69154cffcc6e6a5b3114276c228fd19f0450e7))
+- Incorporates changes from version v1.0.0-beta.6-3-g828b33e
+  ([c53f5b2](https://github.com/ory/oathkeeper/commit/c53f5b2aa40c78e36402679c34bbd9f898a4296a))
+- Incorporates changes from version v1.0.0-beta.8
+  ([92c09fb](https://github.com/ory/oathkeeper/commit/92c09fb28552949cd034ed5555c87dfda91407a3))
+- Incorporates changes from version v1.0.0-beta.9
+  ([b9127f6](https://github.com/ory/oathkeeper/commit/b9127f60de1d96e95310731b88b77b7b443f0d2e))
+- Update documentation links
+  ([#144](https://github.com/ory/oathkeeper/issues/144))
+  ([84131d2](https://github.com/ory/oathkeeper/commit/84131d2201192c92eebcf1f03dd89f417402c985))
+- Update link to security console
+  ([26fdda1](https://github.com/ory/oathkeeper/commit/26fdda126a9b322e5310a2a3a3ed83949f640d2c))
+- Update migration guide
+  ([b2e6d67](https://github.com/ory/oathkeeper/commit/b2e6d6783aa869dad52e30203fa7d2510ae556ef))
+- Updates copyright notice
+  ([e58535d](https://github.com/ory/oathkeeper/commit/e58535d7bdc5f4b6dd8e293741e53cdd8767c61c))
+- Updates issue and pull request templates
+  ([#126](https://github.com/ory/oathkeeper/issues/126))
+  ([5991a92](https://github.com/ory/oathkeeper/commit/5991a922a3fd39bb5704b16116325487b73f2868))
+- Updates issue and pull request templates
+  ([#127](https://github.com/ory/oathkeeper/issues/127))
+  ([e4d0e26](https://github.com/ory/oathkeeper/commit/e4d0e2691618c104c5fe749267a02538bcb35465))
+- Updates link to open collective
+  ([25e0dee](https://github.com/ory/oathkeeper/commit/25e0dee9b0f5ad1d45adc47d0b4e923e045d023f))
+- Updates links to docs
+  ([9dca7c0](https://github.com/ory/oathkeeper/commit/9dca7c0829fc6ac669c621295423e9054989e14f))
+- Updates links to docs
+  ([57ac174](https://github.com/ory/oathkeeper/commit/57ac17475350d713711256e772ffd875772e59b2))
+- Updates newsletter link in README
+  ([97f1dea](https://github.com/ory/oathkeeper/commit/97f1dea021559a43302ffe32e16cd8ee585a0656))
+- Updates readme TOC
+  ([3c0c862](https://github.com/ory/oathkeeper/commit/3c0c8626889f39b223a558e40baf21acc7819f8c))
+- Updates README.md
+  ([1387f9f](https://github.com/ory/oathkeeper/commit/1387f9f2fb57de5c7d23d857575fd54b9bbd824f))
+- Updates TOC
+  ([9b6c0df](https://github.com/ory/oathkeeper/commit/9b6c0dfd8d3548aef356c0d6d700d9805866d22b))
+- Updates upgrade.me
+  ([0118f9f](https://github.com/ory/oathkeeper/commit/0118f9ffbb171876dad21a894f1c99a9c51c6d26))
 
 ### Unclassified
 
-* Add ability to configure scope strategy ([519a536](https://github.com/ory/oathkeeper/commit/519a53628696576891196f0ce733353d639e6aec))
-* Add cookies ci to handler factory ([#103](https://github.com/ory/oathkeeper/issues/103)) ([59aabfa](https://github.com/ory/oathkeeper/commit/59aabfa4b2554f03f65d618a7d7bf1c98a634da3))
-* Add cookies credentials issuer ([032d88e](https://github.com/ory/oathkeeper/commit/032d88ea8dee24506d277d22b7f4aaef2a502fa7))
-* Add endpoint for answering access requests directly ([d211641](https://github.com/ory/oathkeeper/commit/d2116410edf1f5089427858727f155bc0aa4313c)), closes [#42](https://github.com/ory/oathkeeper/issues/42):
+- Add ability to configure scope strategy
+  ([519a536](https://github.com/ory/oathkeeper/commit/519a53628696576891196f0ce733353d639e6aec))
+- Add cookies ci to handler factory
+  ([#103](https://github.com/ory/oathkeeper/issues/103))
+  ([59aabfa](https://github.com/ory/oathkeeper/commit/59aabfa4b2554f03f65d618a7d7bf1c98a634da3))
+- Add cookies credentials issuer
+  ([032d88e](https://github.com/ory/oathkeeper/commit/032d88ea8dee24506d277d22b7f4aaef2a502fa7))
+- Add endpoint for answering access requests directly
+  ([d211641](https://github.com/ory/oathkeeper/commit/d2116410edf1f5089427858727f155bc0aa4313c)),
+  closes [#42](https://github.com/ory/oathkeeper/issues/42):
 
-    > This patch adds endpoint `/judge` to `oathkeeper serve api`. The `/judge` endpoint mimics the behavior of `oathkeeper serve proxy` but instead of forwarding the request to the upstream server, the endpoint answers directly with a HTTP response.
-    > 
-    > The HTTP response returns status code 200 if the request should be allowed and any other status code (e.g. 401, 403) if not.
-    > 
-    > Assuming you are making the following request:
-    > 
-    > ```
-    > PUT /judge/my-service/whatever HTTP/1.1
-    > Host: oathkeeper-api:4456
-    > User-Agent: curl/7.54.0
-    > Authorization: bearer some-token
-    > Accept: */*
-    > Content-Type: application/json
-    > Content-Length: 0
-    > ```
-    > 
-    > And you have a rule which allows token `some-bearer` to access `PUT /my-service/whatever` and you have a credentials issuer which does not modify the Authorization header, the response will be:
-    > 
-    > ```
-    > HTTP/1.1 200 OK
-    > Authorization: bearer-sometoken
-    > Content-Length: 0
-    > Connection: Closed
-    > ```
-    > 
-    > If the rule denies the request, the response will be, for example:
-    > 
-    > ```
-    > HTTP/1.1 401 OK
-    > Content-Length: 0
-    > Connection: Closed
-    > ```
-* Add headers credentials issuer ([b084c32](https://github.com/ory/oathkeeper/commit/b084c3271ab8ca71c9fe766de030572c69057671))
-* Add http proxy timeout config ([#132](https://github.com/ory/oathkeeper/issues/132)) ([b3718ce](https://github.com/ory/oathkeeper/commit/b3718ce56d4bcfe4610806ae6b15382226adab75)):
+  > This patch adds endpoint `/judge` to `oathkeeper serve api`. The `/judge`
+  > endpoint mimics the behavior of `oathkeeper serve proxy` but instead of
+  > forwarding the request to the upstream server, the endpoint answers directly
+  > with a HTTP response.
+  >
+  > The HTTP response returns status code 200 if the request should be allowed
+  > and any other status code (e.g. 401, 403) if not.
+  >
+  > Assuming you are making the following request:
+  >
+  > ```
+  > PUT /judge/my-service/whatever HTTP/1.1
+  > Host: oathkeeper-api:4456
+  > User-Agent: curl/7.54.0
+  > Authorization: bearer some-token
+  > Accept: */*
+  > Content-Type: application/json
+  > Content-Length: 0
+  > ```
+  >
+  > And you have a rule which allows token `some-bearer` to access
+  > `PUT /my-service/whatever` and you have a credentials issuer which does not
+  > modify the Authorization header, the response will be:
+  >
+  > ```
+  > HTTP/1.1 200 OK
+  > Authorization: bearer-sometoken
+  > Content-Length: 0
+  > Connection: Closed
+  > ```
+  >
+  > If the rule denies the request, the response will be, for example:
+  >
+  > ```
+  > HTTP/1.1 401 OK
+  > Content-Length: 0
+  > Connection: Closed
+  > ```
 
-    > Add environment parameters (and description) to configure timeout settings of a server handled proxy requests.
-    > 
-    > It will help prevent a case of unexpected closing a client connection if an upstream request is executing more than default timeout.
-    > 
-    > 
-* Add JWT authenticator ([61625bc](https://github.com/ory/oathkeeper/commit/61625bccebe0b478b980c66a29894dc1ffe48b0a))
-* Add NodeJS SDK ([#94](https://github.com/ory/oathkeeper/issues/94)) ([7505b71](https://github.com/ory/oathkeeper/commit/7505b717f28aaec38e07999ffe1f417484e110f7))
-* Adds ability to specify db url via env var in migrate ([b2cc5d2](https://github.com/ory/oathkeeper/commit/b2cc5d25d23c88c25e4ef415031030a9229dc593))
-* Adds and improves metrics middleware ([b0dfd97](https://github.com/ory/oathkeeper/commit/b0dfd97fd0d947e35727b0eb4301c4ebbbbf3eb0))
-* Adds log message when telemetry is active ([ed2f983](https://github.com/ory/oathkeeper/commit/ed2f9836c6ff2e496b4cbe300d7cee4f1ce5c12e))
-* Adds validator for rules ([#77](https://github.com/ory/oathkeeper/issues/77)) ([f450697](https://github.com/ory/oathkeeper/commit/f45069711b2aa5ed3ace6361a1bc8e9115a76406)):
+- Add headers credentials issuer
+  ([b084c32](https://github.com/ory/oathkeeper/commit/b084c3271ab8ca71c9fe766de030572c69057671))
+- Add http proxy timeout config
+  ([#132](https://github.com/ory/oathkeeper/issues/132))
+  ([b3718ce](https://github.com/ory/oathkeeper/commit/b3718ce56d4bcfe4610806ae6b15382226adab75)):
 
-    > This patch adds an input validator for rules which should prevent
-    > accidental typos or similar issues when creating a rule. Additionally,
-    > no invalid/unconfigured handlers (authorizers, credential issuers,
-    > authenticators) can be used.
-* Align TLS options with hydra ([#114](https://github.com/ory/oathkeeper/issues/114)) ([c763152](https://github.com/ory/oathkeeper/commit/c7631528afc1e60ffed61a5b5e101079224e751b))
-* Allow empty upstream in rules ([e46065a](https://github.com/ory/oathkeeper/commit/e46065afa1d6ad14fa62dad9c6b145e46623c7f0))
-* Allow regex in match scheme ([c6d17c5](https://github.com/ory/oathkeeper/commit/c6d17c54c0a23c519a150971faf8486a957b2e82)), closes [#92](https://github.com/ory/oathkeeper/issues/92)
-* Allows connectivity to MySQL ([fa5388c](https://github.com/ory/oathkeeper/commit/fa5388cfc2cd31f0ecee379a6f515bf4cd48961f)), closes [#82](https://github.com/ory/oathkeeper/issues/82)
-* Authenticator noop should not bypass ([6f8ab4f](https://github.com/ory/oathkeeper/commit/6f8ab4f7d676fbcf06d1eeb4ab1452b15f090185)), closes [#97](https://github.com/ory/oathkeeper/issues/97)
-* Convert AuthenticationSession to local struct type for better handling ([b00b2a2](https://github.com/ory/oathkeeper/commit/b00b2a2498b44df5717b757bffbf13b00184bf68))
-* Disable cors per default ([#107](https://github.com/ory/oathkeeper/issues/107)) ([c5ab0c3](https://github.com/ory/oathkeeper/commit/c5ab0c3175b336bb8bea3b919cae57c838262ab4)):
+  > Add environment parameters (and description) to configure timeout settings
+  > of a server handled proxy requests.
+  >
+  > It will help prevent a case of unexpected closing a client connection if an
+  > upstream request is executing more than default timeout.
 
-    > This patch introduces CORS_ENABLED which defaults to "false".
-    > 
-    > 
-* Doesn't fatal if no ORY Hydra is unresponsive. ([#66](https://github.com/ory/oathkeeper/issues/66)) ([181e9ac](https://github.com/ory/oathkeeper/commit/181e9acf9bdc9adc05e6718df53b7fa1ff539c41)), closes [#65](https://github.com/ory/oathkeeper/issues/65)
-* Enables TLS option on serve api ([#116](https://github.com/ory/oathkeeper/issues/116)) ([83f1f84](https://github.com/ory/oathkeeper/commit/83f1f84a42510f2c9a6d72d33f94ff8117b56a7f))
-* Expose all ORY Hydra ports in tests ([691a72d](https://github.com/ory/oathkeeper/commit/691a72d3372d3a949acadf95130ed7d1432dafac))
-* Expose all ORY Hydra ports in tests ([add70c6](https://github.com/ory/oathkeeper/commit/add70c66f0c30848d845e80e94c9065865d65809))
-* Fix checkResponse message typo ([#106](https://github.com/ory/oathkeeper/issues/106)) ([0d0e653](https://github.com/ory/oathkeeper/commit/0d0e653e11a7b7415ef76334ebe9c1c0b50e47c8))
-* Ignore query parameters when matching url in rules. ([#139](https://github.com/ory/oathkeeper/issues/139)) ([07eb99b](https://github.com/ory/oathkeeper/commit/07eb99bdb669121bcd27559d9f11d0633f5a8877))
-* Improve compatibility with ORY Hydra 1.0.0-beta.8 ([#108](https://github.com/ory/oathkeeper/issues/108)) ([296e012](https://github.com/ory/oathkeeper/commit/296e01254b50b645fae67e51aa668d39652b0778)), closes [#101](https://github.com/ory/oathkeeper/issues/101):
+- Add JWT authenticator
+  ([61625bc](https://github.com/ory/oathkeeper/commit/61625bccebe0b478b980c66a29894dc1ffe48b0a))
+- Add NodeJS SDK ([#94](https://github.com/ory/oathkeeper/issues/94))
+  ([7505b71](https://github.com/ory/oathkeeper/commit/7505b717f28aaec38e07999ffe1f417484e110f7))
+- Adds ability to specify db url via env var in migrate
+  ([b2cc5d2](https://github.com/ory/oathkeeper/commit/b2cc5d25d23c88c25e4ef415031030a9229dc593))
+- Adds and improves metrics middleware
+  ([b0dfd97](https://github.com/ory/oathkeeper/commit/b0dfd97fd0d947e35727b0eb4301c4ebbbbf3eb0))
+- Adds log message when telemetry is active
+  ([ed2f983](https://github.com/ory/oathkeeper/commit/ed2f9836c6ff2e496b4cbe300d7cee4f1ce5c12e))
+- Adds validator for rules ([#77](https://github.com/ory/oathkeeper/issues/77))
+  ([f450697](https://github.com/ory/oathkeeper/commit/f45069711b2aa5ed3ace6361a1bc8e9115a76406)):
 
-    > This patch improves compatibility with ORY Hydra 1.0.0-beta.8 and updates vendored dependencies.
-* Improve hydra integration tests ([e8b7a58](https://github.com/ory/oathkeeper/commit/e8b7a586c5fcb86efddf57d4f2f97a0ff915b869))
-* Improve refresh subroutines ([cc33538](https://github.com/ory/oathkeeper/commit/cc33538f11d9292465bc2fdf0275233b1ff7df9e))
-* Improves cors parsing ([d00dfed](https://github.com/ory/oathkeeper/commit/d00dfed2724cd449744fe189a6f957bdab8f508b))
-* Improves test set up ([6b6bb88](https://github.com/ory/oathkeeper/commit/6b6bb8846385e59436469ba201d94791d3588566))
-* Include headers credential issuer in handler factory ([0e1ef1b](https://github.com/ory/oathkeeper/commit/0e1ef1bf31a4cd48fa72d42f91323d860ac886ef))
-* Introduce health and version endpoint ([029c7ff](https://github.com/ory/oathkeeper/commit/029c7ffab1b68df902d31812a7fde635cc2d880b))
-* Make subject configurable using go template ([#129](https://github.com/ory/oathkeeper/issues/129)) ([ee9dcdd](https://github.com/ory/oathkeeper/commit/ee9dcdd275b6b7f21c4a8b438ebed711acfda5e2))
-* More CredentialsIssuerHeaders tests ([079171f](https://github.com/ory/oathkeeper/commit/079171fc159a62ec4742b73d71f9116d9831bf16))
-* Move headers into new config field ([51eb9fb](https://github.com/ory/oathkeeper/commit/51eb9fb021beff28111a491daa5b9a5d17040bc7))
-* Properly document JWT refresh ([#117](https://github.com/ory/oathkeeper/issues/117)) ([2e024f9](https://github.com/ory/oathkeeper/commit/2e024f91640bf4182d1b1a6fb143d77c523f4596))
-* Properly handle conflicts on PUT and POST ([83b591d](https://github.com/ory/oathkeeper/commit/83b591d8cf3d180ad9d48a72bd92ffdb3a8192ac)), closes [#38](https://github.com/ory/oathkeeper/issues/38):
+  > This patch adds an input validator for rules which should prevent accidental
+  > typos or similar issues when creating a rule. Additionally, no
+  > invalid/unconfigured handlers (authorizers, credential issuers,
+  > authenticators) can be used.
 
-    > Previously, PUT and POST did not result in errors (409) when non-existing
-    > resources were modified, or existing resources were created.
-    > This patch resolves that.
-* Refactors Oathkeeper into new ecosystem ([#60](https://github.com/ory/oathkeeper/issues/60)) ([7acfbca](https://github.com/ory/oathkeeper/commit/7acfbcaca36645a984baded2dc3cbb689154ef8c))
-* Refresh rules in api mode ([08204e8](https://github.com/ory/oathkeeper/commit/08204e8eb60745d8449b2da9780e460f504710c9))
-* Remove config flag ([#111](https://github.com/ory/oathkeeper/issues/111)) ([8385cbc](https://github.com/ory/oathkeeper/commit/8385cbcb05be5e1d5df8d5b3f00130b163d651f6)), closes [#110](https://github.com/ory/oathkeeper/issues/110)
-* Remove config flag ([#111](https://github.com/ory/oathkeeper/issues/111)) ([7de77b8](https://github.com/ory/oathkeeper/commit/7de77b81495c53dd3c3fac3f3524daa10b19fc5d)), closes [#110](https://github.com/ory/oathkeeper/issues/110)
-* Remove package.json from swagger dir ([837d18c](https://github.com/ory/oathkeeper/commit/837d18ca2eec44370b965de190b317dd40369970))
-* Resolve broken introspection scope setting ([18837a9](https://github.com/ory/oathkeeper/commit/18837a9fb18c931b6fadfa39f71520f3f45e6c1c))
-* Resolve HS256 kid mismatch ([6d647d7](https://github.com/ory/oathkeeper/commit/6d647d76b1e41f4ec0d43c79934d601f5e0627af)), closes [#83](https://github.com/ory/oathkeeper/issues/83)
-* Resolves panic when network fails in "rules import" ([078542a](https://github.com/ory/oathkeeper/commit/078542a9c143ca6e18499157b2462a4c986230a3))
-* Streamlines https configuration variables ([#124](https://github.com/ory/oathkeeper/issues/124)) ([9f6f815](https://github.com/ory/oathkeeper/commit/9f6f8155a002699e29c5f02c8ebb48ac5dff17be)), closes [#121](https://github.com/ory/oathkeeper/issues/121)
-* Test for errors ([585672e](https://github.com/ory/oathkeeper/commit/585672e3a4a7e996d575d51889918c049e95106e))
-* Test missing Extra field ([a4d3d2d](https://github.com/ory/oathkeeper/commit/a4d3d2d4708d7c6baec90289a9a0bb956a95566b))
-* Test template caching/lookup ([ab8a402](https://github.com/ory/oathkeeper/commit/ab8a40298071eff9fc0bec66470d7392226cdf6e))
-* Update keto to latest ([3e2a8de](https://github.com/ory/oathkeeper/commit/3e2a8dee9ead7a89d537162b8c4271444ab137df))
-* Upgrade keto authorizer to 0.2.0 ([#145](https://github.com/ory/oathkeeper/issues/145)) ([bcd4836](https://github.com/ory/oathkeeper/commit/bcd4836d2ad38821d2a3c856ff3b851e5dce344a))
-* Support "scope" claim as a string in jwt authenticator (#137) ([ab5240e](https://github.com/ory/oathkeeper/commit/ab5240e9a462cfaf2f632d6b535a3177d2c80c4e)), closes [#137](https://github.com/ory/oathkeeper/issues/137)
-* Test nesting of various types ([188748d](https://github.com/ory/oathkeeper/commit/188748d526edc8aa0e71b163b7d7188755fb9b7f))
-* Update rules stub ([475f39a](https://github.com/ory/oathkeeper/commit/475f39a5f506b21557def2eb967ecdc7bd84d245))
-* Upgrade superagent version ([44ed240](https://github.com/ory/oathkeeper/commit/44ed24017fec12a4de8505b3050018230e885981))
-* Use print funcmap function to override text/template print ([76b2d9d](https://github.com/ory/oathkeeper/commit/76b2d9d13c7983ac24c2076a5f5770f2cb380d43))
-* Validate handler configurations ([a558103](https://github.com/ory/oathkeeper/commit/a55810339ba3ec85654c358b902733c3125f01f0))
-* Adds docker-compose example with postgres ([84f1313](https://github.com/ory/oathkeeper/commit/84f131387845a1f0246d40b074d446ec58b014c0))
-* Removes obsolete benchmark ([3f259da](https://github.com/ory/oathkeeper/commit/3f259da7766eb6a42b54bb3a6f3ddeb49d9363a1))
-* Resolves an issue with cached matchers ([951da25](https://github.com/ory/oathkeeper/commit/951da251e3e862f2d0a1e5076c028a481f0235dd)), closes [#73](https://github.com/ory/oathkeeper/issues/73):
+- Align TLS options with hydra
+  ([#114](https://github.com/ory/oathkeeper/issues/114))
+  ([c763152](https://github.com/ory/oathkeeper/commit/c7631528afc1e60ffed61a5b5e101079224e751b))
+- Allow empty upstream in rules
+  ([e46065a](https://github.com/ory/oathkeeper/commit/e46065afa1d6ad14fa62dad9c6b145e46623c7f0))
+- Allow regex in match scheme
+  ([c6d17c5](https://github.com/ory/oathkeeper/commit/c6d17c54c0a23c519a150971faf8486a957b2e82)),
+  closes [#92](https://github.com/ory/oathkeeper/issues/92)
+- Allows connectivity to MySQL
+  ([fa5388c](https://github.com/ory/oathkeeper/commit/fa5388cfc2cd31f0ecee379a6f515bf4cd48961f)),
+  closes [#82](https://github.com/ory/oathkeeper/issues/82)
+- Authenticator noop should not bypass
+  ([6f8ab4f](https://github.com/ory/oathkeeper/commit/6f8ab4f7d676fbcf06d1eeb4ab1452b15f090185)),
+  closes [#97](https://github.com/ory/oathkeeper/issues/97)
+- Convert AuthenticationSession to local struct type for better handling
+  ([b00b2a2](https://github.com/ory/oathkeeper/commit/b00b2a2498b44df5717b757bffbf13b00184bf68))
+- Disable cors per default
+  ([#107](https://github.com/ory/oathkeeper/issues/107))
+  ([c5ab0c3](https://github.com/ory/oathkeeper/commit/c5ab0c3175b336bb8bea3b919cae57c838262ab4)):
 
-    > This patch resolves an issue where updates would not properly propagate. This caused deleted rules to still be available in the proxy.
-* Resolves issues with broken tests ([6604045](https://github.com/ory/oathkeeper/commit/6604045191446baca03791940ddf746aed4799d1))
-* Resolves naming issues and updates readme ([5495d4a](https://github.com/ory/oathkeeper/commit/5495d4aa6d23a04891b53694e4fc0e0857c2f955))
-* Resolves potential panic in request handler ([ef6e889](https://github.com/ory/oathkeeper/commit/ef6e8894f034ec66bb3b0da1bdda762fe428a14d))
-* Resolves recursive stack overflow ([#81](https://github.com/ory/oathkeeper/issues/81)) ([0594cda](https://github.com/ory/oathkeeper/commit/0594cda346f7ce5af1dc86c6335c1b782632d9eb)), closes [#80](https://github.com/ory/oathkeeper/issues/80)
-* Reduces setup complexity by making strategies configurable ([6626f8f](https://github.com/ory/oathkeeper/commit/6626f8f2aa98f8ee05e5b1f63c1b698083f9ae78)), closes [#71](https://github.com/ory/oathkeeper/issues/71):
+  > This patch introduces CORS_ENABLED which defaults to "false".
 
-    > This patch adds another ID Token signing algorithm (HS256) which is easier to set up as it does not rely on ORY Hydra but instead on a shared secret.
-    > 
-    > Additionally the ability to specify which ID Token singing algorithm to use has been added. Environmental variables to configure the behvaiour have been added as well.
-    > 
-    > Further, the ORY Keto Warden Authorizer strategy is now optional and disabled when the environment variable `AUTHORIZER_KETO_WARDEN_KETO_URL` is empty.
-* Updates to ORY Hydra v1.0.0-beta.2 ([e4c9f2e](https://github.com/ory/oathkeeper/commit/e4c9f2eeed41ab8deeb54f2137ea1b2d90a3bdc3))
-* Tells linguist to ignore SDK files ([ace7f34](https://github.com/ory/oathkeeper/commit/ace7f3411f882c6e89bef7800fb2b700e51cd5f6))
+- Doesn't fatal if no ORY Hydra is unresponsive.
+  ([#66](https://github.com/ory/oathkeeper/issues/66))
+  ([181e9ac](https://github.com/ory/oathkeeper/commit/181e9acf9bdc9adc05e6718df53b7fa1ff539c41)),
+  closes [#65](https://github.com/ory/oathkeeper/issues/65)
+- Enables TLS option on serve api
+  ([#116](https://github.com/ory/oathkeeper/issues/116))
+  ([83f1f84](https://github.com/ory/oathkeeper/commit/83f1f84a42510f2c9a6d72d33f94ff8117b56a7f))
+- Expose all ORY Hydra ports in tests
+  ([691a72d](https://github.com/ory/oathkeeper/commit/691a72d3372d3a949acadf95130ed7d1432dafac))
+- Expose all ORY Hydra ports in tests
+  ([add70c6](https://github.com/ory/oathkeeper/commit/add70c66f0c30848d845e80e94c9065865d65809))
+- Fix checkResponse message typo
+  ([#106](https://github.com/ory/oathkeeper/issues/106))
+  ([0d0e653](https://github.com/ory/oathkeeper/commit/0d0e653e11a7b7415ef76334ebe9c1c0b50e47c8))
+- Ignore query parameters when matching url in rules.
+  ([#139](https://github.com/ory/oathkeeper/issues/139))
+  ([07eb99b](https://github.com/ory/oathkeeper/commit/07eb99bdb669121bcd27559d9f11d0633f5a8877))
+- Improve compatibility with ORY Hydra 1.0.0-beta.8
+  ([#108](https://github.com/ory/oathkeeper/issues/108))
+  ([296e012](https://github.com/ory/oathkeeper/commit/296e01254b50b645fae67e51aa668d39652b0778)),
+  closes [#101](https://github.com/ory/oathkeeper/issues/101):
 
+  > This patch improves compatibility with ORY Hydra 1.0.0-beta.8 and updates
+  > vendored dependencies.
 
+- Improve hydra integration tests
+  ([e8b7a58](https://github.com/ory/oathkeeper/commit/e8b7a586c5fcb86efddf57d4f2f97a0ff915b869))
+- Improve refresh subroutines
+  ([cc33538](https://github.com/ory/oathkeeper/commit/cc33538f11d9292465bc2fdf0275233b1ff7df9e))
+- Improves cors parsing
+  ([d00dfed](https://github.com/ory/oathkeeper/commit/d00dfed2724cd449744fe189a6f957bdab8f508b))
+- Improves test set up
+  ([6b6bb88](https://github.com/ory/oathkeeper/commit/6b6bb8846385e59436469ba201d94791d3588566))
+- Include headers credential issuer in handler factory
+  ([0e1ef1b](https://github.com/ory/oathkeeper/commit/0e1ef1bf31a4cd48fa72d42f91323d860ac886ef))
+- Introduce health and version endpoint
+  ([029c7ff](https://github.com/ory/oathkeeper/commit/029c7ffab1b68df902d31812a7fde635cc2d880b))
+- Make subject configurable using go template
+  ([#129](https://github.com/ory/oathkeeper/issues/129))
+  ([ee9dcdd](https://github.com/ory/oathkeeper/commit/ee9dcdd275b6b7f21c4a8b438ebed711acfda5e2))
+- More CredentialsIssuerHeaders tests
+  ([079171f](https://github.com/ory/oathkeeper/commit/079171fc159a62ec4742b73d71f9116d9831bf16))
+- Move headers into new config field
+  ([51eb9fb](https://github.com/ory/oathkeeper/commit/51eb9fb021beff28111a491daa5b9a5d17040bc7))
+- Properly document JWT refresh
+  ([#117](https://github.com/ory/oathkeeper/issues/117))
+  ([2e024f9](https://github.com/ory/oathkeeper/commit/2e024f91640bf4182d1b1a6fb143d77c523f4596))
+- Properly handle conflicts on PUT and POST
+  ([83b591d](https://github.com/ory/oathkeeper/commit/83b591d8cf3d180ad9d48a72bd92ffdb3a8192ac)),
+  closes [#38](https://github.com/ory/oathkeeper/issues/38):
+
+  > Previously, PUT and POST did not result in errors (409) when non-existing
+  > resources were modified, or existing resources were created. This patch
+  > resolves that.
+
+- Refactors Oathkeeper into new ecosystem
+  ([#60](https://github.com/ory/oathkeeper/issues/60))
+  ([7acfbca](https://github.com/ory/oathkeeper/commit/7acfbcaca36645a984baded2dc3cbb689154ef8c))
+- Refresh rules in api mode
+  ([08204e8](https://github.com/ory/oathkeeper/commit/08204e8eb60745d8449b2da9780e460f504710c9))
+- Remove config flag ([#111](https://github.com/ory/oathkeeper/issues/111))
+  ([8385cbc](https://github.com/ory/oathkeeper/commit/8385cbcb05be5e1d5df8d5b3f00130b163d651f6)),
+  closes [#110](https://github.com/ory/oathkeeper/issues/110)
+- Remove config flag ([#111](https://github.com/ory/oathkeeper/issues/111))
+  ([7de77b8](https://github.com/ory/oathkeeper/commit/7de77b81495c53dd3c3fac3f3524daa10b19fc5d)),
+  closes [#110](https://github.com/ory/oathkeeper/issues/110)
+- Remove package.json from swagger dir
+  ([837d18c](https://github.com/ory/oathkeeper/commit/837d18ca2eec44370b965de190b317dd40369970))
+- Resolve broken introspection scope setting
+  ([18837a9](https://github.com/ory/oathkeeper/commit/18837a9fb18c931b6fadfa39f71520f3f45e6c1c))
+- Resolve HS256 kid mismatch
+  ([6d647d7](https://github.com/ory/oathkeeper/commit/6d647d76b1e41f4ec0d43c79934d601f5e0627af)),
+  closes [#83](https://github.com/ory/oathkeeper/issues/83)
+- Resolves panic when network fails in "rules import"
+  ([078542a](https://github.com/ory/oathkeeper/commit/078542a9c143ca6e18499157b2462a4c986230a3))
+- Streamlines https configuration variables
+  ([#124](https://github.com/ory/oathkeeper/issues/124))
+  ([9f6f815](https://github.com/ory/oathkeeper/commit/9f6f8155a002699e29c5f02c8ebb48ac5dff17be)),
+  closes [#121](https://github.com/ory/oathkeeper/issues/121)
+- Test for errors
+  ([585672e](https://github.com/ory/oathkeeper/commit/585672e3a4a7e996d575d51889918c049e95106e))
+- Test missing Extra field
+  ([a4d3d2d](https://github.com/ory/oathkeeper/commit/a4d3d2d4708d7c6baec90289a9a0bb956a95566b))
+- Test template caching/lookup
+  ([ab8a402](https://github.com/ory/oathkeeper/commit/ab8a40298071eff9fc0bec66470d7392226cdf6e))
+- Update keto to latest
+  ([3e2a8de](https://github.com/ory/oathkeeper/commit/3e2a8dee9ead7a89d537162b8c4271444ab137df))
+- Upgrade keto authorizer to 0.2.0
+  ([#145](https://github.com/ory/oathkeeper/issues/145))
+  ([bcd4836](https://github.com/ory/oathkeeper/commit/bcd4836d2ad38821d2a3c856ff3b851e5dce344a))
+- Support "scope" claim as a string in jwt authenticator (#137)
+  ([ab5240e](https://github.com/ory/oathkeeper/commit/ab5240e9a462cfaf2f632d6b535a3177d2c80c4e)),
+  closes [#137](https://github.com/ory/oathkeeper/issues/137)
+- Test nesting of various types
+  ([188748d](https://github.com/ory/oathkeeper/commit/188748d526edc8aa0e71b163b7d7188755fb9b7f))
+- Update rules stub
+  ([475f39a](https://github.com/ory/oathkeeper/commit/475f39a5f506b21557def2eb967ecdc7bd84d245))
+- Upgrade superagent version
+  ([44ed240](https://github.com/ory/oathkeeper/commit/44ed24017fec12a4de8505b3050018230e885981))
+- Use print funcmap function to override text/template print
+  ([76b2d9d](https://github.com/ory/oathkeeper/commit/76b2d9d13c7983ac24c2076a5f5770f2cb380d43))
+- Validate handler configurations
+  ([a558103](https://github.com/ory/oathkeeper/commit/a55810339ba3ec85654c358b902733c3125f01f0))
+- Adds docker-compose example with postgres
+  ([84f1313](https://github.com/ory/oathkeeper/commit/84f131387845a1f0246d40b074d446ec58b014c0))
+- Removes obsolete benchmark
+  ([3f259da](https://github.com/ory/oathkeeper/commit/3f259da7766eb6a42b54bb3a6f3ddeb49d9363a1))
+- Resolves an issue with cached matchers
+  ([951da25](https://github.com/ory/oathkeeper/commit/951da251e3e862f2d0a1e5076c028a481f0235dd)),
+  closes [#73](https://github.com/ory/oathkeeper/issues/73):
+
+  > This patch resolves an issue where updates would not properly propagate.
+  > This caused deleted rules to still be available in the proxy.
+
+- Resolves issues with broken tests
+  ([6604045](https://github.com/ory/oathkeeper/commit/6604045191446baca03791940ddf746aed4799d1))
+- Resolves naming issues and updates readme
+  ([5495d4a](https://github.com/ory/oathkeeper/commit/5495d4aa6d23a04891b53694e4fc0e0857c2f955))
+- Resolves potential panic in request handler
+  ([ef6e889](https://github.com/ory/oathkeeper/commit/ef6e8894f034ec66bb3b0da1bdda762fe428a14d))
+- Resolves recursive stack overflow
+  ([#81](https://github.com/ory/oathkeeper/issues/81))
+  ([0594cda](https://github.com/ory/oathkeeper/commit/0594cda346f7ce5af1dc86c6335c1b782632d9eb)),
+  closes [#80](https://github.com/ory/oathkeeper/issues/80)
+- Reduces setup complexity by making strategies configurable
+  ([6626f8f](https://github.com/ory/oathkeeper/commit/6626f8f2aa98f8ee05e5b1f63c1b698083f9ae78)),
+  closes [#71](https://github.com/ory/oathkeeper/issues/71):
+
+  > This patch adds another ID Token signing algorithm (HS256) which is easier
+  > to set up as it does not rely on ORY Hydra but instead on a shared secret.
+  >
+  > Additionally the ability to specify which ID Token singing algorithm to use
+  > has been added. Environmental variables to configure the behvaiour have been
+  > added as well.
+  >
+  > Further, the ORY Keto Warden Authorizer strategy is now optional and
+  > disabled when the environment variable `AUTHORIZER_KETO_WARDEN_KETO_URL` is
+  > empty.
+
+- Updates to ORY Hydra v1.0.0-beta.2
+  ([e4c9f2e](https://github.com/ory/oathkeeper/commit/e4c9f2eeed41ab8deeb54f2137ea1b2d90a3bdc3))
+- Tells linguist to ignore SDK files
+  ([ace7f34](https://github.com/ory/oathkeeper/commit/ace7f3411f882c6e89bef7800fb2b700e51cd5f6))
 
 ## [0.11.12](https://github.com/ory/oathkeeper/compare/v0.0.29...v0.11.12) (2018-05-07)
 
-
 ### Documentation
 
-* Adds automatic summary generation ([#49](https://github.com/ory/oathkeeper/issues/49)) ([20fefbc](https://github.com/ory/oathkeeper/commit/20fefbcac042e2a251f8bf047f252e251dbc704b))
-* Adds edit on github links ([95af1bb](https://github.com/ory/oathkeeper/commit/95af1bba9cc1b5dafe12f11ab9876371efedd92a))
-* Adds license note to all source files ([#51](https://github.com/ory/oathkeeper/issues/51)) ([2c8ff2f](https://github.com/ory/oathkeeper/commit/2c8ff2f944574210964456126342d7a41efb73b7))
-* Fixes redirect path ([9bca2f3](https://github.com/ory/oathkeeper/commit/9bca2f36a5d9ef75afb97e63faaffa912c9121d3))
-* Moves documentation to new repository ([#57](https://github.com/ory/oathkeeper/issues/57)) ([a9f21f3](https://github.com/ory/oathkeeper/commit/a9f21f3c5a71442ee879a8457798f8965b869f28))
-* Redirect to ory domain ([0599e63](https://github.com/ory/oathkeeper/commit/0599e63d8628effa242b85e28f66df6a95616a45))
-* Removes newline from swagger doc ([5e297b3](https://github.com/ory/oathkeeper/commit/5e297b39794e4e015dedd716f3402f0bfb6efc1c))
-* Removes stray line in api docs ([bed1a04](https://github.com/ory/oathkeeper/commit/bed1a048cd54bd103c3c6bc62455671a3536d04f))
-* Removes summary plugin ([ce06f4e](https://github.com/ory/oathkeeper/commit/ce06f4eaffda106d009f2b554aecda3e3ba86434))
-* Resolves broken policy and client definitions ([#55](https://github.com/ory/oathkeeper/issues/55)) ([4676f40](https://github.com/ory/oathkeeper/commit/4676f4054090ef705c705a3eaac616f8f513b980)), closes [#53](https://github.com/ory/oathkeeper/issues/53)
-* Updates chat badge to discord ([1bbac52](https://github.com/ory/oathkeeper/commit/1bbac524d5634d8aa286cdd14d9230807123da85))
-* Updates execution instructions ([#56](https://github.com/ory/oathkeeper/issues/56)) ([3bcfd8b](https://github.com/ory/oathkeeper/commit/3bcfd8b1b91df97f78eb6e7b9bb2df7ba398b158)):
+- Adds automatic summary generation
+  ([#49](https://github.com/ory/oathkeeper/issues/49))
+  ([20fefbc](https://github.com/ory/oathkeeper/commit/20fefbcac042e2a251f8bf047f252e251dbc704b))
+- Adds edit on github links
+  ([95af1bb](https://github.com/ory/oathkeeper/commit/95af1bba9cc1b5dafe12f11ab9876371efedd92a))
+- Adds license note to all source files
+  ([#51](https://github.com/ory/oathkeeper/issues/51))
+  ([2c8ff2f](https://github.com/ory/oathkeeper/commit/2c8ff2f944574210964456126342d7a41efb73b7))
+- Fixes redirect path
+  ([9bca2f3](https://github.com/ory/oathkeeper/commit/9bca2f36a5d9ef75afb97e63faaffa912c9121d3))
+- Moves documentation to new repository
+  ([#57](https://github.com/ory/oathkeeper/issues/57))
+  ([a9f21f3](https://github.com/ory/oathkeeper/commit/a9f21f3c5a71442ee879a8457798f8965b869f28))
+- Redirect to ory domain
+  ([0599e63](https://github.com/ory/oathkeeper/commit/0599e63d8628effa242b85e28f66df6a95616a45))
+- Removes newline from swagger doc
+  ([5e297b3](https://github.com/ory/oathkeeper/commit/5e297b39794e4e015dedd716f3402f0bfb6efc1c))
+- Removes stray line in api docs
+  ([bed1a04](https://github.com/ory/oathkeeper/commit/bed1a048cd54bd103c3c6bc62455671a3536d04f))
+- Removes summary plugin
+  ([ce06f4e](https://github.com/ory/oathkeeper/commit/ce06f4eaffda106d009f2b554aecda3e3ba86434))
+- Resolves broken policy and client definitions
+  ([#55](https://github.com/ory/oathkeeper/issues/55))
+  ([4676f40](https://github.com/ory/oathkeeper/commit/4676f4054090ef705c705a3eaac616f8f513b980)),
+  closes [#53](https://github.com/ory/oathkeeper/issues/53)
+- Updates chat badge to discord
+  ([1bbac52](https://github.com/ory/oathkeeper/commit/1bbac524d5634d8aa286cdd14d9230807123da85))
+- Updates execution instructions
+  ([#56](https://github.com/ory/oathkeeper/issues/56))
+  ([3bcfd8b](https://github.com/ory/oathkeeper/commit/3bcfd8b1b91df97f78eb6e7b9bb2df7ba398b158)):
 
-    > Adjusting run script to respect env variables
-* Updates README.md ([#58](https://github.com/ory/oathkeeper/issues/58)) ([bdb542f](https://github.com/ory/oathkeeper/commit/bdb542fcb6006c218f499793f0e44ce30f79cf2a))
-* Updates swagger docs ([5ea68c2](https://github.com/ory/oathkeeper/commit/5ea68c290d757e341932b00cb89c2a9e5b7e2429))
+  > Adjusting run script to respect env variables
 
+- Updates README.md ([#58](https://github.com/ory/oathkeeper/issues/58))
+  ([bdb542f](https://github.com/ory/oathkeeper/commit/bdb542fcb6006c218f499793f0e44ce30f79cf2a))
+- Updates swagger docs
+  ([5ea68c2](https://github.com/ory/oathkeeper/commit/5ea68c290d757e341932b00cb89c2a9e5b7e2429))
 
 ### Unclassified
 
-* Introduces new versioning number to match ORY Hydra ([75b5121](https://github.com/ory/oathkeeper/commit/75b51213a50750a12f670060a34aecadf49fa3e2))
-* Adds mock generation script ([00b51b7](https://github.com/ory/oathkeeper/commit/00b51b7a71089d04a4b3005e5fd15d5e9db22939))
-* Corrects logging typo ([#52](https://github.com/ory/oathkeeper/issues/52)) ([d415291](https://github.com/ory/oathkeeper/commit/d41529123a756cd202b2216a0aa746e137e72e5e)):
+- Introduces new versioning number to match ORY Hydra
+  ([75b5121](https://github.com/ory/oathkeeper/commit/75b51213a50750a12f670060a34aecadf49fa3e2))
+- Adds mock generation script
+  ([00b51b7](https://github.com/ory/oathkeeper/commit/00b51b7a71089d04a4b3005e5fd15d5e9db22939))
+- Corrects logging typo ([#52](https://github.com/ory/oathkeeper/issues/52))
+  ([d415291](https://github.com/ory/oathkeeper/commit/d41529123a756cd202b2216a0aa746e137e72e5e)):
 
-    > This corrects logging from 'oahtkeeper-proxy' to 'oathkeeper-proxy' in,
-    > e.g., the proxy latency logline.
-* Updates hydra sdk mock ([2ff8032](https://github.com/ory/oathkeeper/commit/2ff8032f9362a8ef5d85692ce49d425bfc18f2f0))
-* Updates hydra to 0.11.6 ([ee969f6](https://github.com/ory/oathkeeper/commit/ee969f68145c5398b79fe4e7a9bf7fa74d1e6bf3))
-* Updates license header ([94a2ed2](https://github.com/ory/oathkeeper/commit/94a2ed2a0c381fe2fbf5182c45acb52ca4e2c164))
-* Use source file from vendor for mock generation ([42517c6](https://github.com/ory/oathkeeper/commit/42517c6df9bfb1a5a14606229916b8ba674aa3e1))
-* Uses Hydra v0.11.6 in tests ([9c2cc89](https://github.com/ory/oathkeeper/commit/9c2cc8901f32ab8042fadbd32475e98650c37e72))
-* Adds license ([cc13ae8](https://github.com/ory/oathkeeper/commit/cc13ae8f002426dc3b39b2184b438331e6f63522))
-* Updates README.md ([c9340dc](https://github.com/ory/oathkeeper/commit/c9340dc94d1b6aec4825c8a2ccf423aee1a5fd3b))
+  > This corrects logging from 'oahtkeeper-proxy' to 'oathkeeper-proxy' in,
+  > e.g., the proxy latency logline.
 
-
+- Updates hydra sdk mock
+  ([2ff8032](https://github.com/ory/oathkeeper/commit/2ff8032f9362a8ef5d85692ce49d425bfc18f2f0))
+- Updates hydra to 0.11.6
+  ([ee969f6](https://github.com/ory/oathkeeper/commit/ee969f68145c5398b79fe4e7a9bf7fa74d1e6bf3))
+- Updates license header
+  ([94a2ed2](https://github.com/ory/oathkeeper/commit/94a2ed2a0c381fe2fbf5182c45acb52ca4e2c164))
+- Use source file from vendor for mock generation
+  ([42517c6](https://github.com/ory/oathkeeper/commit/42517c6df9bfb1a5a14606229916b8ba674aa3e1))
+- Uses Hydra v0.11.6 in tests
+  ([9c2cc89](https://github.com/ory/oathkeeper/commit/9c2cc8901f32ab8042fadbd32475e98650c37e72))
+- Adds license
+  ([cc13ae8](https://github.com/ory/oathkeeper/commit/cc13ae8f002426dc3b39b2184b438331e6f63522))
+- Updates README.md
+  ([c9340dc](https://github.com/ory/oathkeeper/commit/c9340dc94d1b6aec4825c8a2ccf423aee1a5fd3b))
 
 ## [0.0.29](https://github.com/ory/oathkeeper/compare/v0.0.28...v0.0.29) (2017-12-19)
 
-
 ### Unclassified
 
-* Adds use field to well known (#48) ([f7353ea](https://github.com/ory/oathkeeper/commit/f7353ea1de25c37f58b9e7532e06210ea575bc29)), closes [#48](https://github.com/ory/oathkeeper/issues/48)
-
-
+- Adds use field to well known (#48)
+  ([f7353ea](https://github.com/ory/oathkeeper/commit/f7353ea1de25c37f58b9e7532e06210ea575bc29)),
+  closes [#48](https://github.com/ory/oathkeeper/issues/48)
 
 ## [0.0.28](https://github.com/ory/oathkeeper/compare/v0.0.27...v0.0.28) (2017-12-19)
 
-
 ### Unclassified
 
-* Replaces key discovery with well-known feature (#46) ([e343a61](https://github.com/ory/oathkeeper/commit/e343a61d6ae8f149f61c832fc567533651a1b16f)), closes [#46](https://github.com/ory/oathkeeper/issues/46) [#43](https://github.com/ory/oathkeeper/issues/43)
-
-
+- Replaces key discovery with well-known feature (#46)
+  ([e343a61](https://github.com/ory/oathkeeper/commit/e343a61d6ae8f149f61c832fc567533651a1b16f)),
+  closes [#46](https://github.com/ory/oathkeeper/issues/46)
+  [#43](https://github.com/ory/oathkeeper/issues/43)
 
 ## [0.0.27](https://github.com/ory/oathkeeper/compare/v0.0.26...v0.0.27) (2017-12-12)
 
-
 ### Unclassified
 
-* Adds cors capabilities to management server ([6519846](https://github.com/ory/oathkeeper/commit/6519846691737a4f8ddfb5c55186d1b0c26db8ad))
-
-
+- Adds cors capabilities to management server
+  ([6519846](https://github.com/ory/oathkeeper/commit/6519846691737a4f8ddfb5c55186d1b0c26db8ad))
 
 ## [0.0.26](https://github.com/ory/oathkeeper/compare/v0.0.25...v0.0.26) (2017-12-11)
 
-
 ### Unclassified
 
-* Adds hydra.introspect to required tokens ([b66462a](https://github.com/ory/oathkeeper/commit/b66462a0ec62d82adb805c6aa29d807c21c5e20b))
-* Fixes broken image link in docs ([1aa2404](https://github.com/ory/oathkeeper/commit/1aa2404b9fa88e69b6e18832f1532978012dba27))
-
-
+- Adds hydra.introspect to required tokens
+  ([b66462a](https://github.com/ory/oathkeeper/commit/b66462a0ec62d82adb805c6aa29d807c21c5e20b))
+- Fixes broken image link in docs
+  ([1aa2404](https://github.com/ory/oathkeeper/commit/1aa2404b9fa88e69b6e18832f1532978012dba27))
 
 ## [0.0.25](https://github.com/ory/oathkeeper/compare/v0.0.24...v0.0.25) (2017-11-28)
 
-
 ### Unclassified
 
-* Add extra data from token introspection to session ([ce8f9f2](https://github.com/ory/oathkeeper/commit/ce8f9f265bad2d60b467d788d4314270c549a461))
-
-
+- Add extra data from token introspection to session
+  ([ce8f9f2](https://github.com/ory/oathkeeper/commit/ce8f9f265bad2d60b467d788d4314270c549a461))
 
 ## [0.0.24](https://github.com/ory/oathkeeper/compare/v0.0.23...v0.0.24) (2017-11-26)
 
-
 ### Unclassified
 
-* Replaces LogError with direct error logging ([73994b8](https://github.com/ory/oathkeeper/commit/73994b850629c6ec267903ad09e2a6eceef7a9cd))
-* Upgrades vendor dependencies ([4207aef](https://github.com/ory/oathkeeper/commit/4207aef3c00a64f315dc0e85cd83adb6e3c9660c))
-* Introduces telemetry module and adds documentation ([c5a7f7a](https://github.com/ory/oathkeeper/commit/c5a7f7a8fc6e0e2a264b5bc3dd29174f86f4b5c9)), closes [#27](https://github.com/ory/oathkeeper/issues/27) [#34](https://github.com/ory/oathkeeper/issues/34)
-* Use oathkeeper public url as issuer ([1e5ae00](https://github.com/ory/oathkeeper/commit/1e5ae00f457aafdd7a284a388704ce954b3339b1))
-
-
+- Replaces LogError with direct error logging
+  ([73994b8](https://github.com/ory/oathkeeper/commit/73994b850629c6ec267903ad09e2a6eceef7a9cd))
+- Upgrades vendor dependencies
+  ([4207aef](https://github.com/ory/oathkeeper/commit/4207aef3c00a64f315dc0e85cd83adb6e3c9660c))
+- Introduces telemetry module and adds documentation
+  ([c5a7f7a](https://github.com/ory/oathkeeper/commit/c5a7f7a8fc6e0e2a264b5bc3dd29174f86f4b5c9)),
+  closes [#27](https://github.com/ory/oathkeeper/issues/27)
+  [#34](https://github.com/ory/oathkeeper/issues/34)
+- Use oathkeeper public url as issuer
+  ([1e5ae00](https://github.com/ory/oathkeeper/commit/1e5ae00f457aafdd7a284a388704ce954b3339b1))
 
 ## [0.0.23](https://github.com/ory/oathkeeper/compare/v0.0.22...v0.0.23) (2017-11-24)
 
-
 ### Documentation
 
-* Add JWK set docs ([#33](https://github.com/ory/oathkeeper/issues/33)) ([95abec8](https://github.com/ory/oathkeeper/commit/95abec817a1fb053a19d47e66725764f56f4c9cc))
-* Update readme ([f448908](https://github.com/ory/oathkeeper/commit/f448908fb38f3b069de488a59e27ff082e610e1a))
-
+- Add JWK set docs ([#33](https://github.com/ory/oathkeeper/issues/33))
+  ([95abec8](https://github.com/ory/oathkeeper/commit/95abec817a1fb053a19d47e66725764f56f4c9cc))
+- Update readme
+  ([f448908](https://github.com/ory/oathkeeper/commit/f448908fb38f3b069de488a59e27ff082e610e1a))
 
 ### Unclassified
 
-* Print formatted output string in rule management CLI (#35) ([b14c74e](https://github.com/ory/oathkeeper/commit/b14c74e6270c4e2fdd9741c3cbe619336efd1435)), closes [#35](https://github.com/ory/oathkeeper/issues/35)
-* Update docs and add tests (#32) ([c6bf7d1](https://github.com/ory/oathkeeper/commit/c6bf7d15e8b935b6ed64551391f9aa23968cf4d9)), closes [#32](https://github.com/ory/oathkeeper/issues/32)
-
-
+- Print formatted output string in rule management CLI (#35)
+  ([b14c74e](https://github.com/ory/oathkeeper/commit/b14c74e6270c4e2fdd9741c3cbe619336efd1435)),
+  closes [#35](https://github.com/ory/oathkeeper/issues/35)
+- Update docs and add tests (#32)
+  ([c6bf7d1](https://github.com/ory/oathkeeper/commit/c6bf7d15e8b935b6ed64551391f9aa23968cf4d9)),
+  closes [#32](https://github.com/ory/oathkeeper/issues/32)
 
 ## [0.0.22](https://github.com/ory/oathkeeper/compare/v0.0.21...v0.0.22) (2017-11-20)
 
-
 ### Unclassified
 
-* Renames bypass values for better clarity ([46a717e](https://github.com/ory/oathkeeper/commit/46a717e0428fba1fcabb0bdb669acaba39aa5444)), closes [#13](https://github.com/ory/oathkeeper/issues/13) [#29](https://github.com/ory/oathkeeper/issues/29)
-
-
+- Renames bypass values for better clarity
+  ([46a717e](https://github.com/ory/oathkeeper/commit/46a717e0428fba1fcabb0bdb669acaba39aa5444)),
+  closes [#13](https://github.com/ory/oathkeeper/issues/13)
+  [#29](https://github.com/ory/oathkeeper/issues/29)
 
 ## [0.0.21](https://github.com/ory/oathkeeper/compare/v0.0.20...v0.0.21) (2017-11-19)
 
-
 ### Unclassified
 
-* Request hydra.keys scope and fix panic ([546b2cf](https://github.com/ory/oathkeeper/commit/546b2cff5e7cea306a60963f646ad4522f5bfd15))
-
-
+- Request hydra.keys scope and fix panic
+  ([546b2cf](https://github.com/ory/oathkeeper/commit/546b2cff5e7cea306a60963f646ad4522f5bfd15))
 
 ## [0.0.20](https://github.com/ory/oathkeeper/compare/v0.0.19...v0.0.20) (2017-11-18)
 
-
 ### Documentation
 
-* Add developer guide link to readme ([68be400](https://github.com/ory/oathkeeper/commit/68be400c070a63b3ec8a7f40bc343ed39a45bed5))
-* Add install and run section ([87f0700](https://github.com/ory/oathkeeper/commit/87f07004b47d9803246bc42bf78c3e5100969033))
-* Fix table of contents in summary ([fdb752b](https://github.com/ory/oathkeeper/commit/fdb752b3172ed746776cb7153f4523b10920f492))
-* Improve swagger documentation ([8f16a9b](https://github.com/ory/oathkeeper/commit/8f16a9b36e1b75415f5e367c0ae5589a74187139))
-* Wrote basic developer guide ([952d27c](https://github.com/ory/oathkeeper/commit/952d27c7639a80b5daddb702a6f790e855b1422b))
-
+- Add developer guide link to readme
+  ([68be400](https://github.com/ory/oathkeeper/commit/68be400c070a63b3ec8a7f40bc343ed39a45bed5))
+- Add install and run section
+  ([87f0700](https://github.com/ory/oathkeeper/commit/87f07004b47d9803246bc42bf78c3e5100969033))
+- Fix table of contents in summary
+  ([fdb752b](https://github.com/ory/oathkeeper/commit/fdb752b3172ed746776cb7153f4523b10920f492))
+- Improve swagger documentation
+  ([8f16a9b](https://github.com/ory/oathkeeper/commit/8f16a9b36e1b75415f5e367c0ae5589a74187139))
+- Wrote basic developer guide
+  ([952d27c](https://github.com/ory/oathkeeper/commit/952d27c7639a80b5daddb702a6f790e855b1422b))
 
 ### Unclassified
 
-* Replace shared secret with RSA key from Hydra for ID token signing ([e7ed8ca](https://github.com/ory/oathkeeper/commit/e7ed8ca672f617a5d67a0d70ca665e3b45fe3e67))
-* Add rules management capabilities to the cli ([289c38a](https://github.com/ory/oathkeeper/commit/289c38ae4b9c67b654e3b24dc45bd28968f75937))
-* Format cmd/serve ([bc2e7c1](https://github.com/ory/oathkeeper/commit/bc2e7c159eea9a203820e396f7588a007722efc8))
-* Ignore gitbook output directory ([580b94f](https://github.com/ory/oathkeeper/commit/580b94fa921363782e02d66981172659dc76dadc))
-
-
+- Replace shared secret with RSA key from Hydra for ID token signing
+  ([e7ed8ca](https://github.com/ory/oathkeeper/commit/e7ed8ca672f617a5d67a0d70ca665e3b45fe3e67))
+- Add rules management capabilities to the cli
+  ([289c38a](https://github.com/ory/oathkeeper/commit/289c38ae4b9c67b654e3b24dc45bd28968f75937))
+- Format cmd/serve
+  ([bc2e7c1](https://github.com/ory/oathkeeper/commit/bc2e7c159eea9a203820e396f7588a007722efc8))
+- Ignore gitbook output directory
+  ([580b94f](https://github.com/ory/oathkeeper/commit/580b94fa921363782e02d66981172659dc76dadc))
 
 ## [0.0.19](https://github.com/ory/oathkeeper/compare/v0.0.18...v0.0.19) (2017-11-13)
 
-
 ### Unclassified
 
-* Use full request URL ([2b4b149](https://github.com/ory/oathkeeper/commit/2b4b1492ce3356a7a251e241a308669517ddba3e))
-
-
+- Use full request URL
+  ([2b4b149](https://github.com/ory/oathkeeper/commit/2b4b1492ce3356a7a251e241a308669517ddba3e))
 
 ## [0.0.18](https://github.com/ory/oathkeeper/compare/v0.0.17...v0.0.18) (2017-11-13)
 
-
 ### Unclassified
 
-* Improve audit capabilities ([c952d21](https://github.com/ory/oathkeeper/commit/c952d21bd59c7f318a3e7c4f98978eb8b3fc7231))
-* Resolve potential panic in token id generation ([8fe9e9a](https://github.com/ory/oathkeeper/commit/8fe9e9a5bd7b951b93c4966f8585945074ff104d)), closes [#22](https://github.com/ory/oathkeeper/issues/22)
-
-
+- Improve audit capabilities
+  ([c952d21](https://github.com/ory/oathkeeper/commit/c952d21bd59c7f318a3e7c4f98978eb8b3fc7231))
+- Resolve potential panic in token id generation
+  ([8fe9e9a](https://github.com/ory/oathkeeper/commit/8fe9e9a5bd7b951b93c4966f8585945074ff104d)),
+  closes [#22](https://github.com/ory/oathkeeper/issues/22)
 
 ## [0.0.17](https://github.com/ory/oathkeeper/compare/v0.0.16...v0.0.17) (2017-11-12)
 
-
 ### Unclassified
 
-* Introduces surrogate_id to SQLManager (#21) ([fbe272f](https://github.com/ory/oathkeeper/commit/fbe272f36e64c4e15758a34f62cc3d03e63c7c64)), closes [#21](https://github.com/ory/oathkeeper/issues/21)
-
-
+- Introduces surrogate_id to SQLManager (#21)
+  ([fbe272f](https://github.com/ory/oathkeeper/commit/fbe272f36e64c4e15758a34f62cc3d03e63c7c64)),
+  closes [#21](https://github.com/ory/oathkeeper/issues/21)
 
 ## [0.0.16](https://github.com/ory/oathkeeper/compare/v0.0.15...v0.0.16) (2017-11-12)
 
-
 ### Unclassified
 
-* Replace MatchesPath with MatchesURL (#20) ([4ee776c](https://github.com/ory/oathkeeper/commit/4ee776cc08201f91dfdab5c0c259c4cfffd88ddb)), closes [#20](https://github.com/ory/oathkeeper/issues/20)
-
-
+- Replace MatchesPath with MatchesURL (#20)
+  ([4ee776c](https://github.com/ory/oathkeeper/commit/4ee776cc08201f91dfdab5c0c259c4cfffd88ddb)),
+  closes [#20](https://github.com/ory/oathkeeper/issues/20)
 
 ## [0.0.15](https://github.com/ory/oathkeeper/compare/v0.0.14...v0.0.15) (2017-11-09)
 
-
 ### Unclassified
 
-* Add HTTPS capabilities and document proxy/management commands (#19) ([98ef623](https://github.com/ory/oathkeeper/commit/98ef623e64a58afa99fcb2db67bf5c514c86334c)), closes [#19](https://github.com/ory/oathkeeper/issues/19)
-
-
+- Add HTTPS capabilities and document proxy/management commands (#19)
+  ([98ef623](https://github.com/ory/oathkeeper/commit/98ef623e64a58afa99fcb2db67bf5c514c86334c)),
+  closes [#19](https://github.com/ory/oathkeeper/issues/19)
 
 ## [0.0.14](https://github.com/ory/oathkeeper/compare/v0.0.13...v0.0.14) (2017-11-07)
 
-
 ### Unclassified
 
-* Make refresh_delay configurable and skip it on boot (#18) ([4863a82](https://github.com/ory/oathkeeper/commit/4863a823d8f510e5c82d7f8c34f5753f18861a03)), closes [#18](https://github.com/ory/oathkeeper/issues/18)
-
-
+- Make refresh_delay configurable and skip it on boot (#18)
+  ([4863a82](https://github.com/ory/oathkeeper/commit/4863a823d8f510e5c82d7f8c34f5753f18861a03)),
+  closes [#18](https://github.com/ory/oathkeeper/issues/18)
 
 ## [0.0.13](https://github.com/ory/oathkeeper/compare/v0.0.12...v0.0.13) (2017-11-07)
 
-
 ### Unclassified
 
-* Store rules path match in plaintext (#17) ([6570b5d](https://github.com/ory/oathkeeper/commit/6570b5d7f3169f63f9d8c31d844660f5394fc37a)), closes [#17](https://github.com/ory/oathkeeper/issues/17)
-
-
+- Store rules path match in plaintext (#17)
+  ([6570b5d](https://github.com/ory/oathkeeper/commit/6570b5d7f3169f63f9d8c31d844660f5394fc37a)),
+  closes [#17](https://github.com/ory/oathkeeper/issues/17)
 
 ## [0.0.12](https://github.com/ory/oathkeeper/compare/v0.0.11...v0.0.12) (2017-11-07)
 
-
 ### Unclassified
 
-* Use ladon regex compiler for matches (#16) ([972a328](https://github.com/ory/oathkeeper/commit/972a328b1a0fca0dfcc41487492f0203c284b54a)), closes [#16](https://github.com/ory/oathkeeper/issues/16)
-* Fix typo in circle-ci test-docker job ([5618c30](https://github.com/ory/oathkeeper/commit/5618c3079ef559ad5dfbacc398a8b95b3c333643))
-* Run docker image in test ([12b5f13](https://github.com/ory/oathkeeper/commit/12b5f13ad997b7c427505bffa1ad7e33aa2de684))
-
-
+- Use ladon regex compiler for matches (#16)
+  ([972a328](https://github.com/ory/oathkeeper/commit/972a328b1a0fca0dfcc41487492f0203c284b54a)),
+  closes [#16](https://github.com/ory/oathkeeper/issues/16)
+- Fix typo in circle-ci test-docker job
+  ([5618c30](https://github.com/ory/oathkeeper/commit/5618c3079ef559ad5dfbacc398a8b95b3c333643))
+- Run docker image in test
+  ([12b5f13](https://github.com/ory/oathkeeper/commit/12b5f13ad997b7c427505bffa1ad7e33aa2de684))
 
 ## [0.0.11](https://github.com/ory/oathkeeper/compare/v0.0.10...v0.0.11) (2017-11-06)
 
-
 ### Unclassified
 
-* Move gatekeeper to $PATH in docker image ([81e5562](https://github.com/ory/oathkeeper/commit/81e5562ead12d1376f6eadff53ce36339dd3599a))
-* Force docker version 17.10 in circle ([3927a78](https://github.com/ory/oathkeeper/commit/3927a789d7b93849fb1b2d0edbccf45781c9030b))
-
-
+- Move gatekeeper to $PATH in docker image
+  ([81e5562](https://github.com/ory/oathkeeper/commit/81e5562ead12d1376f6eadff53ce36339dd3599a))
+- Force docker version 17.10 in circle
+  ([3927a78](https://github.com/ory/oathkeeper/commit/3927a789d7b93849fb1b2d0edbccf45781c9030b))
 
 ## [0.0.10](https://github.com/ory/oathkeeper/compare/v0.0.9...v0.0.10) (2017-11-06)
 
-
 ### Unclassified
 
-* Add ssl certificates to scratch image ([56a3243](https://github.com/ory/oathkeeper/commit/56a3243d1c4be1308b1aa22244548359c94ee181))
-* Build static binary within docker ([4d6d8bf](https://github.com/ory/oathkeeper/commit/4d6d8bf22f7aea16fa21e4fee99c829b9e76de0d))
-
-
+- Add ssl certificates to scratch image
+  ([56a3243](https://github.com/ory/oathkeeper/commit/56a3243d1c4be1308b1aa22244548359c94ee181))
+- Build static binary within docker
+  ([4d6d8bf](https://github.com/ory/oathkeeper/commit/4d6d8bf22f7aea16fa21e4fee99c829b9e76de0d))
 
 ## [0.0.9](https://github.com/ory/oathkeeper/compare/v0.0.8...v0.0.9) (2017-11-06)
 
-
 ### Unclassified
 
-* Build binary statically with CGO disabled ([6dd3761](https://github.com/ory/oathkeeper/commit/6dd376171e3c1219de54984a9a27ac44d76d897b))
-
-
+- Build binary statically with CGO disabled
+  ([6dd3761](https://github.com/ory/oathkeeper/commit/6dd376171e3c1219de54984a9a27ac44d76d897b))
 
 ## [0.0.8](https://github.com/ory/oathkeeper/compare/v0.0.7...v0.0.8) (2017-11-06)
 
-
 ### Unclassified
 
-* Make oathkeeper binary executable# ([9e24888](https://github.com/ory/oathkeeper/commit/9e24888654675208f96913e6c11233b598e78815))
-
-
+- Make oathkeeper binary executable#
+  ([9e24888](https://github.com/ory/oathkeeper/commit/9e24888654675208f96913e6c11233b598e78815))
 
 ## [0.0.7](https://github.com/ory/oathkeeper/compare/v0.0.6...v0.0.7) (2017-11-06)
 
-
 ### Unclassified
 
-* Build oathekeeper docker image statically (#14) ([dbd2037](https://github.com/ory/oathkeeper/commit/dbd2037b56b6104b79607b20394be0e9a30e67e1)), closes [#14](https://github.com/ory/oathkeeper/issues/14):
+- Build oathekeeper docker image statically (#14)
+  ([dbd2037](https://github.com/ory/oathkeeper/commit/dbd2037b56b6104b79607b20394be0e9a30e67e1)),
+  closes [#14](https://github.com/ory/oathkeeper/issues/14):
 
-    > * Build oathekeeper docker image statically
-    > 
-    > * Build oathekeeper docker image statically
-
-
+  > - Build oathekeeper docker image statically
+  >
+  > - Build oathekeeper docker image statically
 
 ## [0.0.6](https://github.com/ory/oathkeeper/compare/v0.0.5...v0.0.6) (2017-11-03)
 
-
 ### Unclassified
 
-* Added serve all command ([dfc071c](https://github.com/ory/oathkeeper/commit/dfc071c02d9fa6fda9832bd35fdc4b1eb96c63c6))
-
-
+- Added serve all command
+  ([dfc071c](https://github.com/ory/oathkeeper/commit/dfc071c02d9fa6fda9832bd35fdc4b1eb96c63c6))
 
 ## [0.0.5](https://github.com/ory/oathkeeper/compare/v0.0.4...v0.0.5) (2017-11-01)
 
-
 ### Unclassified
 
-* Remove goveralls from circle build ([8362e1c](https://github.com/ory/oathkeeper/commit/8362e1c125e2bd74faefd18ff26a9b06f88792aa))
-* Add cors handling to proxy ([84cec15](https://github.com/ory/oathkeeper/commit/84cec15900a97dec6b92423912ef6d4802121036))
-* Use circle ci build status badge ([b776e05](https://github.com/ory/oathkeeper/commit/b776e05e5a3ad60b1b993b6f8dea1d6f5baef7c6))
-* Use circle ci build status badge ([65c4100](https://github.com/ory/oathkeeper/commit/65c4100eab6a8a09ca96e31b009545a09400b1a8))
-* Switch from glide to golang/dep for vendoring ([ec63fa4](https://github.com/ory/oathkeeper/commit/ec63fa47af310a6936f4afada49700c9ca54b9ad))
-* Resolve tests by replacing nil slice (#7) ([971d020](https://github.com/ory/oathkeeper/commit/971d02082956969c9cd6cfcb5afb257606ddeb6b)), closes [#7](https://github.com/ory/oathkeeper/issues/7)
-
-
+- Remove goveralls from circle build
+  ([8362e1c](https://github.com/ory/oathkeeper/commit/8362e1c125e2bd74faefd18ff26a9b06f88792aa))
+- Add cors handling to proxy
+  ([84cec15](https://github.com/ory/oathkeeper/commit/84cec15900a97dec6b92423912ef6d4802121036))
+- Use circle ci build status badge
+  ([b776e05](https://github.com/ory/oathkeeper/commit/b776e05e5a3ad60b1b993b6f8dea1d6f5baef7c6))
+- Use circle ci build status badge
+  ([65c4100](https://github.com/ory/oathkeeper/commit/65c4100eab6a8a09ca96e31b009545a09400b1a8))
+- Switch from glide to golang/dep for vendoring
+  ([ec63fa4](https://github.com/ory/oathkeeper/commit/ec63fa47af310a6936f4afada49700c9ca54b9ad))
+- Resolve tests by replacing nil slice (#7)
+  ([971d020](https://github.com/ory/oathkeeper/commit/971d02082956969c9cd6cfcb5afb257606ddeb6b)),
+  closes [#7](https://github.com/ory/oathkeeper/issues/7)
 
 ## [0.0.4](https://github.com/ory/oathkeeper/compare/v0.0.3...v0.0.4) (2017-10-21)
 
-
 ### Unclassified
 
-* Return arrays instead of null on rule creation (#6) ([02e88be](https://github.com/ory/oathkeeper/commit/02e88beda5415e51b42e33527af90cf59d6a759e)), closes [#6](https://github.com/ory/oathkeeper/issues/6)
-* Add circleci configuration file (#5) ([76e58f2](https://github.com/ory/oathkeeper/commit/76e58f2033e86c522875faafc77717f31274b4f7)), closes [#5](https://github.com/ory/oathkeeper/issues/5)
-
-
+- Return arrays instead of null on rule creation (#6)
+  ([02e88be](https://github.com/ory/oathkeeper/commit/02e88beda5415e51b42e33527af90cf59d6a759e)),
+  closes [#6](https://github.com/ory/oathkeeper/issues/6)
+- Add circleci configuration file (#5)
+  ([76e58f2](https://github.com/ory/oathkeeper/commit/76e58f2033e86c522875faafc77717f31274b4f7)),
+  closes [#5](https://github.com/ory/oathkeeper/issues/5)
 
 ## [0.0.3](https://github.com/ory/oathkeeper/compare/v0.0.2...v0.0.3) (2017-10-18)
 
-
 ### Unclassified
 
-* Force linefeed for shell scripts ([1e4fc77](https://github.com/ory/oathkeeper/commit/1e4fc771df44b7f67b616bc652d0c280131d59cf))
-* When introspection fails return unauthorized ([f5295b4](https://github.com/ory/oathkeeper/commit/f5295b484fd9430bcb0d5333ca9b395f88812d62))
-
-
+- Force linefeed for shell scripts
+  ([1e4fc77](https://github.com/ory/oathkeeper/commit/1e4fc771df44b7f67b616bc652d0c280131d59cf))
+- When introspection fails return unauthorized
+  ([f5295b4](https://github.com/ory/oathkeeper/commit/f5295b484fd9430bcb0d5333ca9b395f88812d62))
 
 ## [0.0.2](https://github.com/ory/oathkeeper/compare/v0.0.1...v0.0.2) (2017-10-12)
 
-
 ### Unclassified
 
-* Add ability to skip acp checks ([18facbb](https://github.com/ory/oathkeeper/commit/18facbbf42baa34aa8740c2952789d1f608cfb90))
-* Remove unnecessary scope hydra.warden.* ([2214498](https://github.com/ory/oathkeeper/commit/2214498c477b8cfb739c0326437d684b291d16eb))
-
-
+- Add ability to skip acp checks
+  ([18facbb](https://github.com/ory/oathkeeper/commit/18facbbf42baa34aa8740c2952789d1f608cfb90))
+- Remove unnecessary scope hydra.warden.\*
+  ([2214498](https://github.com/ory/oathkeeper/commit/2214498c477b8cfb739c0326437d684b291d16eb))
 
 ## [0.0.1](https://github.com/ory/oathkeeper/compare/072f5e4321ac3a143544cf70da337f0734a86483...v0.0.1) (2017-10-10)
 
-
 ### Documentation
 
-* Update readme ([c11056a](https://github.com/ory/oathkeeper/commit/c11056a0714275f21543f2a9a7361e5223c590e8))
-
+- Update readme
+  ([c11056a](https://github.com/ory/oathkeeper/commit/c11056a0714275f21543f2a9a7361e5223c590e8))
 
 ### Unclassified
 
-* Add goveralls report submission ([#2](https://github.com/ory/oathkeeper/issues/2)) ([13f9f81](https://github.com/ory/oathkeeper/commit/13f9f81becb7efb0dba32c8ca4d6df7e98ba7191))
-* Initial commit ([bff82ab](https://github.com/ory/oathkeeper/commit/bff82ab818f993ea091257c261140f4fb0d51038))
-* Initial commit ([072f5e4](https://github.com/ory/oathkeeper/commit/072f5e4321ac3a143544cf70da337f0734a86483))
-
-
-
+- Add goveralls report submission
+  ([#2](https://github.com/ory/oathkeeper/issues/2))
+  ([13f9f81](https://github.com/ory/oathkeeper/commit/13f9f81becb7efb0dba32c8ca4d6df7e98ba7191))
+- Initial commit
+  ([bff82ab](https://github.com/ory/oathkeeper/commit/bff82ab818f993ea091257c261140f4fb0d51038))
+- Initial commit
+  ([072f5e4](https://github.com/ory/oathkeeper/commit/072f5e4321ac3a143544cf70da337f0734a86483))


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/c704df8ef4892cb97ccfe968c2300280ed58c055.