### PR TITLE
feat: Enable custom cache key support for Hydrator

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -1127,6 +1127,11 @@
             "enabled": {
               "$ref": "#/definitions/handlerSwitch"
             },
+            "key": {
+              "type": "string",
+              "title": "Cache key",
+              "description": "Define custom cache key, i.e '{{ print .Subject }}'. All properties must be part of AuthenticationSession."
+            },
             "ttl": {
               "type": "string",
               "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/swag v0.19.9
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/go-swagger/go-swagger v0.25.0
+	github.com/go-swagger/go-swagger v0.28.0
 	github.com/gobuffalo/httptest v1.0.2
 	github.com/gobuffalo/packr/v2 v2.8.0
 	github.com/gobwas/glob v0.2.3

--- a/pipeline/mutate/mutator_hydrator.go
+++ b/pipeline/mutate/mutator_hydrator.go
@@ -241,8 +241,11 @@ func (a *MutatorHydrator) Mutate(r *http.Request, session *authn.AuthenticationS
 	}
 	*session = sessionFromUpstream
 
-	a.hydrateToCache(cfg, encodedSession, session)
-
+	if len(cfg.Cache.Key) > 0 {
+		a.hydrateToCache(cfg, cfg.Cache.Key, session)
+	} else {
+		a.hydrateToCache(cfg, encodedSession, session)
+	}
 	return nil
 }
 

--- a/pipeline/mutate/mutator_hydrator.go
+++ b/pipeline/mutate/mutator_hydrator.go
@@ -85,7 +85,7 @@ type externalAPIConfig struct {
 type cacheConfig struct {
 	Enabled bool   `json:"enabled"`
 	TTL     string `json:"ttl"`
-
+	Key     string `json:"key"`
 	ttl time.Duration
 }
 
@@ -147,6 +147,13 @@ func (a *MutatorHydrator) Mutate(r *http.Request, session *authn.AuthenticationS
 		return err
 	}
 
+	if len(cfg.Cache.Key) > 0 {
+		if cacheSession, ok := a.hydrateFromCache(cfg, cfg.Cache.Key); ok {
+			*session = *cacheSession
+			return nil
+		}
+		a.d.Logger().Debugf("Cache key %s was not found. Falling back on default.", cfg.Cache.Key)
+	}
 	var b bytes.Buffer
 	if err := json.NewEncoder(&b).Encode(session); err != nil {
 		return errors.WithStack(err)

--- a/pipeline/mutate/mutator_hydrator.go
+++ b/pipeline/mutate/mutator_hydrator.go
@@ -86,7 +86,7 @@ type cacheConfig struct {
 	Enabled bool   `json:"enabled"`
 	TTL     string `json:"ttl"`
 	Key     string `json:"key"`
-	ttl time.Duration
+	ttl     time.Duration
 }
 
 type MutatorHydratorConfig struct {

--- a/pipeline/mutate/mutator_hydrator_test.go
+++ b/pipeline/mutate/mutator_hydrator_test.go
@@ -133,8 +133,6 @@ func configWithSpecialCacheKey(key string) func(*httptest.Server) json.RawMessag
 	}
 }
 
-
-
 func TestMutatorHydrator(t *testing.T) {
 	conf := internal.NewConfigurationWithDefaults()
 	reg := internal.NewRegistry(conf)


### PR DESCRIPTION
The cache key for `hydrator` is composed of the whole `AuthenticationSession` - this is not optimal. This PR provides the ability to opt-in to a special cache key as (as part of) `AuthenticationSession` for more fine granular cache control

## Related issue(s)
- None what I found.
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
