### PR TITLE
Fix HEAD not being handled correctly in decision API

### DIFF
--- a/api/decision.go
+++ b/api/decision.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/ory/oathkeeper/pipeline/authn"
@@ -41,13 +42,21 @@ func NewJudgeHandler(r decisionHandlerRegistry) *DecisionHandler {
 
 func (h *DecisionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	if len(r.URL.Path) >= len(DecisionPath) && r.URL.Path[:len(DecisionPath)] == DecisionPath {
-		r.Method = x.OrDefaultString(r.Header.Get(xForwardedMethod), r.Method)
-		r.URL.Scheme = x.OrDefaultString(r.Header.Get(xForwardedProto),
-			x.IfThenElseString(r.TLS != nil, "https", "http"))
-		r.URL.Host = x.OrDefaultString(r.Header.Get(xForwardedHost), r.Host)
-		r.URL.Path = x.OrDefaultString(strings.SplitN(r.Header.Get(xForwardedUri), "?", 2)[0], r.URL.Path[len(DecisionPath):])
-
-		h.decisions(w, r)
+		// Copy the request information, instead of modifing the incoming request directly.
+		// This is nevessary because the middleware would otherwise use e.g. the method from "X-Forwarded-Method" for the response
+		// although the original request had another method, which leads to problem with the HEAD method.
+		// For more information see: https://github.com/thomseddon/traefik-forward-auth/issues/156
+		forwardedReq := &http.Request{
+			Method: x.OrDefaultString(r.Header.Get(xForwardedMethod), r.Method),
+			URL: &url.URL{
+				Scheme: x.OrDefaultString(r.Header.Get(xForwardedProto),
+					x.IfThenElseString(r.TLS != nil, "https", "http")),
+				Host: x.OrDefaultString(r.Header.Get(xForwardedHost), r.Host),
+				Path: x.OrDefaultString(strings.SplitN(r.Header.Get(xForwardedUri), "?", 2)[0], r.URL.Path[len(DecisionPath):]),
+			},
+			Header: r.Header,
+		}
+		h.decisions(w, forwardedReq)
 	} else {
 		next(w, r)
 	}


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Currently oathkeeper cannot handle HEAD requests from traefik Forward Auth middleware, because oathkeeper copies the forwarded method into the incoming request. With this fix HEAD requests now also work.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

Currently when using the oathkeeper decision API together with traefik forward auth, HEAD requests cannot be handled currectly and will result in a timeout on the traefik side. This is because oathkeeper replaces the method of the incoming request with the method in the `X-Forwarded-Method` header and because HEAD requests *must not* contain a body it will not be written by go (https://github.com/golang/go/blob/9123221ccf3c80c741ead5b6f2e960573b1676b9/src/net/http/server.go#L377). But as traefik sends a `GET` requests for forward auth it expects a body back (https://github.com/traefik/traefik/blob/e54ee89330a800d509da7b11b46a6ecbb331e791/pkg/middlewares/auth/forward.go#L129), therefore traefik times out, as no body is sent by oathkeeper.

### Reproduce
Although not the simplest setup, this is how I noticed this bug:

1. setup oathkeeper with any rule you want (e.g. allow everything)
2. setup the docker registry (https://github.com/distribution/distribution)
3. setup traefik to point to the docker registry with a forward auth middleware to oathkeeper
4. do a docker push with a image of your choice to the docker registry
5. the push should retry multiple times and than fail with a 500 internal Server error
6. the traefik logs should indicate timeout issues

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

For a more in depth writeup of the problem: https://github.com/thomseddon/traefik-forward-auth/issues/156