### PR TITLE
chore: remove listx dependency

### DIFF
--- a/go_mod_shadow.go
+++ b/go_mod_shadow.go
@@ -12,7 +12,6 @@ import (
 	_ "github.com/gorilla/websocket"
 
 	_ "github.com/ory/go-acc"
-	_ "github.com/ory/x/tools/listx"
 
 	_ "github.com/ory/cli"
 )


### PR DESCRIPTION
listx doesn't seem to be used anywhere in this repo. Looking at https://github.com/ory/x/blob/master/tools/listx/main.go, it seem replacable with `find -f -name "*.go" -not -path "./vendor/"`. Given that there isn't a vendor folder anymore, this seems obsolete altogether.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
