### PR TITLE
fix: release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
       - uses: ory/ci/sdk/release@master
         with:
           token: ${{ secrets.ORY_BOT_PAT }}
+          swag-spec-location: spec/swagger.json
 
   release:
     name: Generate release

--- a/.schema/version.schema.json
+++ b/.schema/version.schema.json
@@ -1,9 +1,22 @@
 {
   "$id": "https://github.com/ory/oathkeeper/.schema/versions.config.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "All Versions of the ORY Oathkeeper Configuration",
-  "type": "object",
   "oneOf": [
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
+              "const": "v0.40.1"
+            }
+          },
+          "required": ["version"]
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/ory/oathkeeper/v0.40.1/spec/config.schema.json"
+        }
+      ]
+    },
     {
       "allOf": [
         {
@@ -167,5 +180,7 @@
         }
       ]
     }
-  ]
+  ],
+  "title": "All Versions of the ORY Oathkeeper Configuration",
+  "type": "object"
 }

--- a/.schema/version.schema.json
+++ b/.schema/version.schema.json
@@ -9,6 +9,21 @@
         {
           "properties": {
             "version": {
+              "const": "v0.40.0"
+            }
+          },
+          "required": ["version"]
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/ory/oathkeeper/v0.40.0/spec/config.schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "version": {
               "const": "v0.38.4-beta.1"
             }
           },
@@ -125,7 +140,6 @@
       ]
     },
     {
-      "description": "This is the fallback to the latest version (the first one in this schema) in case no version is specified.",
       "allOf": [
         {
           "oneOf": [


### PR DESCRIPTION
I manually added the missing schema references for v0.40.0 and v0.40.1. The next release _should_ go through completely 🤞