### PR TITLE
fix: log credentials verifier error details

### DIFF
--- a/pipeline/authn/authenticator_jwt.go
+++ b/pipeline/authn/authenticator_jwt.go
@@ -97,7 +97,7 @@ func (a *AuthenticatorJWT) Authenticate(r *http.Request, session *Authentication
 	})
 	if err != nil {
 		de := herodot.ToDefaultError(err, "")
-		r := fmt.Sprintf("[%+v]", de)
+		r := fmt.Sprintf("%+v", de)
 		return a.tryEnrichResultErr(token, helper.ErrUnauthorized.WithReason(r).WithTrace(err))
 	}
 

--- a/pipeline/authn/authenticator_jwt.go
+++ b/pipeline/authn/authenticator_jwt.go
@@ -2,6 +2,7 @@ package authn
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/form3tech-oss/jwt-go"
@@ -95,7 +96,9 @@ func (a *AuthenticatorJWT) Authenticate(r *http.Request, session *Authentication
 		ScopeStrategy: a.c.ToScopeStrategy(cf.ScopeStrategy, "authenticators.jwt.Config.scope_strategy"),
 	})
 	if err != nil {
-		return a.tryEnrichResultErr(token, helper.ErrUnauthorized.WithReason(err.Error()).WithTrace(err))
+		de := herodot.ToDefaultError(err, "")
+		r := fmt.Sprintf("[%+v]", de)
+		return a.tryEnrichResultErr(token, helper.ErrUnauthorized.WithReason(r).WithTrace(err))
 	}
 
 	claims, ok := pt.Claims.(jwt.MapClaims)


### PR DESCRIPTION
https://github.com/ory/oathkeeper/issues/467
@aeneasr 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Log error details reported by CredentialsVerifier instead of discarding them.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

Below is an example output with this change applied. Please review the format of the 'missing kid header' error.

