### PR TITLE
feat: introduce auth scheme and jumping to next authentication

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -456,6 +456,11 @@
                   "title": "Header",
                   "type": "string",
                   "description": "The header (case insensitive) that must contain a token for request authentication.\n It can't be set along with query_parameter or cookie."
+                },
+                "auth_scheme": {
+                  "title": "Auth scheme",
+                  "type": "string",
+                  "description": "The auth scheme to accept in case the header is set to Authorization, this is by default set to Bearer."
                 }
               }
             },
@@ -619,6 +624,11 @@
                   "title": "Header",
                   "type": "string",
                   "description": "The header (case insensitive) that must contain a token for request authentication.\n It can't be set along with query_parameter or cookie."
+                },
+                "auth_scheme": {
+                  "title": "Auth scheme",
+                  "type": "string",
+                  "description": "The auth scheme to accept in case the header is set to Authorization, this is by default set to Bearer."
                 }
               }
             },
@@ -842,6 +852,11 @@
                   "title": "Header",
                   "type": "string",
                   "description": "The header (case insensitive) that must contain a token for request authentication.\n It can't be set along with query_parameter or cookie."
+                },
+                "auth_scheme": {
+                  "title": "Auth scheme",
+                  "type": "string",
+                  "description": "The auth scheme to accept in case the header is set to Authorization, this is by default set to Bearer."
                 }
               }
             },

--- a/helper/bearer.go
+++ b/helper/bearer.go
@@ -31,6 +31,7 @@ const (
 
 type BearerTokenLocation struct {
 	Header         *string `json:"header"`
+	AuthScheme     *string `json:"auth_scheme"`
 	QueryParameter *string `json:"query_parameter"`
 	Cookie         *string `json:"cookie"`
 }
@@ -39,7 +40,11 @@ func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation)
 	if tokenLocation != nil {
 		if tokenLocation.Header != nil {
 			if *tokenLocation.Header == defaultAuthorizationHeader {
-				return DefaultBearerTokenFromRequest(r)
+				authScheme := "Bearer"
+				if tokenLocation.AuthScheme != nil {
+					authScheme = *tokenLocation.AuthScheme
+				}
+				return DefaultBearerTokenFromRequest(r, authScheme)
 			}
 			return r.Header.Get(*tokenLocation.Header)
 		} else if tokenLocation.QueryParameter != nil {
@@ -53,13 +58,17 @@ func BearerTokenFromRequest(r *http.Request, tokenLocation *BearerTokenLocation)
 		}
 	}
 
-	return DefaultBearerTokenFromRequest(r)
+	return DefaultBearerTokenFromRequest(r, "Bearer")
 }
 
-func DefaultBearerTokenFromRequest(r *http.Request) string {
+func DefaultBearerTokenFromRequest(r *http.Request, authScheme string) string {
 	token := r.Header.Get(defaultAuthorizationHeader)
+	if authScheme == "" {
+		return token
+	}
+
 	split := strings.SplitN(token, " ", 2)
-	if len(split) != 2 || !strings.EqualFold(strings.ToLower(split[0]), "bearer") {
+	if len(split) != 2 || !strings.EqualFold(strings.ToLower(split[0]), strings.ToLower(authScheme)) {
 		return ""
 	}
 	return split[1]

--- a/helper/bearer_test.go
+++ b/helper/bearer_test.go
@@ -74,4 +74,22 @@ func TestBearerTokenFromRequest(t *testing.T) {
 		token := helper.BearerTokenFromRequest(request, &tokenLocation)
 		assert.Equal(t, expectedToken, token)
 	})
+	t.Run("case=token should be received from authorization header with custom auth scheme if custom location is set to header and token is present", func(t *testing.T) {
+		expectedToken := "token"
+		customHeaderName := "Authorization"
+		customAuthScheme := "AccessToken"
+		request := &http.Request{Header: http.Header{customHeaderName: {customAuthScheme + " " + expectedToken}}}
+		tokenLocation := helper.BearerTokenLocation{Header: &customHeaderName, AuthScheme: &customAuthScheme}
+		token := helper.BearerTokenFromRequest(request, &tokenLocation)
+		assert.Equal(t, expectedToken, token)
+	})
+	t.Run("case=token should be received from authorization header with an empty custom auth scheme if custom location is set to header and token is present", func(t *testing.T) {
+		expectedToken := "token"
+		customHeaderName := "Authorization"
+		customAuthScheme := ""
+		request := &http.Request{Header: http.Header{customHeaderName: {expectedToken}}}
+		tokenLocation := helper.BearerTokenLocation{Header: &customHeaderName, AuthScheme: &customAuthScheme}
+		token := helper.BearerTokenFromRequest(request, &tokenLocation)
+		assert.Equal(t, expectedToken, token)
+	})
 }

--- a/pipeline/authn/authenticator_cookie_session.go
+++ b/pipeline/authn/authenticator_cookie_session.go
@@ -177,6 +177,11 @@ func forwardRequestToSessionStore(r *http.Request, cf AuthenticatorForwardConfig
 
 	defer res.Body.Close()
 
+	// HTTP 406 Not Acceptable
+	if res.StatusCode == http.StatusNotAcceptable {
+		return nil, errors.WithStack(ErrAuthenticatorNotResponsible)
+	}
+
 	if res.StatusCode == http.StatusOK {
 		body, err := ioutil.ReadAll(res.Body)
 		if err != nil {


### PR DESCRIPTION
Some (legacy) application don't use `Bearer` as auth scheme in the `Authorization` header, in the current implementation this means Oathkeeper cannot be used to handle these legacy applications. The bearer token (and cookie) authenticator currently also don't support handling multiple authentication configurations (for example an access token in a header but also in a query parameter).

This change adds an optional `auth_scheme` option to the bearer token authenticator that allows changing the scheme it accepts, it also supports setting an empty scheme for applications that provide a token directly in a header. For compatibility it defaults to `Bearer` when the header is set to `Authorization`. The second change is that the session store endpoint can now return a `HTTP 406 Not Acceptable` response to tell Oathkeeper to jump to the next authentication rule.

This changes were previously discussed on [Slack](https://ory-community.slack.com/archives/C012USDT5QQ/p1645536113144619).

I will add some documentation too about these new features.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
