### PR TITLE
fix: align proxy mode log level with decision mode log level for access request granted log

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -100,7 +100,7 @@ func (d *Proxy) RoundTrip(r *http.Request) (*http.Response, error) {
 			d.r.Logger().
 				WithField("granted", true).
 				WithFields(fields).
-				Warn("Access request granted")
+				Info("Access request granted")
 		}
 
 		return res, err


### PR DESCRIPTION
After turning on proxy mode for oathkeeper, I started to see lot of warning level logs related to "Access request granted" which is supposed to be Info level log like in decision mode. Therefore aligning the log level to Info for access request granted log in proxy mode