### PR TITLE
Allow otel tracing provider in config

### DIFF
--- a/spec/config.schema.json
+++ b/spec/config.schema.json
@@ -1851,8 +1851,8 @@
       "properties": {
         "provider": {
           "type": "string",
-          "description": "Set this to the tracing backend you wish to use. Supports Jaeger, Zipkin, DataDog and elastic-apm. If omitted or empty, tracing will be disabled. Use environment variables to configure DataDog (see https://docs.datadoghq.com/tracing/setup/go/#configuration).",
-          "enum": ["zipkin", "jaeger", "datadog", "elastic-apm"],
+          "description": "Set this to the tracing backend you wish to use. Supports Jaeger, Zipkin, DataDog, elastic-apm and open telemetry. If omitted or empty, tracing will be disabled. Use environment variables to configure DataDog (see https://docs.datadoghq.com/tracing/setup/go/#configuration).",
+          "enum": ["zipkin", "jaeger", "datadog", "elastic-apm", "otel"],
           "examples": ["zipkin"]
         },
         "service_name": {


### PR DESCRIPTION
This PR aims to allow usage of the open telemetry tracing provider of [ory/x](https://github.com/ory/x/blob/master/tracing/tracer.go#L179) in oathkeeper. As ory/x has been [updated to a recent version](https://github.com/ory/oathkeeper/issues/888#issuecomment-1003710287) in #999, this came down to a small change in the configuration schema.

## Related issue(s)
- Fixed #888 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [] I have added tests that prove my fix is effective or that my feature
      works.
- [] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments


