### PR TITLE
feat: Ability to Configure Remote Authorizers to set Headers in AuthenticationSession

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -929,6 +929,17 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "allowed_remote_headers": {
+          "description": "A list of non simple headers the remote is allowed to return to mutate requests.",
+          "title": "Allowed Remote HTTP Headers for his Responses",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minLength": 0,
+          "uniqueItems": true,
+          "default": []
         }
       },
       "required": [
@@ -957,6 +968,17 @@
           "examples": [
             "{\"subject\":\"{{ .Subject }}\"}"
           ]
+        },
+        "allowed_remote_headers": {
+          "description": "A list of non simple headers the remote is allowed to return to mutate requests.",
+          "title": "Allowed Remote HTTP Headers for his Responses",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minLength": 0,
+          "uniqueItems": true,
+          "default": []
         }
       },
       "required": [

--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -930,7 +930,7 @@
             "type": "string"
           }
         },
-        "allowed_remote_headers": {
+        "forward_response_headers_to_upstream": {
           "description": "A list of non simple headers the remote is allowed to return to mutate requests.",
           "title": "Allowed Remote HTTP Headers for his Responses",
           "type": "array",
@@ -969,7 +969,7 @@
             "{\"subject\":\"{{ .Subject }}\"}"
           ]
         },
-        "allowed_remote_headers": {
+        "forward_response_headers_to_upstream": {
           "description": "A list of non simple headers the remote is allowed to return to mutate requests.",
           "title": "Allowed Remote HTTP Headers for his Responses",
           "type": "array",

--- a/.schemas/authorizers.remote_json.schema.json
+++ b/.schemas/authorizers.remote_json.schema.json
@@ -30,7 +30,7 @@
       },
       "description": "A list of non simple headers the remote is allowed to return to mutate requests.",
       "examples": [
-        "X-Branch-Id"
+        "X-Foo"
       ]
     }
   },

--- a/.schemas/authorizers.remote_json.schema.json
+++ b/.schemas/authorizers.remote_json.schema.json
@@ -22,7 +22,7 @@
         "{\"subject\":\"{{ .Subject }}\"}"
       ]
     },
