### PR TITLE
chore: update docusaurus template

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -182,8 +182,7 @@ module.exports = {
         showLastUpdateAuthor: true,
         showLastUpdateTime: true,
         disableVersioning: false,
-
-        include: ['**/*.md', '**/*.mdx', '**/*.js']
+        include: ['**/*.md', '**/*.mdx', '**/*.jsx']
       }
     ],
     '@docusaurus/plugin-content-pages',

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -15,6 +15,7 @@
         "@docusaurus/theme-classic": "2.0.0-beta.3",
         "@docusaurus/theme-search-algolia": "2.0.0-beta.3",
         "classnames": "2.3.1",
+        "docusaurus-theme-redoc": "^0.4.4",
         "file-loader": "6.2.0",
         "mermaid": "8.11.0",
         "node-fetch": "2.6.1",


### PR DESCRIPTION
Updated docusaurus template to current https://github.com/ory/docusaurus-template.