### PR TITLE
Add support for compressed hydrator #988

### DIFF
--- a/pipeline/mutate/mutator_hydrator.go
+++ b/pipeline/mutate/mutator_hydrator.go
@@ -27,6 +27,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"

--- a/pipeline/mutate/mutator_hydrator.go
+++ b/pipeline/mutate/mutator_hydrator.go
@@ -22,6 +22,8 @@ package mutate
 
 import (
 	"bytes"
+	"compress/gzip"
+	"compress/zlib"
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
@@ -51,6 +53,8 @@ const (
 	ErrNoCredentialsProvided            = "No credentials were provided in mutator configuration"
 	contentTypeHeaderKey                = "Content-Type"
 	contentTypeJSONHeaderValue          = "application/json"
+	acceptEncodingHeaderKey							= "Accept-Encoding"
+	acceptEncodingHeaderValue						= "gzip, deflate"
 )
 
 type MutatorHydrator struct {
@@ -188,6 +192,7 @@ func (a *MutatorHydrator) Mutate(r *http.Request, session *authn.AuthenticationS
 		req.SetBasicAuth(credentials.Username, credentials.Password)
 	}
 	req.Header.Set(contentTypeHeaderKey, contentTypeJSONHeaderValue)
+	req.Header.Set(acceptEncodingHeaderKey, acceptEncodingHeaderValue)
 
 	var client *http.Client
 
@@ -234,9 +239,22 @@ func (a *MutatorHydrator) Mutate(r *http.Request, session *authn.AuthenticationS
 	default:
 		return errors.New(ErrNon200ResponseFromAPI)
 	}
+	
+	// Handle compressed data
+	var reader io.ReadCloser
+	switch res.Header.Get("Content-Encoding") {
+	case "gzip":
+		reader, err = gzip.NewReader(res.Body)
+		defer reader.Close()
+	case "deflate":
+		reader, err = zlib.NewReader(res.Body)
+		defer reader.Close()
+	default:
+		reader = res.Body
+	}
 
 	sessionFromUpstream := authn.AuthenticationSession{}
-	err = json.NewDecoder(res.Body).Decode(&sessionFromUpstream)
+	err = json.NewDecoder(reader).Decode(&sessionFromUpstream)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
Oathkeeper doesn't restrict the encoding it accepts when making the hydrator HTTP call. If the hydrator is configured with compression it will try to parse the compressed string directly as JSON and fail. 

This PR restricts the accepted encoding types to gzip and deflate, and add the ability to handle those encodings.
I experimented with brotli as well, but that would require CGO, which seemed too big of a change.

## Related issue(s)

#988

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
I've already deployed this fix in our production environment and it work. 
Don't think we need to update any docs as this fixes a low level bug.

