### PR TITLE
fix: Initialize Header for AuthenticationSession

### DIFF
--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -337,6 +337,7 @@ func (d *RequestHandler) InitializeAuthnSession(r *http.Request, rl *rule.Rule) 
 
 	session := &authn.AuthenticationSession{
 		Subject: "",
+		Header: r.Header,
 	}
 
 	values, err := rl.ExtractRegexGroups(d.c.AccessRuleMatchingStrategy(), r.URL)

--- a/proxy/request_handler_test.go
+++ b/proxy/request_handler_test.go
@@ -44,7 +44,12 @@ import (
 )
 
 func newTestRequest(u string) *http.Request {
-	return &http.Request{URL: x.ParseURLOrPanic(u), Method: "GET"}
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		//do something
+	}
+	req.Header.Add("Test-Header", "Test-Value")
+	return req
 }
 
 func TestHandleError(t *testing.T) {
@@ -549,6 +554,7 @@ func TestInitializeSession(t *testing.T) {
 			session := reg.ProxyRequestHandler().InitializeAuthnSession(tc.r, &rule)
 
 			assert.NotNil(t, session)
+			assert.NotNil(t, session.Header)
 			assert.EqualValues(t, tc.expectContext, session.MatchContext)
 		})
 	}


### PR DESCRIPTION
## Related issue

https://github.com/ory/oathkeeper/issues/512

## Proposed changes

After wasting a lot of time on why I'm not able to use Headers within the Remote Authorizer, I found out that Oathkeeper isn't setting the Headers while initializing the AuthenticationSession. We use Remote Authorizer and pass on some key information through headers only & without this fix we can't use Oathkeeper at all. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
