### PR TITLE
fix: parse introspection result audience for string and string array

### DIFF
--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -83,17 +83,18 @@ func (a *AuthenticatorOAuth2Introspection) GetID() string {
 }
 
 type AuthenticatorOAuth2IntrospectionResult struct {
-	Active    bool                   `json:"active"`
-	Extra     map[string]interface{} `json:"ext"`
-	Subject   string                 `json:"sub,omitempty"`
-	Username  string                 `json:"username"`
-	Audience  []string               `json:"aud"`
-	TokenType string                 `json:"token_type"`
-	Issuer    string                 `json:"iss"`
-	ClientID  string                 `json:"client_id,omitempty"`
-	Scope     string                 `json:"scope,omitempty"`
-	Expires   int64                  `json:"exp"`
-	TokenUse  string                 `json:"token_use"`
+	Active    		bool                   	`json:"active"`
+	Extra     		map[string]interface{} 	`json:"ext"`
+	Subject   		string                 	`json:"sub,omitempty"`
+	Username  		string                 	`json:"username"`
+	Audience  		[]string               	`json:"-"`
+	TokenType 		string                 	`json:"token_type"`
+	Issuer    		string                 	`json:"iss"`
+	ClientID  		string                 	`json:"client_id,omitempty"`
+	Scope     		string                 	`json:"scope,omitempty"`
+	Expires   		int64                  	`json:"exp"`
+	TokenUse  		string           		`json:"token_use"`
+	AudienceHelper  interface{}     		`json:"aud"`
 }
 
 func (a *AuthenticatorOAuth2Introspection) tokenFromCache(config *AuthenticatorOAuth2IntrospectionConfiguration, token string, ss fosite.ScopeStrategy) *AuthenticatorOAuth2IntrospectionResult {
@@ -209,6 +210,15 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session
 
 		if err := json.NewDecoder(resp.Body).Decode(&i); err != nil {
 			return errors.WithStack(err)
+		}
+		if parsedAud, ok := i.AudienceHelper.(string); ok {
+        	i.Audience = []string{string(parsedAud)};
+        }
+	    if parsedAud, ok := i.AudienceHelper.([]interface{}); ok {
+	    	i.Audience = make([]string, len(parsedAud))
+    	    for index, aud := range parsedAud {
+				i.Audience[index] = string(aud.(string))
+			}
 		}
 	}
 


### PR DESCRIPTION
Parse audience of introspection result for both types `string` and `[]string`. I added a helper field on the struct to check the audience response type and then parse it to `Audience` which is always an array.

## Related issue(s)

https://github.com/ory/oathkeeper/issues/491

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
