### PR TITLE
fix: remote_json default configuration

### DIFF
--- a/pipeline/authz/remote_json.go
+++ b/pipeline/authz/remote_json.go
@@ -127,5 +127,9 @@ func (a *AuthorizerRemoteJSON) Config(config json.RawMessage) (*AuthorizerRemote
 		return nil, NewErrAuthorizerMisconfigured(a, err)
 	}
 
+	if c.ForwardResponseHeadersToUpstream == nil {
+		c.ForwardResponseHeadersToUpstream = []string{}
+	}
+
 	return &c, nil
 }

--- a/pipeline/authz/remote_json_test.go
+++ b/pipeline/authz/remote_json_test.go
@@ -235,3 +235,39 @@ func TestAuthorizerRemoteJSONValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthorizerRemoteJSONConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      json.RawMessage
+		expected *AuthorizerRemoteJSONConfiguration
+	}{
+		{
+			name: "valid configuration with forward_response_headers_to_upstream",
+			raw:  json.RawMessage(`{"remote":"http://host/path","payload":"{}","forward_response_headers_to_upstream":["X-Foo"]}`),
+			expected: &AuthorizerRemoteJSONConfiguration{
+				Remote:                           "http://host/path",
+				Payload:                          "{}",
+				ForwardResponseHeadersToUpstream: []string{"X-Foo"},
+			},
+		},
+		{
+			name: "valid configuration without forward_response_headers_to_upstream",
+			raw:  json.RawMessage(`{"remote":"http://host/path","payload":"{}"}`),
+			expected: &AuthorizerRemoteJSONConfiguration{
+				Remote:                           "http://host/path",
+				Payload:                          "{}",
+				ForwardResponseHeadersToUpstream: []string{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := configuration.NewViperProvider(logrusx.New("", ""))
+			a := NewAuthorizerRemoteJSON(p)
+			actual, err := a.Config(tt.raw)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Closes #797

Default to an empty array when `forward_response_headers_to_upstream` is not specified.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
