### PR TITLE
feat(jwt): replace jwt module

### DIFF
--- a/credentials/signer.go
+++ b/credentials/signer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 type Signer interface {

--- a/credentials/signer_default.go
+++ b/credentials/signer_default.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"reflect"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ed25519"
 	"gopkg.in/square/go-jose.v2"

--- a/credentials/signer_default_integration_test.go
+++ b/credentials/signer_default_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/ory/oathkeeper/internal"
 )

--- a/credentials/signer_default_test.go
+++ b/credentials/signer_default_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 

--- a/credentials/verifier.go
+++ b/credentials/verifier.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/ory/fosite"
 )

--- a/credentials/verifier_default.go
+++ b/credentials/verifier_default.go
@@ -6,7 +6,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 
 	"github.com/ory/fosite"

--- a/credentials/verifier_default_test.go
+++ b/credentials/verifier_default_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/gobuffalo/httptest v1.0.2
 	github.com/gobuffalo/packr/v2 v2.8.0
 	github.com/gobwas/glob v0.2.3
+	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/golang/gddo v0.0.0-20190904175337-72a348e765d2
 	github.com/golang/mock v1.4.3
 	github.com/google/go-replayers/httpreplay v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -618,6 +618,8 @@ github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFG
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/gddo v0.0.0-20180828051604-96d2a289f41e/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
 github.com/golang/gddo v0.0.0-20190904175337-72a348e765d2 h1:xisWqjiKEff2B0KfFYGpCqc3M3zdTz+OHQHRc09FeYk=

--- a/pipeline/authn/authenticator_jwt.go
+++ b/pipeline/authn/authenticator_jwt.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 
 	"github.com/ory/go-convenience/jwtx"

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/tidwall/sjson"
 
 	"github.com/ory/herodot"

--- a/pipeline/mutate/mutator_id_token.go
+++ b/pipeline/mutate/mutator_id_token.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/dgraph-io/ristretto"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"

--- a/pipeline/mutate/mutator_id_token_test.go
+++ b/pipeline/mutate/mutator_id_token_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ory/oathkeeper/rule"
 	"github.com/ory/oathkeeper/x"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/ory/viper"
 

--- a/test/e2e/okclient/main.go
+++ b/test/e2e/okclient/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/square/go-jose"
 
 	"github.com/ory/oathkeeper/x"


### PR DESCRIPTION
A while ago we switched this project to use `github.com/form3tech-oss/jwt-go` as `github.com/dgrijalva/jwt-go` wasn't maintained anymore (https://github.com/ory/oathkeeper/pull/635). 
In the meantime the open source community came up with a new repository to combine the efforts of maintaining a jwt module.
Based on https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md the v4 should be fully backwards compatible so that I don't expect any issues to pop up. This PR will also fix https://github.com/ory/oathkeeper/issues/691 as support was recently added in https://github.com/golang-jwt/jwt/pull/36

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
