### PR TITLE
fix: intro preauth client once

### DIFF
--- a/driver/configuration/provider_viper_public_test.go
+++ b/driver/configuration/provider_viper_public_test.go
@@ -300,7 +300,7 @@ func TestViperProvider(t *testing.T) {
 			assert.True(t, p.AuthenticatorIsEnabled(a.GetID()))
 			require.NoError(t, a.Validate(nil))
 
-			config, err := a.Config(nil)
+			config, _, err := a.Config(nil)
 			require.NoError(t, err)
 			assert.Equal(t, "https://my-website.com/oauth2/introspection", config.IntrospectionURL)
 			assert.Equal(t, "exact", config.ScopeStrategy)
@@ -433,7 +433,7 @@ func TestAuthenticatorOAuth2TokenIntrospectionPreAuthorization(t *testing.T) {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
 			a := authn.NewAuthenticatorOAuth2Introspection(v, logrusx.New("", ""))
 
-			config, err := a.Config(json.RawMessage(fmt.Sprintf(`{
+			config, _, err := a.Config(json.RawMessage(fmt.Sprintf(`{
 	"pre_authorization": {
 		"enabled": %v,
 		"client_id": "%v",

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -265,9 +265,9 @@ func (a *AuthenticatorOAuth2Introspection) Config(config json.RawMessage) (*Auth
 	}
 
 	clientKey := fmt.Sprintf("%x", md5.Sum([]byte(config)))
-	a.mu.Lock()
+	a.mu.RLock()
 	client, ok := a.clientMap[clientKey]
-	a.mu.Unlock()
+	a.mu.RUnlock()
 
 	if !ok {
 		a.logger.Debug("Initializing http client")
@@ -310,7 +310,9 @@ func (a *AuthenticatorOAuth2Introspection) Config(config json.RawMessage) (*Auth
 		}
 
 		client = httpx.NewResilientClientLatencyToleranceConfigurable(rt, timeout, maxWait)
+		a.mu.Lock()
 		a.clientMap[clientKey] = client
+		a.mu.Unlock()
 	}
 
 	if c.Cache.TTL != "" {

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -70,8 +70,7 @@ type AuthenticatorOAuth2Introspection struct {
 }
 
 func NewAuthenticatorOAuth2Introspection(c configuration.Provider, logger *logrusx.Logger) *AuthenticatorOAuth2Introspection {
-	var rt http.RoundTripper
-	return &AuthenticatorOAuth2Introspection{c: c, client: httpx.NewResilientClientLatencyToleranceSmall(rt), logger: logger}
+	return &AuthenticatorOAuth2Introspection{c: c, logger: logger}
 }
 
 func (a *AuthenticatorOAuth2Introspection) GetID() string {
@@ -263,6 +262,7 @@ func (a *AuthenticatorOAuth2Introspection) Config(config json.RawMessage) (*Auth
 	}
 
 	if a.client == nil {
+		a.logger.Debug("Initializing http client")
 		var rt http.RoundTripper
 		if c.PreAuth != nil && c.PreAuth.Enabled {
 			var ep url.Values

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -614,9 +614,9 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		if noPreauthClient == preauthOneClient || noPreauthClient == preauthTwoClient || preauthOneClient == preauthTwoClient {
-			t.FailNow()
-		}
+		require.NotEqual(t, noPreauthClient, preauthOneClient)
+		require.NotEqual(t, noPreauthClient, preauthTwoClient)
+		require.NotEqual(t, preauthOneClient, preauthTwoClient)
 
 		_, preauthOneClient2, err := authenticator.Config(preAuthConfigOne)
 		if err != nil {
@@ -642,9 +642,9 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 			t.FailNow()
 		}
 
-		if noPreauthClient == preauthOneClient || noPreauthClient == preauthTwoClient || preauthOneClient == preauthTwoClient {
-			t.FailNow()
-		}
+		require.NotEqual(t, noPreauthClient, preauthOneClient)
+		require.NotEqual(t, noPreauthClient, preauthTwoClient)
+		require.NotEqual(t, preauthOneClient, preauthTwoClient)
 
 	})
 }

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -555,8 +555,12 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				tc.config, _ = sjson.SetBytes(tc.config, "introspection_url", ts.URL+"/oauth2/introspect")
 				tc.config, _ = sjson.SetBytes(tc.config, "pre_authorization.token_url", ts.URL+"/oauth2/token")
 
+				//reinitialize authenticator so client will be reinitialized in authenticator
+				reg := internal.NewRegistry(conf)
+				a, err := reg.PipelineAuthenticator("oauth2_introspection")
+
 				sess := new(AuthenticationSession)
-				err := a.Authenticate(tc.r, sess, tc.config, nil)
+				err = a.Authenticate(tc.r, sess, tc.config, nil)
 				if tc.expectErr {
 					require.Error(t, err)
 					if tc.expectExactErr != nil {

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ory/oathkeeper/internal"
 	. "github.com/ory/oathkeeper/pipeline/authn"
 	"github.com/ory/viper"
+	"github.com/ory/x/logrusx"
 )
 
 func TestAuthenticatorOAuth2Introspection(t *testing.T) {
@@ -555,10 +556,6 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 				tc.config, _ = sjson.SetBytes(tc.config, "introspection_url", ts.URL+"/oauth2/introspect")
 				tc.config, _ = sjson.SetBytes(tc.config, "pre_authorization.token_url", ts.URL+"/oauth2/token")
 
-				//reinitialize authenticator so client will be reinitialized in authenticator
-				reg := internal.NewRegistry(conf)
-				a, err := reg.PipelineAuthenticator("oauth2_introspection")
-
 				sess := new(AuthenticationSession)
 				err = a.Authenticate(tc.r, sess, tc.config, nil)
 				if tc.expectErr {
@@ -592,5 +589,62 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 		viper.Reset()
 		viper.Set(configuration.ViperKeyAuthenticatorOAuth2TokenIntrospectionIsEnabled, true)
 		require.Error(t, a.Validate(json.RawMessage(`{"introspection_url":"/oauth2/token"}`)))
+	})
+
+	t.Run("method=config", func(t *testing.T) {
+		logger := logrusx.New("test", "1")
+		authenticator := NewAuthenticatorOAuth2Introspection(conf, logger)
+
+		noPreauthConfig := []byte(`{ "introspection_url":"http://localhost/oauth2/token" }`)
+		preAuthConfigOne := []byte(`{ "introspection_url":"http://localhost/oauth2/token","pre_authorization":{"token_url":"http://localhost/oauth2/token","client_id":"some_id","client_secret":"some_secret","enabled":true} }`)
+		preAuthConfigTwo := []byte(`{ "introspection_url":"http://localhost/oauth2/token2","pre_authorization":{"token_url":"http://localhost/oauth2/token2","client_id":"some_id2","client_secret":"some_secret2","enabled":true} }`)
+
+		_, noPreauthClient, err := authenticator.Config(noPreauthConfig)
+		if err != nil {
+			require.NoError(t, err)
+		}
+
+		_, preauthOneClient, err := authenticator.Config(preAuthConfigOne)
+		if err != nil {
+			require.NoError(t, err)
+		}
+
+		_, preauthTwoClient, err := authenticator.Config(preAuthConfigTwo)
+		if err != nil {
+			require.NoError(t, err)
+		}
+
+		if noPreauthClient == preauthOneClient || noPreauthClient == preauthTwoClient || preauthOneClient == preauthTwoClient {
+			t.FailNow()
+		}
+
+		_, preauthOneClient2, err := authenticator.Config(preAuthConfigOne)
+		if err != nil {
+			require.NoError(t, err)
+		}
+		if preauthOneClient2 != preauthOneClient {
+			t.FailNow()
+		}
+
+		_, preauthTwoClient2, err := authenticator.Config(preAuthConfigTwo)
+		if err != nil {
+			require.NoError(t, err)
+		}
+		if preauthTwoClient2 != preauthTwoClient {
+			t.FailNow()
+		}
+
+		_, noPreauthClient2, err := authenticator.Config(noPreauthConfig)
+		if err != nil {
+			require.NoError(t, err)
+		}
+		if noPreauthClient2 != noPreauthClient {
+			t.FailNow()
+		}
+
+		if noPreauthClient == preauthOneClient || noPreauthClient == preauthTwoClient || preauthOneClient == preauthTwoClient {
+			t.FailNow()
+		}
+
 	})
 }


### PR DESCRIPTION
## Related issue

#712 

## Proposed changes

Only initializes oauth client once during config stage per config and doesn't initialize when creating new introspector.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

