### PR TITLE
fix: allow forwarding query parameters to the session store

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -420,6 +420,12 @@
           "title": "Only Cookies",
           "description": "A list of possible cookies to look for on incoming requests, and will fallthrough to the next authenticator if none of the passed cookies are set on the request."
         },
+        "preserve_query": {
+          "title": "Preserve Query",
+          "type": "boolean",
+          "default": true,
+          "description": "When unset or set to true, any query parameters specified in `check_session_url` will be preserved instead of overwriting them with the query parameters from the original request"
+        },
         "preserve_path": {
           "title": "Preserve Path",
           "type": "boolean",
@@ -511,6 +517,12 @@
               }
             }
           ]
+        },
+        "preserve_query": {
+          "title": "Preserve Query",
+          "type": "boolean",
+          "default": true,
+          "description": "When unset or set to true, any query parameters specified in `check_session_url` will be preserved instead of overwriting them with the query parameters from the original request"
         },
         "preserve_path": {
           "title": "Preserve Path",

--- a/docs/docs/pipeline/authn.md
+++ b/docs/docs/pipeline/authn.md
@@ -246,6 +246,9 @@ appropriately.
 - `preserve_path` (boolean, optional) - If set, any path in `check_session_url`
   will be preserved instead of replacing the path with the path of the request
   being checked.
+- `preserve_query` (boolean, optional) - If unset or true, query parameters in
+  `check_session_url` will be preserved instead of replacing them with the
+  query of the request being checked.
 - `extra_from` (string, optional - defaults to `extra`) - A
   [GJSON Path](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) pointing
   to the `extra` field. This defaults to `extra`, but it could also be `@this`
@@ -292,6 +295,7 @@ authenticators:
       only:
         - sessionid
       preserve_path: true
+      preserve_query: true
 ```
 
 ### Access Rule Example
@@ -342,6 +346,9 @@ appropriately.
 - `preserve_path` (boolean, optional) - If set, any path in `check_session_url`
   will be preserved instead of replacing the path with the path of the request
   being checked.
+- `preserve_query` (boolean, optional) - If unset or true, query parameters in
+  `check_session_url` will be preserved instead of replacing them with the
+  query of the request being checked.
 - `extra_from` (string, optional - defaults to `extra`) - A
   [GJSON Path](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) pointing
   to the `extra` field. This defaults to `extra`, but it could also be `@this`
@@ -415,6 +422,7 @@ authenticators:
         # or
         # cookie: auth-token
       preserve_path: true
+      preserve_query: true
 ```
 
 ### Access Rule Example

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -18,11 +18,15 @@ Config files can be formatted as JSON, YAML and TOML. Some configuration values
 support reloading without server restart. All configuration values can be set
 using environment variables, as documented below.
 
+:::warning Disclaimer
+
 This reference configuration documents all keys, also deprecated ones! It is a
 reference for all possible configuration values.
 
 If you are looking for an example configuration, it is better to try out the
 quickstart.
+
+:::
 
 To find out more about edge cases like setting string array values through
 environmental variables head to the
@@ -150,6 +154,16 @@ authenticators:
       #
       check_session_url: https://session-store-host
 
+      ## preserve_query ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export AUTHENTICATORS_COOKIE_SESSION_CONFIG_PRESERVE_QUERY=<value>
+      # - Windows Command Line (CMD):
+      #    > set AUTHENTICATORS_COOKIE_SESSION_CONFIG_PRESERVE_QUERY=<value>
+      #
+      preserve_query: false
+
       ## preserve_path ##
       #
       # Set this value using environment variables on
@@ -159,6 +173,16 @@ authenticators:
       #    > set AUTHENTICATORS_COOKIE_SESSION_CONFIG_PRESERVE_PATH=<value>
       #
       preserve_path: false
+
+      ## preserve_host ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export AUTHENTICATORS_COOKIE_SESSION_CONFIG_PRESERVE_HOST=<value>
+      # - Windows Command Line (CMD):
+      #    > set AUTHENTICATORS_COOKIE_SESSION_CONFIG_PRESERVE_HOST=<value>
+      #
+      preserve_host: false
 
       ## extra_from ##
       #
@@ -226,6 +250,16 @@ authenticators:
       #
       check_session_url: https://session-store-host
 
+      ## preserve_query ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export AUTHENTICATORS_BEARER_TOKEN_CONFIG_PRESERVE_QUERY=<value>
+      # - Windows Command Line (CMD):
+      #    > set AUTHENTICATORS_BEARER_TOKEN_CONFIG_PRESERVE_QUERY=<value>
+      #
+      preserve_query: false
+
       ## preserve_path ##
       #
       # Set this value using environment variables on
@@ -235,6 +269,16 @@ authenticators:
       #    > set AUTHENTICATORS_BEARER_TOKEN_CONFIG_PRESERVE_PATH=<value>
       #
       preserve_path: false
+
+      ## preserve_host ##
+      #
+      # Set this value using environment variables on
+      # - Linux/macOS:
+      #    $ export AUTHENTICATORS_BEARER_TOKEN_CONFIG_PRESERVE_HOST=<value>
+      # - Windows Command Line (CMD):
+      #    > set AUTHENTICATORS_BEARER_TOKEN_CONFIG_PRESERVE_HOST=<value>
+      #
+      preserve_host: false
 
       ## extra_from ##
       #

--- a/pipeline/authn/authenticator_bearer_token.go
+++ b/pipeline/authn/authenticator_bearer_token.go
@@ -26,6 +26,7 @@ type AuthenticatorBearerTokenFilter struct {
 type AuthenticatorBearerTokenConfiguration struct {
 	CheckSessionURL     string                      `json:"check_session_url"`
 	BearerTokenLocation *helper.BearerTokenLocation `json:"token_from"`
+	PreserveQuery       bool                        `json:"preserve_query"`
 	PreservePath        bool                        `json:"preserve_path"`
 	PreserveHost        bool                        `json:"preserve_host"`
 	ExtraFrom           string                      `json:"extra_from"`
@@ -84,7 +85,7 @@ func (a *AuthenticatorBearerToken) Authenticate(r *http.Request, session *Authen
 		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
-	body, err := forwardRequestToSessionStore(r, cf.CheckSessionURL, cf.PreservePath, cf.PreserveHost, cf.SetHeaders)
+	body, err := forwardRequestToSessionStore(r, cf.CheckSessionURL, cf.PreserveQuery, cf.PreservePath, cf.PreserveHost, cf.SetHeaders)
 	if err != nil {
 		return err
 	}

--- a/pipeline/authn/authenticator_cookie_session_test.go
+++ b/pipeline/authn/authenticator_cookie_session_test.go
@@ -32,7 +32,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 		t.Run("description=should fail because session store returned 400", func(t *testing.T) {
 			testServer, _ := makeServer(400, `{}`)
 			err := pipelineAuthenticator.Authenticate(
-				makeRequest("GET", "/", map[string]string{"sessionid": "zyx"}, ""),
+				makeRequest("GET", "/", "", map[string]string{"sessionid": "zyx"}, ""),
 				session,
 				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s"}`, testServer.URL)),
 				nil,
@@ -43,7 +43,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 		t.Run("description=should pass because session store returned 200", func(t *testing.T) {
 			testServer, _ := makeServer(200, `{"subject": "123", "extra": {"foo": "bar"}}`)
 			err := pipelineAuthenticator.Authenticate(
-				makeRequest("GET", "/", map[string]string{"sessionid": "zyx"}, ""),
+				makeRequest("GET", "/", "", map[string]string{"sessionid": "zyx"}, ""),
 				session,
 				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s"}`, testServer.URL)),
 				nil,
@@ -58,7 +58,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 		t.Run("description=should pass through method, path, and headers to auth server", func(t *testing.T) {
 			testServer, requestRecorder := makeServer(200, `{"subject": "123"}`)
 			err := pipelineAuthenticator.Authenticate(
-				makeRequest("PUT", "/users/123?query=string", map[string]string{"sessionid": "zyx"}, ""),
+				makeRequest("PUT", "/users/123", "query=string", map[string]string{"sessionid": "zyx"}, ""),
 				session,
 				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s"}`, testServer.URL)),
 				nil,
@@ -67,17 +67,18 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 			assert.Len(t, requestRecorder.requests, 1)
 			r := requestRecorder.requests[0]
 			assert.Equal(t, r.Method, "PUT")
-			assert.Equal(t, r.URL.Path, "/users/123?query=string")
+			assert.Equal(t, r.URL.Path, "/users/123")
+			assert.Equal(t, r.URL.RawQuery, "query=string")
 			assert.Equal(t, r.Header.Get("Cookie"), "sessionid=zyx")
 			assert.Equal(t, &AuthenticationSession{Subject: "123"}, session)
 		})
 
-		t.Run("description=should pass through method and headers ONLY to auth server when PreservePath is true", func(t *testing.T) {
+		t.Run("description=should pass through method and headers ONLY to auth server when PreservePath and PreserveQuery are true", func(t *testing.T) {
 			testServer, requestRecorder := makeServer(200, `{"subject": "123"}`)
 			err := pipelineAuthenticator.Authenticate(
-				makeRequest("PUT", "/users/123?query=string", map[string]string{"sessionid": "zyx"}, ""),
+				makeRequest("PUT", "/users/123", "query=string", map[string]string{"sessionid": "zyx"}, ""),
 				session,
-				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s", "preserve_path": true}`, testServer.URL)),
+				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s", "preserve_path": true, "preserve_query": true}`, testServer.URL)),
 				nil,
 			)
 			require.NoError(t, err, "%#v", errors.Cause(err))
@@ -85,13 +86,14 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 			r := requestRecorder.requests[0]
 			assert.Equal(t, r.Method, "PUT")
 			assert.Equal(t, r.URL.Path, "/")
+			assert.Equal(t, r.URL.RawQuery, "")
 			assert.Equal(t, r.Header.Get("Cookie"), "sessionid=zyx")
 			assert.Equal(t, &AuthenticationSession{Subject: "123"}, session)
 		})
 
 		t.Run("description=should pass through x-forwarded-host if preserve_host is set to true", func(t *testing.T) {
 			testServer, requestRecorder := makeServer(200, `{"subject": "123"}`)
-			req := makeRequest("PUT", "/users/123?query=string", map[string]string{"sessionid": "zyx"}, "")
+			req := makeRequest("PUT", "/users/123", "query=string", map[string]string{"sessionid": "zyx"}, "")
 			expectedHost := "some-host"
 			req.Host = expectedHost
 			err := pipelineAuthenticator.Authenticate(
@@ -112,7 +114,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 
 		t.Run("description=should pass not override x-forwarded-host in set_headers", func(t *testing.T) {
 			testServer, requestRecorder := makeServer(200, `{"subject": "123"}`)
-			req := makeRequest("PUT", "/users/123?query=string", map[string]string{"sessionid": "zyx"}, "")
+			req := makeRequest("PUT", "/users/123", "query=string", map[string]string{"sessionid": "zyx"}, "")
 			expectedHost := "some-host"
 			req.Host = expectedHost
 			err := pipelineAuthenticator.Authenticate(
@@ -136,7 +138,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 		t.Run("description=does not pass request body through to auth server", func(t *testing.T) {
 			testServer, requestRecorder := makeServer(200, `{}`)
 			pipelineAuthenticator.Authenticate(
-				makeRequest("POST", "/", map[string]string{"sessionid": "zyx"}, "Some body..."),
+				makeRequest("POST", "/", "", map[string]string{"sessionid": "zyx"}, "Some body..."),
 				session,
 				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s"}`, testServer.URL)),
 				nil,
@@ -151,7 +153,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 		t.Run("description=should fallthrough if only is specified and no cookie specified is set", func(t *testing.T) {
 			testServer, requestRecorder := makeServer(200, `{}`)
 			err := pipelineAuthenticator.Authenticate(
-				makeRequest("GET", "/", map[string]string{"sessionid": "zyx"}, ""),
+				makeRequest("GET", "/", "", map[string]string{"sessionid": "zyx"}, ""),
 				session,
 				json.RawMessage(fmt.Sprintf(`{"only": ["session", "sid"], "check_session_url": "%s"}`, testServer.URL)),
 				nil,
@@ -163,7 +165,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 		t.Run("description=should fallthrough if is missing and it has no cookies", func(t *testing.T) {
 			testServer, requestRecorder := makeServer(200, `{}`)
 			err := pipelineAuthenticator.Authenticate(
-				makeRequest("GET", "/", map[string]string{}, ""),
+				makeRequest("GET", "/", "", map[string]string{}, ""),
 				session,
 				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s"}`, testServer.URL)),
 				nil,
@@ -175,7 +177,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 		t.Run("description=should not fallthrough if only is specified and cookie specified is set", func(t *testing.T) {
 			testServer, _ := makeServer(200, `{}`)
 			err := pipelineAuthenticator.Authenticate(
-				makeRequest("GET", "/", map[string]string{"sid": "zyx"}, ""),
+				makeRequest("GET", "/", "", map[string]string{"sid": "zyx"}, ""),
 				session,
 				json.RawMessage(fmt.Sprintf(`{"only": ["session", "sid"], "check_session_url": "%s"}`, testServer.URL)),
 				nil,
@@ -186,7 +188,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 		t.Run("description=should work with nested extra keys", func(t *testing.T) {
 			testServer, _ := makeServer(200, `{"subject": "123", "session": {"foo": "bar"}}`)
 			err := pipelineAuthenticator.Authenticate(
-				makeRequest("GET", "/", map[string]string{"sessionid": "zyx"}, ""),
+				makeRequest("GET", "/", "", map[string]string{"sessionid": "zyx"}, ""),
 				session,
 				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s", "extra_from": "session"}`, testServer.URL)),
 				nil,
@@ -201,7 +203,7 @@ func TestAuthenticatorCookieSession(t *testing.T) {
 		t.Run("description=should work with the root key for extra and a custom subject key", func(t *testing.T) {
 			testServer, _ := makeServer(200, `{"identity": {"id": "123"}, "session": {"foo": "bar"}}`)
 			err := pipelineAuthenticator.Authenticate(
-				makeRequest("GET", "/", map[string]string{"sessionid": "zyx"}, ""),
+				makeRequest("GET", "/", "", map[string]string{"sessionid": "zyx"}, ""),
 				session,
 				json.RawMessage(fmt.Sprintf(`{"check_session_url": "%s", "subject_from": "identity.id", "extra_from": "@this"}`, testServer.URL)),
 				nil,
@@ -232,7 +234,7 @@ func makeServer(statusCode int, responseBody string) (*httptest.Server, *Request
 	return testServer, requestRecorder
 }
 
-func makeRequest(method string, path string, cookies map[string]string, bodyStr string) *http.Request {
+func makeRequest(method string, path string, rawQuery string, cookies map[string]string, bodyStr string) *http.Request {
 	var body io.ReadCloser
 	header := http.Header{}
 	if bodyStr != "" {
@@ -241,7 +243,7 @@ func makeRequest(method string, path string, cookies map[string]string, bodyStr 
 	}
 	req := &http.Request{
 		Method: method,
-		URL:    &url.URL{Path: path},
+		URL:    &url.URL{Path: path, RawQuery: rawQuery},
 		Header: header,
 		Body:   body,
 	}


### PR DESCRIPTION
This commit adds a new flag, preserve_query, in order to resolve issue #786. It
would be ideal for this flag to be false by default for consistency with
preserve_path, but it is true by default in order to preserve backwards
compatibility.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