```
INFO[2021-05-03T00:35:08Z]/root/go/pkg/mod/github.com/ory/x@v0.0.163/reqlog/middleware.go:139 github.com/ory/x/reqlog.(*Middleware).ServeHTTP() completed handling request                    http_request=map[headers:map[accept:*/* x-forwarded-for:192.168.0.24,10.1.131.132 x-forwarded-proto:https] host:api.websecute.local method:GET path:/api/anon/telemetry/8df166db-06f1-4cea-a1b2-6ad2cedece3d/view-count query:<nil> remote:127.0.0.1:35970 scheme:http] http_response=map[status:200 text_status:OK took:164.476µs]
INFO[2021-05-03T00:38:51Z]/root/go/pkg/mod/github.com/ory/x@v0.0.163/reqlog/middleware.go:131 github.com/ory/x/reqlog.(*Middleware).ServeHTTP() started handling request                      http_request=map[headers:map[accept:*/* authorization:Bearer [censored] x-forwarded-for:192.168.0.24,10.1.131.132 x-forwarded-proto:https] host:api.websecute.local method:POST path:/decisions/api/user/articles query:<nil> remote:127.0.0.1:39636 scheme:http]
INFO[2021-05-03T00:38:51Z]/oathkeeper/gz/oathkeeper/proxy/request_handler.go:227 github.com/ory/oathkeeper/proxy.(*RequestHandler).HandleRequest() Access credentials are invalid                audience=application service_name=ORY Oathkeeper service_version=master
INFO[2021-05-03T00:38:51Z]/oathkeeper/gz/oathkeeper/api/decision.go:114 github.com/ory/oathkeeper/api.(*DecisionHandler).decisions() Access request denied                         audience=application error=map[debug: details:map[jwt_claims:{"amr":["pwd"],"aud":["api1"],"auth_time":1592982259,"client_id":"js","exp":"1620005931","idp":"local","iss":"https://websecute.local","nbf":1493002040,"scope":["openid","profile","api1"],"sub":"727f3ab0-a85e-4620-9a39-c3e0dad3acb4"}] message:Access credentials are invalid reason:[rid=
error=An internal server error occurred, please contact the system administrator
reason=The JSON Web Token must contain a kid header value but did not.
details=map[]
debug=

github.com/ory/oathkeeper/credentials.(*VerifierDefault).Verify.func1
        /oathkeeper/gz/oathkeeper/credentials/verifier_default.go:45
github.com/form3tech-oss/jwt-go.(*Parser).ParseWithClaims
        /root/go/pkg/mod/github.com/form3tech-oss/jwt-go@v3.2.2+incompatible/parser.go:51
github.com/form3tech-oss/jwt-go.ParseWithClaims
        /root/go/pkg/mod/github.com/form3tech-oss/jwt-go@v3.2.2+incompatible/token.go:93
github.com/ory/oathkeeper/credentials.(*VerifierDefault).Verify
        /oathkeeper/gz/oathkeeper/credentials/verifier_default.go:38
github.com/ory/oathkeeper/pipeline/authn.(*AuthenticatorJWT).Authenticate
        /oathkeeper/gz/oathkeeper/pipeline/authn/authenticator_jwt.go:90
github.com/ory/oathkeeper/proxy.(*RequestHandler).HandleRequest
        /oathkeeper/gz/oathkeeper/proxy/request_handler.go:216
github.com/ory/oathkeeper/api.(*DecisionHandler).decisions
        /oathkeeper/gz/oathkeeper/api/decision.go:109
github.com/ory/oathkeeper/api.(*DecisionHandler).ServeHTTP
        /oathkeeper/gz/oathkeeper/api/decision.go:63
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/x/reqlog.(*Middleware).ServeHTTP
        /root/go/pkg/mod/github.com/ory/x@v0.0.163/reqlog/middleware.go:134
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/oathkeeper/metrics.(*Middleware).ServeHTTP
        /oathkeeper/gz/oathkeeper/metrics/middleware.go:88
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/x/metricsx.(*Service).ServeHTTP
        /root/go/pkg/mod/github.com/ory/x@v0.0.163/metricsx/middleware.go:261
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/urfave/negroni.(*Negroni).ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:96
net/http.serverHandler.ServeHTTP
        /nix/store/28w6zm2qkxhlbhv1s1ixn434vsnx5qps-go-1.15.5/share/go/src/net/http/server.go:2843
net/http.(*conn).serve
        /nix/store/28w6zm2qkxhlbhv1s1ixn434vsnx5qps-go-1.15.5/share/go/src/net/http/server.go:1925
runtime.goexit
        /nix/store/28w6zm2qkxhlbhv1s1ixn434vsnx5qps-go-1.15.5/share/go/src/runtime/asm_amd64.s:1374] status:Unauthorized status_code:401 trace:
github.com/ory/herodot.(*DefaultError).WithTrace
        /root/go/pkg/mod/github.com/ory/herodot@v0.8.4/error_default.go:52
github.com/ory/oathkeeper/pipeline/authn.(*AuthenticatorJWT).Authenticate
        /oathkeeper/gz/oathkeeper/pipeline/authn/authenticator_jwt.go:101
github.com/ory/oathkeeper/proxy.(*RequestHandler).HandleRequest
        /oathkeeper/gz/oathkeeper/proxy/request_handler.go:216
github.com/ory/oathkeeper/api.(*DecisionHandler).decisions
        /oathkeeper/gz/oathkeeper/api/decision.go:109
github.com/ory/oathkeeper/api.(*DecisionHandler).ServeHTTP
        /oathkeeper/gz/oathkeeper/api/decision.go:63
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/x/reqlog.(*Middleware).ServeHTTP
        /root/go/pkg/mod/github.com/ory/x@v0.0.163/reqlog/middleware.go:134
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/oathkeeper/metrics.(*Middleware).ServeHTTP
        /oathkeeper/gz/oathkeeper/metrics/middleware.go:88
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/x/metricsx.(*Service).ServeHTTP
        /root/go/pkg/mod/github.com/ory/x@v0.0.163/metricsx/middleware.go:261
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/urfave/negroni.(*Negroni).ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:96
net/http.serverHandler.ServeHTTP
        /nix/store/28w6zm2qkxhlbhv1s1ixn434vsnx5qps-go-1.15.5/share/go/src/net/http/server.go:2843
net/http.(*conn).serve
        /nix/store/28w6zm2qkxhlbhv1s1ixn434vsnx5qps-go-1.15.5/share/go/src/net/http/server.go:1925
runtime.goexit
        /nix/store/28w6zm2qkxhlbhv1s1ixn434vsnx5qps-go-1.15.5/share/go/src/runtime/asm_amd64.s:1374] granted=false http_host=api.websecute.local http_method=POST http_url=https://api.websecute.local/api/user/articles http_user_agent= service_name=ORY Oathkeeper service_version=master
ERRO[2021-05-03T00:38:51Z]/root/go/pkg/mod/github.com/ory/herodot@v0.8.4/error_reporter.go:30 github.com/ory/herodot.DefaultErrorReporter.func1() An error occurred while handling a request    code=401 debug= details=map[jwt_claims:{"amr":["pwd"],"aud":["api1"],"auth_time":1592982259,"client_id":"js","exp":"1620005931","idp":"local","iss":"https://websecute.local","nbf":1493002040,"scope":["openid","profile","api1"],"sub":"727f3ab0-a85e-4620-9a39-c3e0dad3acb4"}] error=Access credentials are invalid reason=[rid=
error=An internal server error occurred, please contact the system administrator
reason=The JSON Web Token must contain a kid header value but did not.
details=map[]
debug=

github.com/ory/oathkeeper/credentials.(*VerifierDefault).Verify.func1
        /oathkeeper/gz/oathkeeper/credentials/verifier_default.go:45
github.com/form3tech-oss/jwt-go.(*Parser).ParseWithClaims
        /root/go/pkg/mod/github.com/form3tech-oss/jwt-go@v3.2.2+incompatible/parser.go:51
github.com/form3tech-oss/jwt-go.ParseWithClaims
        /root/go/pkg/mod/github.com/form3tech-oss/jwt-go@v3.2.2+incompatible/token.go:93
github.com/ory/oathkeeper/credentials.(*VerifierDefault).Verify
        /oathkeeper/gz/oathkeeper/credentials/verifier_default.go:38
github.com/ory/oathkeeper/pipeline/authn.(*AuthenticatorJWT).Authenticate
        /oathkeeper/gz/oathkeeper/pipeline/authn/authenticator_jwt.go:90
github.com/ory/oathkeeper/proxy.(*RequestHandler).HandleRequest
        /oathkeeper/gz/oathkeeper/proxy/request_handler.go:216
github.com/ory/oathkeeper/api.(*DecisionHandler).decisions
        /oathkeeper/gz/oathkeeper/api/decision.go:109
github.com/ory/oathkeeper/api.(*DecisionHandler).ServeHTTP
        /oathkeeper/gz/oathkeeper/api/decision.go:63
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/x/reqlog.(*Middleware).ServeHTTP
        /root/go/pkg/mod/github.com/ory/x@v0.0.163/reqlog/middleware.go:134
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/oathkeeper/metrics.(*Middleware).ServeHTTP
        /oathkeeper/gz/oathkeeper/metrics/middleware.go:88
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/x/metricsx.(*Service).ServeHTTP
        /root/go/pkg/mod/github.com/ory/x@v0.0.163/metricsx/middleware.go:261
github.com/urfave/negroni.middleware.ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/urfave/negroni.(*Negroni).ServeHTTP
        /root/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:96
net/http.serverHandler.ServeHTTP
        /nix/store/28w6zm2qkxhlbhv1s1ixn434vsnx5qps-go-1.15.5/share/go/src/net/http/server.go:2843
net/http.(*conn).serve
        /nix/store/28w6zm2qkxhlbhv1s1ixn434vsnx5qps-go-1.15.5/share/go/src/net/http/server.go:1925
runtime.goexit
        /nix/store/28w6zm2qkxhlbhv1s1ixn434vsnx5qps-go-1.15.5/share/go/src/runtime/asm_amd64.s:1374] request-id= status=401 writer=JSON
INFO[2021-05-03T00:38:51Z]/root/go/pkg/mod/github.com/ory/x@v0.0.163/reqlog/middleware.go:139 github.com/ory/x/reqlog.(*Middleware).ServeHTTP() completed handling request                    http_request=map[headers:map[accept:*/* authorization:Bearer [censored] x-forwarded-for:192.168.0.24,10.1.131.132 x-forwarded-proto:https] host:api.websecute.local method:POST path:/api/user/articles query:<nil> remote:127.0.0.1:39636 scheme:http] http_response=map[status:401 text_status:Unauthorized took:742.407µs]
INFO[2021-05-03T00:39:06Z]/root/go/pkg/mod/github.com/ory/x@v0.0.163/reqlog/middleware.go:131 github.com/ory/x/reqlog.(*Middleware).ServeHTTP() started handling request                      http_request=map[headers:map[accept:*/* authorization:Bearer [censored] x-forwarded-for:192.168.0.24,10.1.131.132 x-forwarded-proto:https] host:api.websecute.local method:POST path:/decisions/api/user/articles query:<nil> remote:127.0.0.1:39864 scheme:http]
INFO[2021-05-03T00:39:06Z]/oathkeeper/gz/oathkeeper/api/decision.go:123 github.com/ory/oathkeeper/api.(*DecisionHandler).decisions() Access request granted                        audience=application granted=true http_host=api.websecute.local http_method=POST http_url=https://api.websecute.local/api/user/articles http_user_agent= service_name=ORY Oathkeeper service_version=master
INFO[2021-05-03T00:39:06Z]/root/go/pkg/mod/github.com/ory/x@v0.0.163/reqlog/middleware.go:139 github.com/ory/x/reqlog.(*Middleware).ServeHTTP() completed handling request                    http_request=map[headers:map[accept:*/* authorization:Bearer [censored] x-forwarded-for:192.168.0.24,10.1.131.132 x-forwarded-proto:https] host:api.websecute.local method:POST path:/api/user/articles query:<nil> remote:127.0.0.1:39864 scheme:http] http_response=map[status:200 text_status:OK took:2.110661ms]
```


<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
