### PR TITLE
feat: proxy request allowed headers

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -109,6 +109,25 @@
         }
       }
     },
+    "requests": {
+      "title": "Proxy requests",
+      "description": "Configure proxy request handler using the following options.",
+      "type": "object",
+      "properties": {
+        "allowed_headers": {
+          "description": "A list of non simple headers the client is allowed to use with in receiving requests.",
+          "title": "Allowed Request HTTP Headers",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minLength": 0,
+          "uniqueItems": true,
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
     "cors": {
       "title": "Cross Origin Resource Sharing (CORS)",
       "description": "Configure [Cross Origin Resource Sharing (CORS)](http://www.w3.org/TR/cors/) using the following options.",

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -65,6 +65,25 @@
         }
       }
     },
+    "request": {
+      "title": "Proxy requests",
+      "description": "Configure proxy request handler using the following options.",
+      "type": "object",
+      "properties": {
+        "allowed_client_headers": {
+          "description": "A list of non simple headers the client is allowed to use with in receiving requests.",
+          "title": "Allowed Request HTTP Headers",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minLength": 0,
+          "uniqueItems": true,
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
     "cors": {
       "title": "Cross Origin Resource Sharing (CORS)",
       "description": "Configure [Cross Origin Resource Sharing (CORS)](http://www.w3.org/TR/cors/) using the following options.",

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -1518,6 +1518,24 @@ serve:
       #
       read: 5s
 
+    ## Proxy requests ##
+    #
+    # Configure proxy request handler using the following options.
+    #
+    request:
+      ## Allowed Request HTTP Headers ##
+      #
+      # A list of non simple headers the client is allowed to use with in receiving requests.
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export SERVE_PROXY_REQUEST_ALLOWED_CLIENT_HEADERS=<value>
+      # - Windows Command Line (CMD):
+      #    > set SERVE_PROXY_REQUEST_ALLOWED_CLIENT_HEADERS=<value>
+      #
+      allowed_client_headers:
+        - ''
+        
     ## Cross Origin Resource Sharing (CORS) ##
     #
     # Configure [Cross Origin Resource Sharing (CORS)](http://www.w3.org/TR/cors/) using the following options.

--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -60,6 +60,8 @@ type Provider interface {
 	ParseURLs(sources []string) ([]url.URL, error)
 	JSONWebKeyURLs() []string
 
+	ProxyAllowedClientHeaders() []string
+
 	TracingServiceName() string
 	TracingProvider() string
 	TracingJaegerConfig() *tracing.JaegerConfig

--- a/driver/configuration/provider_viper.go
+++ b/driver/configuration/provider_viper.go
@@ -43,6 +43,7 @@ const (
 	ViperKeyProxyIdleTimeout                    = "serve.proxy.timeout.idle"
 	ViperKeyProxyServeAddressHost               = "serve.proxy.host"
 	ViperKeyProxyServeAddressPort               = "serve.proxy.port"
+	ViperKeyProxyAllowedClientHeaders           = "serve.proxy.request.allowed_client_headers"
 	ViperKeyAPIServeAddressHost                 = "serve.api.host"
 	ViperKeyAPIServeAddressPort                 = "serve.api.port"
 	ViperKeyAPIReadTimeout                      = "serve.api.timeout.read"
@@ -412,6 +413,10 @@ func (v *ViperProvider) MutatorConfig(id string, override json.RawMessage, dest 
 
 func (v *ViperProvider) JSONWebKeyURLs() []string {
 	return viperx.GetStringSlice(v.l, ViperKeyMutatorIDTokenJWKSURL, []string{})
+}
+
+func (v *ViperProvider) ProxyAllowedClientHeaders() []string {
+	return viperx.GetStringSlice(v.l, ViperKeyProxyAllowedClientHeaders, []string{})
 }
 
 func (v *ViperProvider) TracingServiceName() string {

--- a/driver/configuration/provider_viper_public_test.go
+++ b/driver/configuration/provider_viper_public_test.go
@@ -192,6 +192,14 @@ func TestViperProvider(t *testing.T) {
 			assert.Equal(t, true, p.PrometheusCollapseRequestPaths())
 		})
 
+		t.Run("group=requests", func(t *testing.T) {
+			t.Run("case=should pass array values", func(t *testing.T) {
+				assert.Equal(t, []string{
+					"X-B3-Traceid",
+				}, p.ProxyAllowedClientHeaders())
+			})
+		})
+
 		t.Run("group=cors", func(t *testing.T) {
 			assert.True(t, p.CORSEnabled("proxy"))
 			assert.True(t, p.CORSEnabled("api"))

--- a/internal/config/.oathkeeper.yaml
+++ b/internal/config/.oathkeeper.yaml
@@ -17,6 +17,10 @@ serve:
       write: 2s
       idle: 3s
 
+    request:
+      allowed_client_headers:
+        - X-B3-Traceid
+
     cors:
       enabled: true
       allowed_origins:

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -347,11 +347,14 @@ func (d *RequestHandler) InitializeAuthnSession(r *http.Request, rl *rule.Rule) 
 			WithField("reason_id", "capture_groups_error").
 			Warn("Unable to capture the groups for the MatchContext")
 	} else {
+		for _, k := range d.c.ProxyAllowedClientHeaders() {
+			session.Header.Add(k, r.Header.Get(k))
+		}
+
 		session.MatchContext = authn.MatchContext{
 			RegexpCaptureGroups: values,
 			URL:                 r.URL,
 			Method:              r.Method,
-			Header:              r.Header,
 		}
 	}
 

--- a/x/template.go
+++ b/x/template.go
@@ -2,6 +2,7 @@ package x
 
 import (
 	"fmt"
+	"net/http"
 	"reflect"
 	"text/template"
 
@@ -32,6 +33,9 @@ func NewTemplate(id string) *template.Template {
 				}
 
 				return ""
+			},
+			"printHeader": func(header http.Header, key string) string {
+				return header.Get(key)
 			},
 		}).
 		Funcs(sprig.TxtFuncMap())


### PR DESCRIPTION
## Proposed changes

Configure and allow client headers to be used in `AuthenticationSession`.

Inspired by https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto.html#envoy-v3-api-msg-extensions-filters-http-ext-authz-v3-authorizationrequest

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

