### PR TITLE
chore: remove double tabs from Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ endef
 $(foreach dep, $(GO_DEPENDENCIES), $(eval $(call make-go-dependency, $(dep))))
 
 node_modules: package-lock.json
-		npm ci
-		touch node_modules
+	npm ci
+	touch node_modules
 
 .bin/clidoc: go.mod
-		go build -o .bin/clidoc ./cmd/clidoc/.
+	go build -o .bin/clidoc ./cmd/clidoc/.
 
 .bin/goimports: Makefile
 	GOBIN=$(shell pwd)/.bin go install golang.org/x/tools/cmd/goimports@latest
@@ -29,59 +29,59 @@ node_modules: package-lock.json
 # Formats the code
 .PHONY: format
 format: .bin/goimports node_modules
-		goimports -w --local github.com/ory .
-		gofmt -l -s -w .
-		npm exec -- prettier --write .
+	goimports -w --local github.com/ory .
+	gofmt -l -s -w .
+	npm exec -- prettier --write .
 
 .bin/ory: Makefile
-		bash <(curl https://raw.githubusercontent.com/ory/meta/master/install.sh) -b .bin ory v0.1.22
-		touch -a -m .bin/ory
+	bash <(curl https://raw.githubusercontent.com/ory/meta/master/install.sh) -b .bin ory v0.1.22
+	touch -a -m .bin/ory
 
 # Generates the SDK
 .PHONY: sdk
 sdk: .bin/swagger .bin/ory node_modules
-		rm -rf internal/httpclient
-		mkdir -p internal/httpclient
+	rm -rf internal/httpclient
+	mkdir -p internal/httpclient
 
-		swagger generate spec -m -o spec/swagger.json \
-			-c github.com/ory/oathkeeper \
-			-c github.com/ory/x/healthx
-		ory dev swagger sanitize ./spec/swagger.json
-		swagger validate ./spec/swagger.json
-		CIRCLE_PROJECT_USERNAME=ory CIRCLE_PROJECT_REPONAME=oathkeeper \
-				ory dev openapi migrate \
-					--health-path-tags metadata \
-					-p https://raw.githubusercontent.com/ory/x/master/healthx/openapi/patch.yaml \
-					-p file://.schema/openapi/patches/meta.yaml \
-					spec/swagger.json spec/api.json
+	swagger generate spec -m -o spec/swagger.json \
+		-c github.com/ory/oathkeeper \
+		-c github.com/ory/x/healthx
+	ory dev swagger sanitize ./spec/swagger.json
+	swagger validate ./spec/swagger.json
+	CIRCLE_PROJECT_USERNAME=ory CIRCLE_PROJECT_REPONAME=oathkeeper \
+		ory dev openapi migrate \
+			--health-path-tags metadata \
+			-p https://raw.githubusercontent.com/ory/x/master/healthx/openapi/patch.yaml \
+			-p file://.schema/openapi/patches/meta.yaml \
+			spec/swagger.json spec/api.json
 
-		swagger generate client -f ./spec/swagger.json -t internal/httpclient -A Ory_Oathkeeper
+	swagger generate client -f ./spec/swagger.json -t internal/httpclient -A Ory_Oathkeeper
 
-		make --no-print-dir format
+	make --no-print-dir format
 
 .PHONY: install-stable
 install-stable:
-		OATHKEEPER_LATEST=$$(git describe --abbrev=0 --tags)
-		git checkout $$OATHKEEPER_LATEST
-		GO111MODULE=on go install \
-				-ldflags "-X github.com/ory/oathkeeper/x.Version=$$OATHKEEPER_LATEST -X github.com/ory/oathkeeper/x.Date=`TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ'` -X github.com/ory/oathkeeper/x.Commit=`git rev-parse HEAD`" \
-				.
-		git checkout master
+	OATHKEEPER_LATEST=$$(git describe --abbrev=0 --tags)
+	git checkout $$OATHKEEPER_LATEST
+	GO111MODULE=on go install \
+		-ldflags "-X github.com/ory/oathkeeper/x.Version=$$OATHKEEPER_LATEST -X github.com/ory/oathkeeper/x.Date=`TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ'` -X github.com/ory/oathkeeper/x.Commit=`git rev-parse HEAD`" \
+		.
+	git checkout master
 
 .PHONY: install
 install:
-		GO111MODULE=on go install .
+	GO111MODULE=on go install .
 
 .PHONY: docker
 docker:
-		CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=amd64 go build
-		docker build -t oryd/oathkeeper:dev .
-		docker build -t oryd/oathkeeper:dev-alpine -f Dockerfile-alpine .
-		rm oathkeeper
+	CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=amd64 go build
+	docker build -t oryd/oathkeeper:dev .
+	docker build -t oryd/oathkeeper:dev-alpine -f Dockerfile-alpine .
+	rm oathkeeper
 
 docs/cli: .bin/clidoc
-		clidoc .
+	clidoc .
 
 .PHONY: post-release
 post-release:
-		echo "nothing to do"
+	echo "nothing to do"


### PR DESCRIPTION
Reduces the indentation of Makefiles from double tabs to single tabs.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).