-    "allowed_remote_headers": {
+        "forward_response_headers_to_upstream": {
       "title": "Allowed Remote HTTP Headers for his Responses",
       "type": "array",
       "items": {

--- a/.schemas/authorizers.remote_json.schema.json
+++ b/.schemas/authorizers.remote_json.schema.json
@@ -21,6 +21,17 @@
       "examples": [
         "{\"subject\":\"{{ .Subject }}\"}"
       ]
+    },
+    "allowed_remote_headers": {
+      "title": "Allowed Remote HTTP Headers for his Responses",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "A list of non simple headers the remote is allowed to return to mutate requests.",
+      "examples": [
+        "X-Branch-Id"
+      ]
     }
   },
   "required": [

--- a/docs/docs/pipeline/authz.md
+++ b/docs/docs/pipeline/authz.md
@@ -348,7 +348,7 @@ authorizers:
       "headers": {
         "X-Subject": "{{ print .Subject }}"
       },
-      "allowed_remote_headers": [
+      "forward_response_headers_to_upstream": [
         "X-Branch-Id"
       ]
     }
@@ -379,7 +379,7 @@ Forbidden" response code, the access is denied.
   to an
   [`AuthenticationSession`](https://github.com/ory/oathkeeper/blob/master/pipeline/authn/authenticator.go#L40)
   object. See [Session](../pipeline.md#session) for more details.
-- `allowed_remote_headers` (slice of strings, optional) - The HTTP headers that
+- `forward_response_headers_to_upstream` (slice of strings, optional) - The HTTP headers that
   will be allowed from remote authorizer responses. If returned, headers on this list
   will be forward to upstream services.
 
@@ -441,9 +441,9 @@ authorizers:
       "remote": "http://my-remote-authorizer/authorize",
       "payload": "{\"subject\": \"{{ print .Subject }}\", \"resource\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 0 }}\"}"
     },
-    "allowed_remote_headers": {
+    "forward_response_headers_to_upstream": [
       "X-Branch-Id"
-    }
+    ]
   }
   "mutators": [
     {

--- a/docs/docs/pipeline/authz.md
+++ b/docs/docs/pipeline/authz.md
@@ -292,7 +292,7 @@ if it returns a "403 Forbidden" response code, the access is denied.
   to an
   [`AuthenticationSession`](https://github.com/ory/oathkeeper/blob/master/pipeline/authn/authenticator.go#L40)
   object. See [Session](../pipeline.md#session) for more details.
-- `allowed_remote_headers` (slice of strings, optional) - The HTTP headers that 
+- `forward_response_headers_to_upstream` (slice of strings, optional) - The HTTP headers that 
   will be allowed from remote authorizer responses. If returned, headers on this list 
   will be forward to upstream services.
 
@@ -348,9 +348,9 @@ authorizers:
       "headers": {
         "X-Subject": "{{ print .Subject }}"
       },
-      "allowed_remote_headers": {
+      "allowed_remote_headers": [
         "X-Branch-Id"
-      }
+      ]
     }
   }
   "mutators": [

--- a/docs/docs/pipeline/authz.md
+++ b/docs/docs/pipeline/authz.md
@@ -292,6 +292,9 @@ if it returns a "403 Forbidden" response code, the access is denied.
   to an
   [`AuthenticationSession`](https://github.com/ory/oathkeeper/blob/master/pipeline/authn/authenticator.go#L40)
   object. See [Session](../pipeline.md#session) for more details.
+- `allowed_remote_headers` (slice of strings, optional) - The HTTP headers that 
+  will be allowed from remote authorizer responses. If returned, headers on this list 
+  will be forward to upstream services.
 
 #### Example
 
@@ -344,6 +347,9 @@ authorizers:
       "remote": "http://my-remote-authorizer/authorize",
       "headers": {
         "X-Subject": "{{ print .Subject }}"
+      },
+      "allowed_remote_headers": {
+        "X-Branch-Id"
       }
     }
   }
@@ -373,6 +379,10 @@ Forbidden" response code, the access is denied.
   to an
   [`AuthenticationSession`](https://github.com/ory/oathkeeper/blob/master/pipeline/authn/authenticator.go#L40)
   object. See [Session](../pipeline.md#session) for more details.
+- `allowed_remote_headers` (slice of strings, optional) - The HTTP headers that
+  will be allowed from remote authorizer responses. If returned, headers on this list
+  will be forward to upstream services.
+
 
 #### Example
 
@@ -430,6 +440,9 @@ authorizers:
     "config": {
       "remote": "http://my-remote-authorizer/authorize",
       "payload": "{\"subject\": \"{{ print .Subject }}\", \"resource\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 0 }}\"}"
+    },
+    "allowed_remote_headers": {
+      "X-Branch-Id"
     }
   }
   "mutators": [

--- a/docs/docs/pipeline/authz.md
+++ b/docs/docs/pipeline/authz.md
@@ -349,7 +349,7 @@ authorizers:
         "X-Subject": "{{ print .Subject }}"
       },
       "forward_response_headers_to_upstream": [
-        "X-Branch-Id"
+        "X-Foo"
       ]
     }
   }
@@ -442,7 +442,7 @@ authorizers:
       "payload": "{\"subject\": \"{{ print .Subject }}\", \"resource\": \"{{ printIndex .MatchContext.RegexpCaptureGroups 0 }}\"}"
     },
     "forward_response_headers_to_upstream": [
-      "X-Branch-Id"
+      "X-Foo"
     ]
   }
   "mutators": [

--- a/internal/config/.oathkeeper.yaml
+++ b/internal/config/.oathkeeper.yaml
@@ -265,7 +265,7 @@ authorizers:
       remote: https://host/path
       headers: {}
       forward_response_headers_to_upstream:
-        - x-foo-bar
+        - x-foo
 
   # Configures the remote_json authorizer
   remote_json:
@@ -276,7 +276,7 @@ authorizers:
       remote: https://host/path
       payload: "{}"
       forward_response_headers_to_upstream:
-        - x-foo-bar
+        - x-foo
 
 # All mutators can be configured under this configuration key
 mutators:

--- a/internal/config/.oathkeeper.yaml
+++ b/internal/config/.oathkeeper.yaml
@@ -264,6 +264,8 @@ authorizers:
     config:
       remote: https://host/path
       headers: {}
+      allowed_remote_headers:
+        - x-foo-bar
 
   # Configures the remote_json authorizer
   remote_json:
@@ -273,6 +275,8 @@ authorizers:
     config:
       remote: https://host/path
       payload: "{}"
+      allowed_remote_headers:
+        - x-foo-bar
 
 # All mutators can be configured under this configuration key
 mutators:

--- a/internal/config/.oathkeeper.yaml
+++ b/internal/config/.oathkeeper.yaml
@@ -264,7 +264,7 @@ authorizers:
     config:
       remote: https://host/path
       headers: {}
-      allowed_remote_headers:
+      forward_response_headers_to_upstream:
         - x-foo-bar
 
   # Configures the remote_json authorizer
@@ -275,7 +275,7 @@ authorizers:
     config:
       remote: https://host/path
       payload: "{}"
-      allowed_remote_headers:
+      forward_response_headers_to_upstream:
         - x-foo-bar
 
 # All mutators can be configured under this configuration key

--- a/pipeline/authz/remote.go
+++ b/pipeline/authz/remote.go
@@ -21,8 +21,9 @@ import (
 
 // AuthorizerRemoteConfiguration represents a configuration for the remote authorizer.
 type AuthorizerRemoteConfiguration struct {
-	Remote  string            `json:"remote"`
-	Headers map[string]string `json:"headers"`
+	Remote               string            `json:"remote"`
+	Headers              map[string]string `json:"headers"`
+	AllowedRemoteHeaders []string          `json:"allowed_remote_headers"`
 }
 
 // AuthorizerRemote implements the Authorizer interface.
@@ -106,6 +107,10 @@ func (a *AuthorizerRemote) Authorize(r *http.Request, session *authn.Authenticat
 		return errors.WithStack(helper.ErrForbidden)
 	} else if res.StatusCode != http.StatusOK {
 		return errors.Errorf("expected status code %d but got %d", http.StatusOK, res.StatusCode)
+	}
+
+	for _, allowedHeader := range c.AllowedRemoteHeaders {
+		session.SetHeader(allowedHeader, res.Header.Get(allowedHeader))
 	}
 
 	return nil

--- a/pipeline/authz/remote.go
+++ b/pipeline/authz/remote.go
@@ -21,9 +21,9 @@ import (
 
 // AuthorizerRemoteConfiguration represents a configuration for the remote authorizer.
 type AuthorizerRemoteConfiguration struct {
-	Remote               string            `json:"remote"`
-	Headers              map[string]string `json:"headers"`
-	AllowedRemoteHeaders []string          `json:"allowed_remote_headers"`
+	Remote                           string            `json:"remote"`
+	Headers                          map[string]string `json:"headers"`
+	ForwardResponseHeadersToUpstream []string          `json:"forward_response_headers_to_upstream"`
 }
 
 // AuthorizerRemote implements the Authorizer interface.
@@ -109,7 +109,7 @@ func (a *AuthorizerRemote) Authorize(r *http.Request, session *authn.Authenticat
 		return errors.Errorf("expected status code %d but got %d", http.StatusOK, res.StatusCode)
 	}
 
-	for _, allowedHeader := range c.AllowedRemoteHeaders {
+	for _, allowedHeader := range c.ForwardResponseHeadersToUpstream {
 		session.SetHeader(allowedHeader, res.Header.Get(allowedHeader))
 	}
 

--- a/pipeline/authz/remote_json.go
+++ b/pipeline/authz/remote_json.go
@@ -21,9 +21,9 @@ import (
 
 // AuthorizerRemoteJSONConfiguration represents a configuration for the remote_json authorizer.
 type AuthorizerRemoteJSONConfiguration struct {
-	Remote               string   `json:"remote"`
-	Payload              string   `json:"payload"`
-	AllowedRemoteHeaders []string `json:"allowed_remote_headers"`
+	Remote                           string   `json:"remote"`
+	Payload                          string   `json:"payload"`
+	ForwardResponseHeadersToUpstream []string `json:"forward_response_headers_to_upstream"`
 }
 
 // PayloadTemplateID returns a string with which to associate the payload template.
@@ -102,7 +102,7 @@ func (a *AuthorizerRemoteJSON) Authorize(r *http.Request, session *authn.Authent
 		return errors.Errorf("expected status code %d but got %d", http.StatusOK, res.StatusCode)
 	}
 
-	for _, allowedHeader := range c.AllowedRemoteHeaders {
+	for _, allowedHeader := range c.ForwardResponseHeadersToUpstream {
 		session.SetHeader(allowedHeader, res.Header.Get(allowedHeader))
 	}
 

--- a/pipeline/authz/remote_json.go
+++ b/pipeline/authz/remote_json.go
@@ -21,8 +21,9 @@ import (
 
 // AuthorizerRemoteJSONConfiguration represents a configuration for the remote_json authorizer.
 type AuthorizerRemoteJSONConfiguration struct {
-	Remote  string `json:"remote"`
-	Payload string `json:"payload"`
+	Remote               string   `json:"remote"`
+	Payload              string   `json:"payload"`
+	AllowedRemoteHeaders []string `json:"allowed_remote_headers"`
 }
 
 // PayloadTemplateID returns a string with which to associate the payload template.
@@ -99,6 +100,10 @@ func (a *AuthorizerRemoteJSON) Authorize(r *http.Request, session *authn.Authent
 		return errors.WithStack(helper.ErrForbidden)
 	} else if res.StatusCode != http.StatusOK {
 		return errors.Errorf("expected status code %d but got %d", http.StatusOK, res.StatusCode)
+	}
+
+	for _, allowedHeader := range c.AllowedRemoteHeaders {
+		session.SetHeader(allowedHeader, res.Header.Get(allowedHeader))
 	}
 
 	return nil

--- a/pipeline/authz/remote_json_test.go
+++ b/pipeline/authz/remote_json_test.go
@@ -121,7 +121,7 @@ func TestAuthorizerRemoteJSONAuthorize(t *testing.T) {
 			},
 			session:            new(authn.AuthenticationSession),
 			sessionHeaderMatch: &http.Header{"X-Foo": []string{""}},
-			config:             json.RawMessage(`{"allowed_remote_headers":["X-Foo"]}`),
+			config:             json.RawMessage(`{"payload":"{}","allowed_remote_headers":["X-Foo"]}`),
 		},
 		{
 			name: "authentication session",

--- a/pipeline/authz/remote_json_test.go
+++ b/pipeline/authz/remote_json_test.go
@@ -109,7 +109,7 @@ func TestAuthorizerRemoteJSONAuthorize(t *testing.T) {
 			},
 			session:            new(authn.AuthenticationSession),
 			sessionHeaderMatch: &http.Header{"X-Foo": []string{"bar"}},
-			config:             json.RawMessage(`{"payload":"{}","allowed_remote_headers":["X-Foo"]}`),
+			config:             json.RawMessage(`{"payload":"{}","forward_response_headers_to_upstream":["X-Foo"]}`),
 		},
 		{
 			name: "ok with not allowed headers",
@@ -121,7 +121,7 @@ func TestAuthorizerRemoteJSONAuthorize(t *testing.T) {
 			},
 			session:            new(authn.AuthenticationSession),
 			sessionHeaderMatch: &http.Header{"X-Foo": []string{""}},
-			config:             json.RawMessage(`{"payload":"{}","allowed_remote_headers":["X-Foo"]}`),
+			config:             json.RawMessage(`{"payload":"{}","forward_response_headers_to_upstream":["X-Foo"]}`),
 		},
 		{
 			name: "authentication session",

--- a/pipeline/authz/remote_test.go
+++ b/pipeline/authz/remote_test.go
@@ -24,12 +24,13 @@ import (
 
 func TestAuthorizerRemoteAuthorize(t *testing.T) {
 	tests := []struct {
-		name    string
-		setup   func(t *testing.T) *httptest.Server
-		session *authn.AuthenticationSession
-		body    string
-		config  json.RawMessage
-		wantErr bool
+		name               string
+		setup              func(t *testing.T) *httptest.Server
+		session            *authn.AuthenticationSession
+		sessionHeaderMatch *http.Header
+		body               string
+		config             json.RawMessage
+		wantErr            bool
 	}{
 		{
 			name:    "invalid configuration",
@@ -116,6 +117,30 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 			config: json.RawMessage(`{}`),
 		},
 		{
+			name: "ok with allowed headers",
+			setup: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("X-Foo", "bar")
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			session:            new(authn.AuthenticationSession),
+			sessionHeaderMatch: &http.Header{"X-Foo": []string{"bar"}},
+			config:             json.RawMessage(`{"allowed_remote_headers":["X-Foo"]}`),
+		},
+		{
+			name: "ok with not allowed headers",
+			setup: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("X-Bar", "foo")
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			session:            new(authn.AuthenticationSession),
+			sessionHeaderMatch: &http.Header{"X-Foo": []string{""}},
+			config:             json.RawMessage(`{"allowed_remote_headers":["X-Foo"]}`),
+		},
+		{
 			name: "authentication session",
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -155,6 +180,10 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 			}
 			if err := a.Authorize(r, tt.session, tt.config, &rule.Rule{}); (err != nil) != tt.wantErr {
 				t.Errorf("Authorize() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.sessionHeaderMatch != nil {
+				assert.Equal(t, tt.sessionHeaderMatch, &tt.session.Header)
 			}
 		})
 	}

--- a/pipeline/authz/remote_test.go
+++ b/pipeline/authz/remote_test.go
@@ -126,7 +126,7 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 			},
 			session:            new(authn.AuthenticationSession),
 			sessionHeaderMatch: &http.Header{"X-Foo": []string{"bar"}},
-			config:             json.RawMessage(`{"allowed_remote_headers":["X-Foo"]}`),
+			config:             json.RawMessage(`{"forward_response_headers_to_upstream":["X-Foo"]}`),
 		},
 		{
 			name: "ok with not allowed headers",
@@ -138,7 +138,7 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 			},
 			session:            new(authn.AuthenticationSession),
 			sessionHeaderMatch: &http.Header{"X-Foo": []string{""}},
-			config:             json.RawMessage(`{"allowed_remote_headers":["X-Foo"]}`),
+			config:             json.RawMessage(`{"forward_response_headers_to_upstream":["X-Foo"]}`),
 		},
 		{
 			name: "authentication session",


### PR DESCRIPTION
## Related issue

## Proposed changes

The remote authorizers may have useful context from user's permissions. So with this changes, custom authorizers using `remote` and `remote_json` can return some useful headers to be forward into the AuthenticationSession, meaning that these headers will be passed to upstream services. 

For example, an user containing scopes/branches inside an organization profile has some level of data addressed to him. In this case, the upstream service need to know that, and "filter" the data according to his "branch_id". The permission that is given to the user (and the remote authorizers manages) has a record of the "branch_id", for the following responses will be returned as status code 200 (if granted) and containing a header like `X-Branch-Id`. 

The upstream service receives the `X-Branch-Id` and does your thing.

**The configuration requires to configure a list of "allowed headers" returning from remote authorizer, that will be accepted in the pipeline.**

---

Without this, we have to perform another request using the mutator `Hydrador` to retrieve the users' "branch_id", that is not a good performance approach in my vision for this set. 

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments
