### PR TITLE
chore: Fix building docker image for docker-compose

### DIFF
--- a/Dockerfile-dc
+++ b/Dockerfile-dc
@@ -10,6 +10,7 @@ WORKDIR /app
 ENV GO111MODULE on
 RUN go get -u github.com/gobuffalo/packr/v2/packr2
 RUN packr2
+RUN go mod download && go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 
 USER ory


### PR DESCRIPTION
## Related issue(s)

Could not build docker image for `docker-compose.yml`

### How to reproduce error

```
$ docker-compose build
[+] Building 33.3s (13/13) FINISHED
 => [internal] load build definition from Dockerfile-dc                                                                                                                                                                                        0.0s
 => => transferring dockerfile: 418B                                                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                              0.0s
 => => transferring context: 34B                                                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/golang:1.16-alpine3.14                                                                                                                                                                      2.0s
 => [1/9] FROM docker.io/library/golang:1.16-alpine3.14@sha256:fdefd31550d3bf7616677d9a3bbee882f47e1a03bb87e8ef7ddf085299617ceb                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                              0.1s
 => => transferring context: 86.53kB                                                                                                                                                                                                           0.1s
 => CACHED [2/9] RUN addgroup -S ory;     adduser -S ory -G ory -D -H -s /bin/nologin                                                                                                                                                          0.0s
 => CACHED [3/9] RUN apk add -U --no-cache ca-certificates                                                                                                                                                                                     0.0s
 => [4/9] ADD . /app                                                                                                                                                                                                                           0.2s
 => [5/9] WORKDIR /app                                                                                                                                                                                                                         0.0s
 => [6/9] RUN go get -u github.com/gobuffalo/packr/v2/packr2                                                                                                                                                                                  10.9s
 => [7/9] RUN packr2                                                                                                                                                                                                                           0.5s
 => [8/9] RUN go mod download                                                                                                                                                                                                                 18.7s
 => ERROR [9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build                                                                                                                                                                             0.9s
------
 > [9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build:
#13 0.839 /go/pkg/mod/gocloud.dev@v0.20.0/blob/gcsblob/gcsblob.go:72:2: missing go.sum entry for module providing package cloud.google.com/go/compute/metadata (imported by gocloud.dev/blob/gcsblob); to add:
#13 0.839 	go get gocloud.dev/blob/gcsblob@v0.20.0
#13 0.839 /go/pkg/mod/gocloud.dev@v0.20.0/blob/gcsblob/iam.go:25:2: missing go.sum entry for module providing package cloud.google.com/go/iam/credentials/apiv1 (imported by gocloud.dev/blob/gcsblob); to add:
#13 0.839 	go get gocloud.dev/blob/gcsblob@v0.20.0
#13 0.839 /go/pkg/mod/gocloud.dev@v0.20.0/blob/gcsblob/gcsblob.go:73:2: missing go.sum entry needed to verify package cloud.google.com/go/storage (imported by gocloud.dev/blob/gcsblob) is provided by exactly one module; to add:
#13 0.839 	go get gocloud.dev/blob/gcsblob@v0.20.0
#13 0.839 /go/pkg/mod/github.com/prometheus/client_golang@v1.5.0/prometheus/desc.go:22:2: missing go.sum entry for module providing package github.com/cespare/xxhash/v2 (imported by github.com/prometheus/client_golang/prometheus); to add:
#13 0.839 	go get github.com/prometheus/client_golang/prometheus@v1.5.0
#13 0.839 /go/pkg/mod/github.com/ory/viper@v1.7.5/viper.go:39:2: missing go.sum entry for module providing package github.com/fsnotify/fsnotify (imported by github.com/ory/x/viperx); to add:
#13 0.839 	go get github.com/ory/x/viperx@v0.0.165
#13 0.839 /go/pkg/mod/github.com/prometheus/client_golang@v1.5.0/prometheus/desc.go:23:2: missing go.sum entry for module providing package github.com/golang/protobuf/proto (imported by github.com/prometheus/client_golang/prometheus); to add:
#13 0.839 	go get github.com/prometheus/client_golang/prometheus@v1.5.0
#13 0.839 /go/pkg/mod/github.com/prometheus/client_golang@v1.5.0/prometheus/value.go:23:2: missing go.sum entry for module providing package github.com/golang/protobuf/ptypes (imported by github.com/prometheus/client_golang/prometheus); to add:
#13 0.839 	go get github.com/prometheus/client_golang/prometheus@v1.5.0
#13 0.839 /go/pkg/mod/github.com/prometheus/client_model@v0.2.0/go/metrics.pb.go:9:2: missing go.sum entry for module providing package github.com/golang/protobuf/ptypes/timestamp (imported by github.com/prometheus/client_model/go); to add:
#13 0.839 	go get github.com/prometheus/client_model/go@v0.2.0
#13 0.839 /go/pkg/mod/github.com/pborman/uuid@v1.2.0/marshal.go:11:2: missing go.sum entry for module providing package github.com/google/uuid (imported by github.com/ory/x/jwksx); to add:
#13 0.839 	go get github.com/ory/x/jwksx@v0.0.165
#13 0.839 /go/pkg/mod/gocloud.dev@v0.20.0/blob/gcsblob/iam.go:26:2: missing go.sum entry for module providing package github.com/googleapis/gax-go/v2 (imported by gocloud.dev/blob/gcsblob); to add:
#13 0.839 	go get gocloud.dev/blob/gcsblob@v0.20.0
#13 0.839 /go/pkg/mod/github.com/ory/viper@v1.7.5/viper.go:42:2: missing go.sum entry for module providing package github.com/magiconair/properties (imported by github.com/ory/viper); to add:
#13 0.839 	go get github.com/ory/viper@v1.7.5
#13 0.840 /go/pkg/mod/github.com/ory/viper@v1.7.5/viper.go:43:2: missing go.sum entry for module providing package github.com/mitchellh/mapstructure (imported by github.com/ory/viper); to add:
#13 0.840 	go get github.com/ory/viper@v1.7.5
#13 0.840 /go/pkg/mod/github.com/ory/viper@v1.7.5/viper.go:44:2: missing go.sum entry for module providing package github.com/pelletier/go-toml (imported by github.com/ory/viper); to add:
#13 0.840 	go get github.com/ory/viper@v1.7.5
#13 0.840 /go/pkg/mod/github.com/ory/viper@v1.7.5/util.go:21:2: missing go.sum entry for module providing package github.com/spf13/afero (imported by github.com/ory/viper); to add:
#13 0.840 	go get github.com/ory/viper@v1.7.5
#13 0.840 /go/pkg/mod/github.com/ory/viper@v1.7.5/util.go:22:2: missing go.sum entry for module providing package github.com/spf13/cast (imported by github.com/ory/x/viperx); to add:
#13 0.840 	go get github.com/ory/x/viperx@v0.0.165
#13 0.840 /go/pkg/mod/gocloud.dev@v0.20.0/internal/oc/metrics.go:19:2: missing go.sum entry for module providing package go.opencensus.io/plugin/ocgrpc (imported by gocloud.dev/internal/oc); to add:
#13 0.840 	go get gocloud.dev/internal/oc@v0.20.0
#13 0.840 /go/pkg/mod/gocloud.dev@v0.20.0/blob/blob.go:81:2: missing go.sum entry for module providing package go.opencensus.io/stats (imported by gocloud.dev/blob); to add:
#13 0.840 	go get gocloud.dev/blob@v0.20.0
#13 0.840 /go/pkg/mod/gocloud.dev@v0.20.0/blob/blob.go:82:2: missing go.sum entry for module providing package go.opencensus.io/stats/view (imported by gocloud.dev/blob); to add:
#13 0.840 	go get gocloud.dev/blob@v0.20.0
#13 0.840 /go/pkg/mod/gocloud.dev@v0.20.0/blob/blob.go:83:2: missing go.sum entry for module providing package go.opencensus.io/tag (imported by gocloud.dev/blob); to add:
#13 0.840 	go get gocloud.dev/blob@v0.20.0
#13 0.840 /go/pkg/mod/gocloud.dev@v0.20.0/internal/oc/trace.go:25:2: missing go.sum entry for module providing package go.opencensus.io/trace (imported by gocloud.dev/internal/oc); to add:
#13 0.840 	go get gocloud.dev/internal/oc@v0.20.0
#13 0.840 /go/pkg/mod/github.com/uber/jaeger-client-go@v2.22.1+incompatible/span_context.go:24:2: missing go.sum entry for module providing package go.uber.org/atomic (imported by github.com/uber/jaeger-client-go); to add:
#13 0.840 	go get github.com/uber/jaeger-client-go@v2.22.1+incompatible
#13 0.840 /go/pkg/mod/github.com/!puerkito!bio/purell@v1.1.1/purell.go:17:2: missing go.sum entry for module providing package golang.org/x/net/idna (imported by github.com/PuerkitoBio/purell); to add:
#13 0.840 	go get github.com/PuerkitoBio/purell@v1.1.1
#13 0.840 /go/pkg/mod/gocloud.dev@v0.20.0/gcp/gcp.go:24:2: missing go.sum entry for module providing package golang.org/x/oauth2 (imported by github.com/ory/oathkeeper/pipeline/authn); to add:
#13 0.840 	go get github.com/ory/oathkeeper/pipeline/authn
#13 0.840 pipeline/authn/authenticator_oauth2_client_credentials.go:19:2: missing go.sum entry for module providing package golang.org/x/oauth2/clientcredentials (imported by github.com/ory/oathkeeper/pipeline/authn); to add:
#13 0.840 	go get github.com/ory/oathkeeper/pipeline/authn
#13 0.840 /go/pkg/mod/gocloud.dev@v0.20.0/gcp/gcp.go:25:2: missing go.sum entry for module providing package golang.org/x/oauth2/google (imported by gocloud.dev/blob/gcsblob); to add:
#13 0.840 	go get gocloud.dev/blob/gcsblob@v0.20.0
#13 0.840 /go/pkg/mod/github.com/!puerkito!bio/purell@v1.1.1/purell.go:18:2: missing go.sum entry for module providing package golang.org/x/text/unicode/norm (imported by github.com/PuerkitoBio/purell); to add:
#13 0.840 	go get github.com/PuerkitoBio/purell@v1.1.1
#13 0.841 /go/pkg/mod/github.com/!puerkito!bio/purell@v1.1.1/purell.go:19:2: missing go.sum entry for module providing package golang.org/x/text/width (imported by github.com/PuerkitoBio/purell); to add:
#13 0.841 	go get github.com/PuerkitoBio/purell@v1.1.1
#13 0.841 /go/pkg/mod/gocloud.dev@v0.20.0/blob/gcsblob/gcsblob.go:76:2: missing go.sum entry for module providing package google.golang.org/api/googleapi (imported by gocloud.dev/blob/gcsblob); to add:
#13 0.841 	go get gocloud.dev/blob/gcsblob@v0.20.0
#13 0.841 /go/pkg/mod/gocloud.dev@v0.20.0/blob/gcsblob/gcsblob.go:77:2: missing go.sum entry for module providing package google.golang.org/api/iterator (imported by gocloud.dev/blob/gcsblob); to add:
#13 0.841 	go get gocloud.dev/blob/gcsblob@v0.20.0
#13 0.841 /go/pkg/mod/github.com/google/go-replayers/httpreplay@v0.1.0/google/google.go:23:2: missing go.sum entry for module providing package google.golang.org/api/option (imported by github.com/ory/oathkeeper/internal/cloudstorage); to add:
#13 0.841 	go get github.com/ory/oathkeeper/internal/cloudstorage
#13 0.841 /go/pkg/mod/github.com/google/go-replayers/httpreplay@v0.1.0/google/google.go:24:2: missing go.sum entry for module providing package google.golang.org/api/transport/http (imported by github.com/google/go-replayers/httpreplay/google); to add:
#13 0.841 	go get github.com/google/go-replayers/httpreplay/google@v0.1.0
#13 0.841 /go/pkg/mod/gocloud.dev@v0.20.0/blob/gcsblob/iam.go:27:2: missing go.sum entry for module providing package google.golang.org/genproto/googleapis/iam/credentials/v1 (imported by gocloud.dev/blob/gcsblob); to add:
#13 0.841 	go get gocloud.dev/blob/gcsblob@v0.20.0
#13 0.841 /go/pkg/mod/github.com/googleapis/gax-go@v2.0.2+incompatible/call_option.go:36:2: missing go.sum entry for module providing package google.golang.org/grpc (imported by gocloud.dev/internal/useragent); to add:
#13 0.841 	go get gocloud.dev/internal/useragent@v0.20.0
#13 0.841 /go/pkg/mod/github.com/googleapis/gax-go@v2.0.2+incompatible/call_option.go:37:2: missing go.sum entry for module providing package google.golang.org/grpc/codes (imported by gocloud.dev/internal/gcerr); to add:
#13 0.841 	go get gocloud.dev/internal/gcerr@v0.20.0
#13 0.841 /go/pkg/mod/github.com/openzipkin/zipkin-go@v0.2.2/propagation/b3/grpc.go:18:2: missing go.sum entry for module providing package google.golang.org/grpc/metadata (imported by github.com/openzipkin/zipkin-go/propagation/b3); to add:
#13 0.841 	go get github.com/openzipkin/zipkin-go/propagation/b3@v0.2.2
#13 0.841 /go/pkg/mod/github.com/googleapis/gax-go@v2.0.2+incompatible/call_option.go:38:2: missing go.sum entry for module providing package google.golang.org/grpc/status (imported by gocloud.dev/internal/gcerr); to add:
#13 0.841 	go get gocloud.dev/internal/gcerr@v0.20.0
#13 0.841 /go/pkg/mod/github.com/ory/viper@v1.7.5/viper.go:50:2: missing go.sum entry for module providing package gopkg.in/ini.v1 (imported by github.com/ory/viper); to add:
#13 0.841 	go get github.com/ory/viper@v1.7.5
#13 0.841 /go/pkg/mod/github.com/ory/viper@v1.7.5/viper.go:51:2: missing go.sum entry for module providing package gopkg.in/yaml.v2 (imported by github.com/ory/x/viperx); to add:
#13 0.841 	go get github.com/ory/x/viperx@v0.0.165
#13 0.841 /go/pkg/mod/github.com/stretchr/testify@v1.7.0/assert/assertions.go:22:2: missing go.sum entry for module providing package gopkg.in/yaml.v3 (imported by github.com/stretchr/testify/assert); to add:
#13 0.841 	go get github.com/stretchr/testify/assert@v1.7.0
------
failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build]: exit code: 1
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
