### PR TITLE
feat: basic authenticator (#254)

### DIFF
--- a/.schemas/authenticators.basic.schema.json
+++ b/.schemas/authenticators.basic.schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://raw.githubusercontent.com/ory/oathkeeper/master/.schemas/authenticators.basic.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Basic Authenticator Configuration",
+  "description": "This section is optional when the authenticator is disabled.",
+  "properties": {
+    "credentials": {
+      "title": "Credentials",
+      "type": "string",
+      "description": "The Basic credentials in form of 'username:password' hashed with SHA256"
+    }
+  },
+  "required": ["credentials"],
+  "additionalProperties": false
+}

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -310,6 +310,20 @@
       },
       "additionalProperties": false
     },
+    "configAuthenticatorsBasic": {
+      "type": "object",
+      "title": "Basic Authenticator Configuration",
+      "description": "This section is optional when the authenticator is disabled.",
+      "properties": {
+        "credentials": {
+          "title": "Credentials",
+          "type": "string",
+          "description": "The Basic credentials in form of 'username:password' hashed with SHA256"
+        }
+      },
+      "required": ["credentials"],
+      "additionalProperties": false
+    },
     "configAuthenticatorsCookieSession": {
       "type": "object",
       "title": "Cookie Session Authenticator Configuration",
@@ -995,6 +1009,17 @@
             },
             "config": {
               "$ref": "#/definitions/configAuthenticatorsAnonymous"
+            }
+          }
+        },
+        "basic": {
+          "title": "Basic",
+          "description": "The [`basic` authenticator](https://www.ory.sh/docs/oathkeeper/pipeline/authn#basic).",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "$ref": "#/definitions/configAuthenticatorsBasic"
             }
           }
         },

--- a/driver/registry_memory.go
+++ b/driver/registry_memory.go
@@ -369,6 +369,7 @@ func (r *RegistryMemory) prepareAuthn() {
 		interim := []authn.Authenticator{
 			authn.NewAuthenticatorAnonymous(r.c),
 			authn.NewAuthenticatorCookieSession(r.c),
+			authn.NewAuthenticatorBasic(r.c),
 			authn.NewAuthenticatorBearerToken(r.c),
 			authn.NewAuthenticatorJWT(r.c, r),
 			authn.NewAuthenticatorNoOp(r.c),

--- a/pipeline/authn/authenticator_basic.go
+++ b/pipeline/authn/authenticator_basic.go
@@ -1,0 +1,95 @@
+// Copyright © 2022 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package authn
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/ory/oathkeeper/driver/configuration"
+	"github.com/ory/oathkeeper/helper"
+	"github.com/ory/oathkeeper/pipeline"
+)
+
+type AuthenticatorBasicConfiguration struct {
+	Credentials string `json:"credentials"`
+}
+
+type AuthenticatorBasic struct {
+	c configuration.Provider
+}
+
+func NewAuthenticatorBasic(
+	c configuration.Provider,
+) *AuthenticatorBasic {
+	return &AuthenticatorBasic{
+		c: c,
+	}
+}
+
+func (a *AuthenticatorBasic) GetID() string {
+	return "basic"
+}
+
+func (a *AuthenticatorBasic) Validate(config json.RawMessage) error {
+	if !a.c.AuthenticatorIsEnabled(a.GetID()) {
+		return NewErrAuthenticatorNotEnabled(a)
+	}
+
+	_, err := a.Config(config)
+	return err
+}
+
+func (a *AuthenticatorBasic) Config(config json.RawMessage) (*AuthenticatorBasicConfiguration, error) {
+	var c AuthenticatorBasicConfiguration
+	if err := a.c.AuthenticatorConfig(a.GetID(), config, &c); err != nil {
+		return nil, NewErrAuthenticatorMisconfigured(a, err)
+	}
+
+	return &c, nil
+}
+
+func (a *AuthenticatorBasic) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
+	cf, err := a.Config(config)
+	if err != nil {
+		return err
+	}
+
+	authorization := r.Header.Get("Authorization")
+	if authorization == "" {
+		return helper.ErrUnauthorized
+	}
+
+	token, err := BasicTokenFromHeader(authorization)
+	if err != nil {
+		return helper.ErrUnauthorized.WithReason("Basic token is not correctly base64 encoded")
+	}
+
+	h := sha256.New()
+	h.Write([]byte(token))
+	hash := hex.EncodeToString(h.Sum(nil))
+
+	if hash == cf.Credentials {
+		return nil
+	}
+
+	return helper.ErrUnauthorized
+}
+
+func BasicTokenFromHeader(header string) (string, error) {
+	split := strings.SplitN(header, " ", 2)
+	if len(split) != 2 || !strings.EqualFold(strings.ToLower(split[0]), "basic") {
+		return "", nil
+	}
+	rawDecodedText, err := base64.StdEncoding.DecodeString(split[1])
+	if err != nil {
+		return "", err
+	}
+
+	return string(rawDecodedText), nil
+}

