### PR TITLE
chore: allow both string and []string in aud field

### DIFF
--- a/pipeline/authn/authenticator_oauth2_introspection_test.go
+++ b/pipeline/authn/authenticator_oauth2_introspection_test.go
@@ -840,4 +840,22 @@ func TestAuthenticatorOAuth2Introspection(t *testing.T) {
 			require.NotEqual(t, noPreauthClient3, noPreauthClient)
 		})
 	})
+
+	t.Run("unmarshal-audience", func(t *testing.T) {
+		t.Run("Should pass because audience is a valid string", func(t *testing.T) {
+			var aud Audience
+			data := `"audience"`
+			json.Unmarshal([]byte(data), &aud)
+			require.NoError(t, err)
+			require.Equal(t, Audience{"audience"}, aud)
+		})
+
+		t.Run("Should pass because audience is a valid string array", func(t *testing.T) {
+			var aud Audience
+			data := `["audience1","audience2"]`
+			json.Unmarshal([]byte(data), &aud)
+			require.NoError(t, err)
+			require.Equal(t, Audience{"audience1", "audience2"}, aud)
+		})
+	})
 }


### PR DESCRIPTION
According to the [specification](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3), the `aud` field can either be an array of strings or a single string. Oathkeeper only supports arrays, which breaks the integration with IAM tools like Keycloak and forces users to use ugly hacks like setting an additional fake audience. This change adds support for strings to Oathkeeper.

## Related issue(s)

@aeneasr 
#491 
#601 
#792 
#810

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.