### PR TITLE
chore: store oauth2 introspection result as bytes in cache

### DIFF
--- a/pipeline/authn/authenticator_oauth2_introspection_cache_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_cache_test.go
@@ -1,0 +1,71 @@
+package authn
+
+import (
+	"github.com/ory/fosite"
+	"github.com/ory/oathkeeper/driver/configuration"
+	"github.com/ory/viper"
+	"github.com/ory/x/logrusx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestCache(t *testing.T) {
+	viper.Reset()
+
+	viper.Set("authenticators.oauth2_introspection.config.cache.enabled", true)
+	viper.Set("authenticators.oauth2_introspection.config.introspection_url", "http://localhost:8080/")
+
+	logger := logrusx.New("", "")
+	c := configuration.NewViperProvider(logger)
+	a := NewAuthenticatorOAuth2Introspection(c, logger)
+	assert.Equal(t, "oauth2_introspection", a.GetID())
+
+	config, _, err := a.Config(nil)
+	require.NoError(t, err)
+
+	t.Run("method=tokenToCache", func(t *testing.T) {
+		t.Run("case=cache value", func(t *testing.T) {
+			i := &AuthenticatorOAuth2IntrospectionResult{
+				Active: true,
+				Extra:  map[string]interface{}{"extra": "foo"},
+			}
+
+			a.tokenToCache(config, i, "token", fosite.WildcardScopeStrategy)
+			// wait cache to save value
+			time.Sleep(time.Millisecond * 100)
+
+			// modify struct should not affect cached value
+			i.Active = false
+			v := a.tokenFromCache(config, "token", fosite.WildcardScopeStrategy)
+			require.NotNil(t, v)
+			require.True(t, v.Active)
+		})
+
+		t.Run("case=value cannot be marshaled to json should not be cached", func(t *testing.T) {
+			i := &AuthenticatorOAuth2IntrospectionResult{
+				Active: false,
+				Extra:  map[string]interface{}{"extra": make(chan bool, 1)},
+			}
+
+			a.tokenToCache(config, i, "invalid-token", fosite.WildcardScopeStrategy)
+			// wait cache to save value
+			time.Sleep(time.Millisecond * 100)
+
+			v := a.tokenFromCache(config, "invalid-token", fosite.WildcardScopeStrategy)
+			require.Nil(t, v)
+		})
+
+		t.Run("case=cached invalid json value should not working", func(t *testing.T) {
+			ok := a.tokenCache.Set("invalid-json", "invalid-json-string", 1)
+			require.True(t, ok)
+			// wait cache to save value
+			time.Sleep(time.Millisecond * 100)
+
+			v := a.tokenFromCache(config, "invalid-json", fosite.WildcardScopeStrategy)
+			require.Nil(t, v)
+		})
+	})
+
+}

--- a/pipeline/authn/authenticator_oauth2_introspection_cache_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_cache_test.go
@@ -1,14 +1,15 @@
 package authn
 
 import (
+	"testing"
+	"time"
+
 	"github.com/ory/fosite"
 	"github.com/ory/oathkeeper/driver/configuration"
 	"github.com/ory/viper"
 	"github.com/ory/x/logrusx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestCache(t *testing.T) {

--- a/pipeline/authn/authenticator_oauth2_introspection_cache_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_cache_test.go
@@ -35,7 +35,7 @@ func TestCache(t *testing.T) {
 
 			a.tokenToCache(config, i, "token", fosite.WildcardScopeStrategy)
 			// wait cache to save value
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 10)
 
 			// modify struct should not affect cached value
 			i.Active = false
@@ -52,7 +52,7 @@ func TestCache(t *testing.T) {
 
 			a.tokenToCache(config, i, "invalid-token", fosite.WildcardScopeStrategy)
 			// wait cache to save value
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 10)
 
 			v := a.tokenFromCache(config, "invalid-token", fosite.WildcardScopeStrategy)
 			require.Nil(t, v)
@@ -62,7 +62,7 @@ func TestCache(t *testing.T) {
 			ok := a.tokenCache.Set("invalid-json", []byte("invalid-json-string"), 1)
 			require.True(t, ok)
 			// wait cache to save value
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 10)
 
 			v := a.tokenFromCache(config, "invalid-json", fosite.WildcardScopeStrategy)
 			require.Nil(t, v)
@@ -73,16 +73,16 @@ func TestCache(t *testing.T) {
 				Active: true,
 			}
 
-			config, _, _ := a.Config([]byte(`{ "cache": { "ttl": "1s" } }`))
+			config, _, _ := a.Config([]byte(`{ "cache": { "ttl": "100ms" } }`))
 			a.tokenToCache(config, i, "token", fosite.WildcardScopeStrategy)
 			// wait cache to save value
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 10)
 
 			v := a.tokenFromCache(config, "token", fosite.WildcardScopeStrategy)
 			require.NotNil(t, v)
 
 			// wait cache to be expired
-			time.Sleep(time.Second)
+			time.Sleep(time.Millisecond * 100)
 			v = a.tokenFromCache(config, "token", fosite.WildcardScopeStrategy)
 			require.Nil(t, v)
 		})


### PR DESCRIPTION
OAuth2 introspection result are using raw value to be stored in cache, but the cached value may be edit after stored into cache, which may cause go map concurrent write issue, so I changed the cached value to bytes using json serializer. 

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
