### PR TITLE
Force MinVersion to use TLS in version 1.3 to improve in security

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -62,7 +62,7 @@ func runProxy(d driver.Driver, n *negroni.Negroni, logger *logrusx.Logger, prom 
 		server := graceful.WithDefaults(&http.Server{
 			Addr:         addr,
 			Handler:      n,
-			TLSConfig:    &tls.Config{Certificates: certs, MinVersion: SSL.VersionTLS13},
+			TLSConfig:    &tls.Config{Certificates: certs, MinVersion: tls.VersionTLS13},
 			ReadTimeout:  d.Configuration().ProxyReadTimeout(),
 			WriteTimeout: d.Configuration().ProxyWriteTimeout(),
 			IdleTimeout:  d.Configuration().ProxyIdleTimeout(),
@@ -107,7 +107,7 @@ func runAPI(d driver.Driver, n *negroni.Negroni, logger *logrusx.Logger, prom *m
 		server := graceful.WithDefaults(&http.Server{
 			Addr:         addr,
 			Handler:      n,
-			TLSConfig:    &tls.Config{Certificates: certs, MinVersion: SSL.VersionTLS13},
+			TLSConfig:    &tls.Config{Certificates: certs, MinVersion: tls.VersionTLS13},
 			ReadTimeout:  d.Configuration().APIReadTimeout(),
 			WriteTimeout: d.Configuration().APIWriteTimeout(),
 			IdleTimeout:  d.Configuration().APIIdleTimeout(),

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -62,7 +62,7 @@ func runProxy(d driver.Driver, n *negroni.Negroni, logger *logrusx.Logger, prom 
 		server := graceful.WithDefaults(&http.Server{
 			Addr:         addr,
 			Handler:      n,
-			TLSConfig:    &tls.Config{Certificates: certs},
+			TLSConfig:    &tls.Config{Certificates: certs, MinVersion: SSL.VersionTLS13},
 			ReadTimeout:  d.Configuration().ProxyReadTimeout(),
 			WriteTimeout: d.Configuration().ProxyWriteTimeout(),
 			IdleTimeout:  d.Configuration().ProxyIdleTimeout(),
@@ -107,7 +107,7 @@ func runAPI(d driver.Driver, n *negroni.Negroni, logger *logrusx.Logger, prom *m
 		server := graceful.WithDefaults(&http.Server{
 			Addr:         addr,
 			Handler:      n,
-			TLSConfig:    &tls.Config{Certificates: certs},
+			TLSConfig:    &tls.Config{Certificates: certs, MinVersion: SSL.VersionTLS13},
 			ReadTimeout:  d.Configuration().APIReadTimeout(),
 			WriteTimeout: d.Configuration().APIWriteTimeout(),
 			IdleTimeout:  d.Configuration().APIIdleTimeout(),


### PR DESCRIPTION
So by default, that resource uses TLS version 1.0, which is not secure. The recommendation by OWASP is to use version 1.3. 

Please look at the following cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html

#security 
