### PR TITLE
feat: allow fallback when using JWT

### DIFF
--- a/pipeline/authn/authenticator_jwt.go
+++ b/pipeline/authn/authenticator_jwt.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
@@ -76,6 +77,12 @@ func (a *AuthenticatorJWT) Authenticate(r *http.Request, session *Authentication
 
 	token := helper.BearerTokenFromRequest(r, cf.BearerTokenLocation)
 	if token == "" {
+		return errors.WithStack(ErrAuthenticatorNotResponsible)
+	}
+
+	// If the token is not a JWT, declare ourselves not responsible. This enables using fallback authenticators (i. e.
+	// bearer_token or oauth2_introspection) for different token types at the same location.
+	if len(strings.Split(token, ".")) != 3 {
 		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -136,6 +136,13 @@ func TestAuthenticatorJWT(t *testing.T) {
 				expectExactErr: ErrAuthenticatorNotResponsible,
 			},
 			{
+				d:              "should return error saying that authenticator is not responsible for validating the request, as the token provided is not a JWT",
+				r:              &http.Request{Header: http.Header{"X-Custom-Header": []string{"bm90LWp3dA=="}}}, // not-jwt
+				config:         `{"token_from": {"header": "X-Custom-Header"}}`,
+				expectErr:      true,
+				expectExactErr: ErrAuthenticatorNotResponsible,
+			},
+			{
 				d: "should pass because the valid JWT token was provided in a proper location (custom header)",
 				r: &http.Request{Header: http.Header{"X-Custom-Header": []string{gen(keys[1], jwt.MapClaims{
 					"sub": "sub",


### PR DESCRIPTION
We try to use the `jwt` authenticator alongside the `bearer_token` authenticator. Our application receives requests with different token type, both in the `Authorization` header. The `bearer_token` tokens are not JWTs.

Currently this is not possible, as the JWT authenticator declares itself responsible as long as _any_ token is provided at the correct location.

With the proposed change, the JWT authenticator will only declare itself responsible if the token at least looks like a JWT (`<header>.<payload>.<signature>`). That way, a subsequent authenticator can attempt authentication with the same token.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).