--- a/pipeline/authn/authenticator_basic_test.go
+++ b/pipeline/authn/authenticator_basic_test.go
@@ -1,0 +1,68 @@
+// Copyright © 2022 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package authn_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/ory/oathkeeper/helper"
+	"github.com/ory/oathkeeper/internal"
+	"github.com/ory/oathkeeper/pipeline/authn"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthenticatorBasic(t *testing.T) {
+	t.Parallel()
+	conf := internal.NewConfigurationWithDefaults()
+	reg := internal.NewRegistry(conf)
+
+	session := new(authn.AuthenticationSession)
+
+	a, err := reg.PipelineAuthenticator("basic")
+	require.NoError(t, err)
+	assert.Equal(t, "basic", a.GetID())
+
+	t.Run("method=authenticate/case=empty auth", func(t *testing.T) {
+		err := a.Authenticate(
+			&http.Request{Header: http.Header{}},
+			session,
+			json.RawMessage(`{"credentials":"bc842c31a9e54efe320d30d948be61291f3ceee4766e36ab25fa65243cd76e0e"}`),
+			nil)
+			require.Error(t, err)
+			assert.EqualError(t, err, helper.ErrUnauthorized.Error())
+	})
+
+	t.Run("method=authenticate/case=incorrect base64 token", func(t *testing.T) {
+		err := a.Authenticate(
+			&http.Request{Header: http.Header{ "Authorization": {"Basic " + "123"} }},
+			session,
+			json.RawMessage(`{"credentials":"bc842c31a9e54efe320d30d948be61291f3ceee4766e36ab25fa65243cd76e0e"}`),
+			nil)
+			require.Error(t, err)
+			assert.EqualError(t, err, helper.ErrUnauthorized.Error())
+	})
+
+	t.Run("method=authenticate/case=incorrect auth", func(t *testing.T) {
+		err := a.Authenticate(
+			&http.Request{Header: http.Header{ "Authorization": {"Basic " + "dXNlcjpwYXNz"} }},
+			session,
+			json.RawMessage(`{"credentials":"bc842c31a9e54efe320d30d948be61291f3ceee4766e36ab25fa65243cd76e0e"}`),
+			nil)
+			require.Error(t, err)
+			assert.EqualError(t, err, helper.ErrUnauthorized.Error())
+	})
+
+	t.Run("method=authenticate/case=correct auth", func(t *testing.T) {
+		err := a.Authenticate(
+			&http.Request{Header: http.Header{ "Authorization": {"Basic " + "dXNlcm5hbWU6cGFzc3dvcmQ="} }},
+			session,
+			json.RawMessage(`{"credentials":"bc842c31a9e54efe320d30d948be61291f3ceee4766e36ab25fa65243cd76e0e"}`),
+			nil)
+			require.NoError(t, err)
+	})
+}

--- a/spec/config.schema.json
+++ b/spec/config.schema.json
@@ -354,6 +354,20 @@
       },
       "additionalProperties": false
     },
+    "configAuthenticatorsBasic": {
+      "type": "object",
+      "title": "Basic Authenticator Configuration",
+      "description": "This section is optional when the authenticator is disabled.",
+      "properties": {
+        "credentials": {
+          "title": "Credentials",
+          "type": "string",
+          "description": "The Basic credentials in form of 'username:password' hashed with SHA256"
+        }
+      },
+      "required": ["credentials"],
+      "additionalProperties": false
+    },
     "configAuthenticatorsCookieSession": {
       "type": "object",
       "title": "Cookie Session Authenticator Configuration",
@@ -1287,6 +1301,17 @@
             },
             "config": {
               "$ref": "#/definitions/configAuthenticatorsAnonymous"
+            }
+          }
+        },
+        "basic": {
+          "title": "Basic",
+          "description": "The [`basic` authenticator](https://www.ory.sh/docs/oathkeeper/pipeline/authn#basic).",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "$ref": "#/definitions/configAuthenticatorsBasic"
             }
           }
         },

--- a/spec/pipeline/authenticators.basic.schema.json
+++ b/spec/pipeline/authenticators.basic.schema.json
@@ -1,0 +1,5 @@
+{
+  "$id": "/.schema/authenticators.basic.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "/.schema/config.schema.json#/definitions/configAuthenticatorsBasic"
+}


### PR DESCRIPTION
Basic authentication is sometimes useful for content that should not be publicly accessible, but does not need the level of security of other authentication methods. Ex. in-development web pages, temporarily hidden content.

It should work in combination with `WWW-Authenticate` error handler.

## Related issue(s)

[#254](https://github.com/ory/oathkeeper/issues/254)
This issue is quite old, but I today stumbled upon situation where basic authn could be useful to me - so I've decided to implement it.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further comments

I will prepare a PR to docs if this feat gets approved.