### PR TITLE
fix: add caching to koanf config to fix performance regression

### DIFF
--- a/driver/configuration/provider_koanf.go
+++ b/driver/configuration/provider_koanf.go
@@ -6,6 +6,7 @@ package configuration
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -13,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/dgraph-io/ristretto"
 
 	"github.com/google/uuid"
 	"github.com/knadh/koanf"
@@ -40,11 +43,7 @@ type (
 		l      *logrusx.Logger
 		ctx    context.Context
 
-		enabledMutex sync.RWMutex
-		enabledCache map[uint64]bool
-
-		configMutex sync.RWMutex
-		configCache map[uint64]json.RawMessage
+		configValidationCache *ristretto.Cache
 
 		subscriptions subscriptions
 	}
@@ -60,13 +59,24 @@ type (
 var _ Provider = new(KoanfProvider)
 
 func NewKoanfProvider(ctx context.Context, flags *pflag.FlagSet, l *logrusx.Logger, opts ...configx.OptionModifier) (kp *KoanfProvider, err error) {
+	maxItems := int64(5000)
+	cache, _ := ristretto.NewCache(&ristretto.Config{
+		NumCounters:        maxItems * 10,
+		MaxCost:            maxItems,
+		BufferItems:        64,
+		Metrics:            false,
+		IgnoreInternalCost: true,
+		Cost: func(value interface{}) int64 {
+			return 1
+		},
+	})
+
 	kp = &KoanfProvider{
 		ctx: ctx,
 		l:   l,
 
-		enabledCache:  make(map[uint64]bool),
-		configCache:   make(map[uint64]json.RawMessage),
-		subscriptions: subscriptions{data: make(map[SubscriptionID]callback)},
+		configValidationCache: cache,
+		subscriptions:         subscriptions{data: make(map[SubscriptionID]callback)},
 	}
 	kp.source, err = configx.New(
 		ctx,
@@ -283,6 +293,20 @@ func (v *KoanfProvider) pipelineIsEnabled(prefix, id string) bool {
 	return v.source.Bool(fmt.Sprintf("%s.%s.enabled", prefix, id))
 }
 
+func (v *KoanfProvider) hashPipelineConfig(prefix, id string, marshalled []byte) string {
+	slices := [][]byte{
+		[]byte(prefix),
+		[]byte(id),
+		marshalled,
+	}
+
+	var hashSlices []byte
+	for _, s := range slices {
+		hashSlices = append(hashSlices, s...)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(hashSlices))
+}
+
 func (v *KoanfProvider) PipelineConfig(prefix, id string, override json.RawMessage, dest interface{}) error {
 	if dest == nil {
 		return nil
@@ -302,8 +326,13 @@ func (v *KoanfProvider) PipelineConfig(prefix, id string, override json.RawMessa
 		return errors.WithStack(err)
 	}
 
-	if err = v.validatePipelineConfig(prefix, id, marshalled); err != nil {
-		return errors.WithStack(err)
+	hash := v.hashPipelineConfig(prefix, id, marshalled)
+	item, found := v.configValidationCache.Get(hash)
+	if !found || !item.(bool) {
+		if err = v.validatePipelineConfig(prefix, id, marshalled); err != nil {
+			return errors.WithStack(err)
+		}
+		v.configValidationCache.Set(hash, true, 0)
 	}
 
 	if err := json.NewDecoder(bytes.NewBuffer(marshalled)).Decode(dest); err != nil {


### PR DESCRIPTION
Fix https://github.com/ory/oathkeeper/issues/1033 of a performance regression in v0.40.0.
It seems linked to a perpetual config reloading, leading to a lot of JSON marshalling being CPU intensive.
Adding back in-memory caching, as we used to have for Viper configuration.

## Related issue(s)

Fixes #1033

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
