### PR TITLE
fix: introspection response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 LICENSE.txt
 *-packr.go
 dev
+local-conf/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ node_modules/
 LICENSE.txt
 *-packr.go
 dev
-local-conf/

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -96,7 +96,7 @@ type AuthenticatorOAuth2IntrospectionResult struct {
 	TokenUse  string                 `json:"token_use"`
 }
 
-// based on
+// Audience value mau be a single sensitive string.
 type AuthenticatorOAuth2IntrospectionResultFork struct {
 	Active    bool                   `json:"active"`
 	Extra     map[string]interface{} `json:"ext"`
@@ -146,7 +146,6 @@ func (a *AuthenticatorOAuth2Introspection) tokenFromCache(config *AuthenticatorO
 		return nil
 	}
 
-	fmt.Printf("[Response From Keycloak : %+v\n", item)
 	i, ok := item.(*AuthenticatorOAuth2IntrospectionResult)
 	if !ok {
 		return modifyResponse(item)

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -111,7 +111,7 @@ type AuthenticatorOAuth2IntrospectionResultFork struct {
 	TokenUse  string                 `json:"token_use"`
 }
 
-func modifyResponse(old interface{}) *AuthenticatorOAuth2IntrospectionResult {
+func ModifyResponse(old interface{}) *AuthenticatorOAuth2IntrospectionResult {
 	i, ok := old.(*AuthenticatorOAuth2IntrospectionResultFork)
 	if !ok {
 		return nil
@@ -148,7 +148,7 @@ func (a *AuthenticatorOAuth2Introspection) tokenFromCache(config *AuthenticatorO
 
 	i, ok := item.(*AuthenticatorOAuth2IntrospectionResult)
 	if !ok {
-		return modifyResponse(item)
+		return ModifyResponse(item)
 	}
 
 	return i

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -96,6 +96,42 @@ type AuthenticatorOAuth2IntrospectionResult struct {
 	TokenUse  string                 `json:"token_use"`
 }
 
+// based on
+type AuthenticatorOAuth2IntrospectionResultFork struct {
+	Active    bool                   `json:"active"`
+	Extra     map[string]interface{} `json:"ext"`
+	Subject   string                 `json:"sub,omitempty"`
+	Username  string                 `json:"username"`
+	Audience  string                 `json:"aud"`
+	TokenType string                 `json:"token_type"`
+	Issuer    string                 `json:"iss"`
+	ClientID  string                 `json:"client_id,omitempty"`
+	Scope     string                 `json:"scope,omitempty"`
+	Expires   int64                  `json:"exp"`
+	TokenUse  string                 `json:"token_use"`
+}
+
+func modifyResponse(old interface{}) *AuthenticatorOAuth2IntrospectionResult {
+	i, ok := old.(*AuthenticatorOAuth2IntrospectionResultFork)
+	if !ok {
+		return nil
+	}
+	audience := append([]string{}, i.Audience)
+	return &AuthenticatorOAuth2IntrospectionResult{
+		Active:    i.Active,
+		Extra:     i.Extra,
+		Subject:   i.Subject,
+		Username:  i.Username,
+		Audience:  audience,
+		TokenType: i.TokenType,
+		Issuer:    i.Issuer,
+		ClientID:  i.ClientID,
+		Scope:     i.Scope,
+		Expires:   i.Expires,
+		TokenUse:  i.TokenUse,
+	}
+}
+
 func (a *AuthenticatorOAuth2Introspection) tokenFromCache(config *AuthenticatorOAuth2IntrospectionConfiguration, token string, ss fosite.ScopeStrategy) *AuthenticatorOAuth2IntrospectionResult {
 	if !config.Cache.Enabled {
 		return nil
@@ -110,9 +146,10 @@ func (a *AuthenticatorOAuth2Introspection) tokenFromCache(config *AuthenticatorO
 		return nil
 	}
 
+	fmt.Printf("[Response From Keycloak : %+v\n", item)
 	i, ok := item.(*AuthenticatorOAuth2IntrospectionResult)
 	if !ok {
-		return nil
+		return modifyResponse(item)
 	}
 
 	return i

--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -25,22 +25,21 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/ory/x/assertx"
-
 	"github.com/julienschmidt/httprouter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/tidwall/sjson"
-
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/oathkeeper/internal"
 	. "github.com/ory/oathkeeper/pipeline/authn"
 	"github.com/ory/viper"
+	"github.com/ory/x/assertx"
 	"github.com/ory/x/logrusx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/sjson"
 )
 
 func TestAuthenticatorOAuth2Introspection(t *testing.T) {
@@ -840,4 +839,43 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 			require.NotEqual(t, noPreauthClient3, noPreauthClient)
 		})
 	})
+}
+
+func Test_ModifyResponse(t *testing.T) {
+	type args struct {
+		old interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want *AuthenticatorOAuth2IntrospectionResult
+	}{
+		{
+			name: "Test No Error",
+			args: args{
+				old: &AuthenticatorOAuth2IntrospectionResultFork{
+					Audience: "application",
+				},
+			},
+			want: &AuthenticatorOAuth2IntrospectionResult{
+				Audience: []string{"application"},
+			},
+		},
+		{
+			name: "Test Different Struct (Error)",
+			args: args{
+				old: &AuthenticatorOAuth2IntrospectionPreAuthConfiguration{
+					Audience: "application",
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ModifyResponse(tt.args.old); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("modifyResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
I try to fixing the issue related oauth2_introspection not parsing single string aud value

Based on this protocol https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation the audience field need to changed, to receive []string or string. 

```REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain identifiers for other audiences. In the general case, the aud value is an array of case sensitive strings. In the common special case when there is one audience, the aud value MAY be a single case sensitive string.
```
There are some solutions we can implement : 

1. Change the audience as an interface 
  -  https://github.com/ory/oathkeeper/blob/e4e2263c7b97e47506919e29442efb395eaba99d/pipeline/authn/authenticator_oauth2_introspection.go#L90
  Effort : 
  - Need to create function to check the type of interface, string or []string
  - Need to update the current unit testing, possible break the current unit test
  
2. Create new struct and then set the audience as a single string, so if there is possibility failed to unmarshal / casting and then unmarshal / cast with this new struct
  Effort :
 - Create new function to modify the response
 - Not break the current unit testing

So, because of that, I decide to create new struct named Fork and add the function modify struct in this PR.
With this Fork struct and this function the unit testing also work fine after I execute in my local.
Hopefully with this PR can help everyone that face same issue.
Thank you

## Related issue(s)

https://github.com/ory/oathkeeper/issues/491



## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).


