### PR TITLE
fix: don't pass websocket headers on to session store

### DIFF
--- a/pipeline/authn/authenticator_cookie_session.go
+++ b/pipeline/authn/authenticator_cookie_session.go
@@ -155,6 +155,10 @@ func forwardRequestToSessionStore(r *http.Request, checkSessionURL string, prese
 
 	// We need to make a COPY of the header, not modify r.Header!
 	for k, v := range r.Header {
+		// remove websocket-related headers to not confuse reverse proxies
+		if k == "Upgrade" || k == "Connection" || k == "Sec-Websocket-Key" || k == "Sec-Websocket-Version" {
+			continue
+		}
 		req.Header[k] = v
 	}
 


### PR DESCRIPTION
When Oathkeeper is used to secure the initial connection request to a websocket endpoint, that doesn't mean we also want to open a websocket connection to the session store. With this commit, the "Connection: Upgrade" and related headers are removed now, so the session store receives a "normal" HTTP request.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

-->

```
BREAKING CHANGES: With this patch, the "Connection", "Upgrade", "Sec-Websocket-Key", and "Sec-Websocket-Version" HTTP Headers are not relayed to the session store anymore.
```

## Related issue(s)

https://github.com/ory/cloud/issues/76
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] ~~I have referenced an issue containing the design document if my change
      introduces a new feature.~~ not a new feature
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
