### PR TITLE
Fix cache behavior with TTL 

### DIFF
--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -183,10 +183,11 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session
 	ss := a.c.ToScopeStrategy(cf.ScopeStrategy, "authenticators.oauth2_introspection.config.scope_strategy")
 
 	i := a.tokenFromCache(cf, token, ss)
+	inCache := i != nil
 
 	// If the token can not be found, and the scope strategy is nil, and the required scope list
 	// is not empty, then we can not use the cache.
-	if i == nil {
+	if !inCache {
 		body := url.Values{"token": {token}}
 		if ss == nil {
 			body.Add("scope", strings.Join(cf.Scopes, " "))
@@ -256,7 +257,9 @@ func (a *AuthenticatorOAuth2Introspection) Authenticate(r *http.Request, session
 		}
 	}
 
-	a.tokenToCache(cf, i, token, ss)
+	if !inCache {
+		a.tokenToCache(cf, i, token, ss)
+	}
 
 	if len(i.Extra) == 0 {
 		i.Extra = map[string]interface{}{}

--- a/pipeline/authn/authenticator_oauth2_introspection.go
+++ b/pipeline/authn/authenticator_oauth2_introspection.go
@@ -352,6 +352,14 @@ func (a *AuthenticatorOAuth2Introspection) Config(config json.RawMessage) (*Auth
 		if err != nil {
 			return nil, nil, err
 		}
+
+		// clear cache if previous ttl was longer (or none)
+		if a.tokenCache != nil {
+			if a.cacheTTL == nil || (a.cacheTTL != nil && a.cacheTTL.Seconds() > cacheTTL.Seconds()) {
+				a.tokenCache.Clear()
+			}
+		}
+
 		a.cacheTTL = &cacheTTL
 	}
 


### PR DESCRIPTION
This pull requests fixes a possible issue in the behavior of the oauth2 introspection authenticator cache with TTL.

The problem is any token successfully authenticated is pushed to the cache, even if it the token was already cached. When using cache TTL, this makes possible to keep a token in the cache by forcing the token authentication with a period less than the TTL.

This fix doesn't introduce breaking changes.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

Although this PR fixes the problem above, maybe I'm missing details of the cache implementation or whether stopping re-caching already cached tokens is a desired behavior (e.g. my fix would probably break a LRU cache), so please check that this does not adversely affect the behavior of the cache.