### PR TITLE
Oauth2 client credential flow support for hydrator mutator

### DIFF
--- a/.schemas/mutators.hydrator.schema.json
+++ b/.schemas/mutators.hydrator.schema.json
@@ -38,6 +38,67 @@
             }
           }
         },
+        "pre_authorization": {
+          "title": "Pre-Authorization",
+          "description": "Enable pre-authorization in cases where the OAuth 2.0 Token Introspection endpoint is protected by OAuth 2.0 Bearer Tokens that can be retrieved using the OAuth 2.0 Client Credentials grant.",
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "Enabled",
+                  "const": false,
+                  "default": false
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "client_id",
+                "client_secret",
+                "token_url"
+              ],
+              "properties": {
+                "enabled": {
+                  "title": "Enabled",
+                  "const": true,
+                  "default": false
+                },
+                "client_id": {
+                  "type": "string",
+                  "title": "OAuth 2.0 Client ID",
+                  "description": "The OAuth 2.0 Client ID to be used for the OAuth 2.0 Client Credentials Grant.\n\n>If pre-authorization is enabled, this value is required."
+                },
+                "client_secret": {
+                  "type": "string",
+                  "title": "OAuth 2.0 Client Secret",
+                  "description": "The OAuth 2.0 Client Secret to be used for the OAuth 2.0 Client Credentials Grant.\n\n>If pre-authorization is enabled, this value is required."
+                },
+                "token_url": {
+                  "type": "string",
+                  "format": "uri",
+                  "title": "OAuth 2.0 Token URL",
+                  "description": "The OAuth 2.0 Token Endpoint where the OAuth 2.0 Client Credentials Grant will be performed.\n\n>If pre-authorization is enabled, this value is required."
+                },
+                "scope": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "title": "OAuth 2.0 Scope",
+                  "description": "The OAuth 2.0 Scope to be requested during the OAuth 2.0 Client Credentials Grant.",
+                  "examples": [
+                    [
+                      "[\"foo\", \"bar\"]"
+                    ]
+                  ]
+                }
+              }
+            }
+          ]
+        },
         "retry": {
           "type": "object",
           "additionalProperties": false,


### PR DESCRIPTION


## Related issue

https://github.com/ory/oathkeeper/issues/565

## Proposed changes

Using the Oauth2 Client Credential Flow will beneficial to operate and include other services, protected with oauth2. for some users to hydrate (enrich) the pipeline flow in the Oathkeeper.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X ] I have read the [security policy](../security/policy).
- [X ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

No tests because of the nature of this change - it seems that I am not able to write tests without including 3rd party to issue the access tokens. I may require some help with documentation especially as I am not native speaker.
