### PR TITLE
feat: allow for easily matching rules using path prefixes

### DIFF
--- a/driver/configuration/config_keys.go
+++ b/driver/configuration/config_keys.go
@@ -24,6 +24,7 @@ const (
 	PrometheusServeCollapseRequestPaths Key = "serve.prometheus.collapse_request_paths"
 	AccessRuleRepositories              Key = "access_rules.repositories"
 	AccessRuleMatchingStrategy          Key = "access_rules.matching_strategy"
+	AcccessRulePrefixMatchingEnabled    Key = "access_rules.prefix_matching_enabled"
 )
 
 // Authorizers

--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -28,6 +28,7 @@ type MatchingStrategy string
 const (
 	Regexp                  MatchingStrategy = "regexp"
 	Glob                    MatchingStrategy = "glob"
+	Prefix                  MatchingStrategy = "prefix"
 	DefaultMatchingStrategy                  = Regexp
 )
 

--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -28,7 +28,6 @@ type MatchingStrategy string
 const (
 	Regexp                  MatchingStrategy = "regexp"
 	Glob                    MatchingStrategy = "glob"
-	Prefix                  MatchingStrategy = "prefix"
 	DefaultMatchingStrategy                  = Regexp
 )
 
@@ -59,6 +58,7 @@ type Provider interface {
 
 	AccessRuleRepositories() []url.URL
 	AccessRuleMatchingStrategy() MatchingStrategy
+	AcccessRulePrefixMatchingEnabled() bool
 
 	ProxyServeAddress() string
 	APIServeAddress() string

--- a/driver/configuration/provider_koanf.go
+++ b/driver/configuration/provider_koanf.go
@@ -172,6 +172,11 @@ func (v *KoanfProvider) AccessRuleMatchingStrategy() MatchingStrategy {
 	return MatchingStrategy(v.source.String(AccessRuleMatchingStrategy))
 }
 
+// AcccessRulePrefixMatching returns if prefix matching should be used.
+func (v *KoanfProvider) AcccessRulePrefixMatchingEnabled() bool {
+	return v.source.Bool(AcccessRulePrefixMatchingEnabled)
+}
+
 func (v *KoanfProvider) CORSEnabled(iface string) bool {
 	_, enabled := v.CORS(iface)
 	return enabled

--- a/internal/config/.oathkeeper.yaml
+++ b/internal/config/.oathkeeper.yaml
@@ -103,6 +103,8 @@ access_rules:
     - https://path-to-my-rules/rules.json
   # Optional fields describing matching strategy, defaults to "regexp".
   matching_strategy: glob
+  # Optional fields describing if rules should be matched using path prefixes, defaults to false.
+  prefix_matching_enabled: false
 
 errors:
   fallback:

--- a/rule/matcher.go
+++ b/rule/matcher.go
@@ -9,7 +9,7 @@ import (
 )
 
 type (
-	Protocol int
+	Protocol string
 
 	Matcher interface {
 		Match(ctx context.Context, method string, u *url.URL, protocol Protocol) (*Rule, error)
@@ -17,6 +17,6 @@ type (
 )
 
 const (
-	ProtocolHTTP Protocol = iota
-	ProtocolGRPC
+	ProtocolHTTP Protocol = "http"
+	ProtocolGRPC Protocol = "grpc"
 )

--- a/rule/matcher_test.go
+++ b/rule/matcher_test.go
@@ -99,6 +99,45 @@ var testRulesGlob = []Rule{
 	},
 }
 
+var testRulesPrefix = []Rule{
+	{
+		ID:             "foo1",
+		Match:          &Match{URL: "https://localhost:1234/foo", Methods: []string{"POST"}},
+		Description:    "Create users rule",
+		Authorizer:     Handler{Handler: "allow", Config: []byte(`{"type":"any"}`)},
+		Authenticators: []Handler{{Handler: "anonymous", Config: []byte(`{"name":"anonymous1"}`)}},
+		Mutators:       []Handler{{Handler: "id_token", Config: []byte(`{"issuer":"anything"}`)}},
+		Upstream:       Upstream{URL: "http://localhost:1235/", StripPath: "/bar", PreserveHost: true},
+	},
+	{
+		ID:             "foo2",
+		Match:          &Match{URL: "https://localhost:34/baz", Methods: []string{"GET"}},
+		Description:    "Get users rule",
+		Authorizer:     Handler{Handler: "deny", Config: []byte(`{"type":"any"}`)},
+		Authenticators: []Handler{{Handler: "oauth2_introspection", Config: []byte(`{"name":"anonymous1"}`)}},
+		Mutators:       []Handler{{Handler: "id_token", Config: []byte(`{"issuer":"anything"}`)}},
+		Upstream:       Upstream{URL: "http://localhost:333/", StripPath: "/foo", PreserveHost: false},
+	},
+	{
+		ID:             "foo3",
+		Match:          &Match{URL: "https://localhost:343/baz", Methods: []string{"GET"}},
+		Description:    "Get users rule",
+		Authorizer:     Handler{Handler: "deny"},
+		Authenticators: []Handler{{Handler: "oauth2_introspection"}},
+		Mutators:       []Handler{{Handler: "id_token"}},
+		Upstream:       Upstream{URL: "http://localhost:3333/", StripPath: "/foo", PreserveHost: false},
+	},
+	{
+		ID:             "grpc1",
+		Match:          &MatchGRPC{Authority: "baz.example.com", FullMethod: "grpc.api/Call"},
+		Description:    "gRPC Rule",
+		Authorizer:     Handler{Handler: "allow", Config: []byte(`{"type":"any"}`)},
+		Authenticators: []Handler{{Handler: "anonymous", Config: []byte(`{"name":"anonymous1"}`)}},
+		Mutators:       []Handler{{Handler: "id_token", Config: []byte(`{"issuer":"anything"}`)}},
+		Upstream:       Upstream{URL: "http://bar.example.com/", PreserveHost: false},
+	},
+}
+
 func TestMatcher(t *testing.T) {
 	type m interface {
 		Matcher
@@ -188,6 +227,40 @@ func TestMatcher(t *testing.T) {
 
 			t.Run("case=updated", func(t *testing.T) {
 				testMatcher(t, matcher, "GET", "https://localhost:34/baz", ProtocolHTTP, false, &testRulesGlob[1])
+				testMatcher(t, matcher, "POST", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
+				testMatcher(t, matcher, "DELETE", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
+			})
+		})
+		t.Run(fmt.Sprintf("prefix matcher=%s", name), func(t *testing.T) {
+			require.NoError(t, matcher.SetMatchingStrategy(context.Background(), configuration.Prefix))
+			require.NoError(t, matcher.Set(context.Background(), []Rule{}))
+			t.Run("case=empty", func(t *testing.T) {
+				testMatcher(t, matcher, "GET", "https://localhost:34/baz", ProtocolHTTP, true, nil)
+				testMatcher(t, matcher, "POST", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
+				testMatcher(t, matcher, "DELETE", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
+			})
+
+			require.NoError(t, matcher.Set(context.Background(), testRulesPrefix))
+
+			t.Run("case=created", func(t *testing.T) {
+				testMatcher(t, matcher, "POST", "https://localhost:1234/foo", ProtocolHTTP, false, &testRulesPrefix[0])
+				testMatcher(t, matcher, "GET", "https://localhost:34/baz", ProtocolHTTP, false, &testRulesPrefix[1])
+				testMatcher(t, matcher, "DELETE", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
+				testMatcher(t, matcher, "POST", "grpc://bar.example.com/grpc.api/Call", ProtocolGRPC, false, &testRulesPrefix[3])
+			})
+
+			t.Run("case=cache", func(t *testing.T) {
+				r, err := matcher.Match(context.Background(), "GET", mustParseURL(t, "https://localhost:34/baz"), ProtocolHTTP)
+				require.NoError(t, err)
+				_, err = matcher.Get(context.Background(), r.ID)
+				require.NoError(t, err)
+				// assert.NotEmpty(t, got.matchingEngine.Checksum())
+			})
+
+			require.NoError(t, matcher.Set(context.Background(), testRulesPrefix[1:]))
+
+			t.Run("case=updated", func(t *testing.T) {
+				testMatcher(t, matcher, "GET", "https://localhost:34/baz", ProtocolHTTP, false, &testRulesPrefix[1])
 				testMatcher(t, matcher, "POST", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
 				testMatcher(t, matcher, "DELETE", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
 			})

--- a/rule/matcher_test.go
+++ b/rule/matcher_test.go
@@ -129,7 +129,7 @@ var testRulesPrefix = []Rule{
 	},
 	{
 		ID:             "grpc1",
-		Match:          &MatchGRPC{Authority: "baz.example.com", FullMethod: "grpc.api/Call"},
+		Match:          &MatchGRPC{Authority: "bar.example.com", FullMethod: "grpc.api/Call"},
 		Description:    "gRPC Rule",
 		Authorizer:     Handler{Handler: "allow", Config: []byte(`{"type":"any"}`)},
 		Authenticators: []Handler{{Handler: "anonymous", Config: []byte(`{"name":"anonymous1"}`)}},

--- a/rule/matcher_test.go
+++ b/rule/matcher_test.go
@@ -102,7 +102,7 @@ var testRulesGlob = []Rule{
 var testRulesPrefix = []Rule{
 	{
 		ID:             "foo1",
-		Match:          &Match{URL: "https://localhost:1234/foo", Methods: []string{"POST"}},
+		Match:          &Match{URL: "https://localhost:1234/<foo|bar>", Methods: []string{"POST"}},
 		Description:    "Create users rule",
 		Authorizer:     Handler{Handler: "allow", Config: []byte(`{"type":"any"}`)},
 		Authenticators: []Handler{{Handler: "anonymous", Config: []byte(`{"name":"anonymous1"}`)}},
@@ -111,7 +111,25 @@ var testRulesPrefix = []Rule{
 	},
 	{
 		ID:             "foo2",
-		Match:          &Match{URL: "https://localhost:34/baz", Methods: []string{"GET"}},
+		Match:          &Match{URL: "https://localhost:1234/foo/<baz|bar>", Methods: []string{"POST"}},
+		Description:    "Create users rule",
+		Authorizer:     Handler{Handler: "allow", Config: []byte(`{"type":"any"}`)},
+		Authenticators: []Handler{{Handler: "anonymous", Config: []byte(`{"name":"anonymous1"}`)}},
+		Mutators:       []Handler{{Handler: "id_token", Config: []byte(`{"issuer":"anything"}`)}},
+		Upstream:       Upstream{URL: "http://localhost:1235/", StripPath: "/bar", PreserveHost: true},
+	},
+	{
+		ID:             "foo3",
+		Match:          &Match{URL: "https://localhost:1234/foo/something/<baz|bar>", Methods: []string{"POST"}},
+		Description:    "Create users rule",
+		Authorizer:     Handler{Handler: "allow", Config: []byte(`{"type":"any"}`)},
+		Authenticators: []Handler{{Handler: "anonymous", Config: []byte(`{"name":"anonymous1"}`)}},
+		Mutators:       []Handler{{Handler: "id_token", Config: []byte(`{"issuer":"anything"}`)}},
+		Upstream:       Upstream{URL: "http://localhost:1235/", StripPath: "/bar", PreserveHost: true},
+	},
+	{
+		ID:             "foo4",
+		Match:          &Match{URL: "https://localhost:34/<baz|bar>", Methods: []string{"GET"}},
 		Description:    "Get users rule",
 		Authorizer:     Handler{Handler: "deny", Config: []byte(`{"type":"any"}`)},
 		Authenticators: []Handler{{Handler: "oauth2_introspection", Config: []byte(`{"name":"anonymous1"}`)}},
@@ -119,8 +137,8 @@ var testRulesPrefix = []Rule{
 		Upstream:       Upstream{URL: "http://localhost:333/", StripPath: "/foo", PreserveHost: false},
 	},
 	{
-		ID:             "foo3",
-		Match:          &Match{URL: "https://localhost:343/baz", Methods: []string{"GET"}},
+		ID:             "foo5",
+		Match:          &Match{URL: "https://localhost:343/<baz|bar>", Methods: []string{"GET"}},
 		Description:    "Get users rule",
 		Authorizer:     Handler{Handler: "deny"},
 		Authenticators: []Handler{{Handler: "oauth2_introspection"}},
@@ -232,7 +250,8 @@ func TestMatcher(t *testing.T) {
 			})
 		})
 		t.Run(fmt.Sprintf("prefix matcher=%s", name), func(t *testing.T) {
-			require.NoError(t, matcher.SetMatchingStrategy(context.Background(), configuration.Prefix))
+			require.NoError(t, matcher.SetMatchingStrategy(context.Background(), configuration.Regexp))
+			require.NoError(t, matcher.SetPrefixMatching(context.Background(), true))
 			require.NoError(t, matcher.Set(context.Background(), []Rule{}))
 			t.Run("case=empty", func(t *testing.T) {
 				testMatcher(t, matcher, "GET", "https://localhost:34/baz", ProtocolHTTP, true, nil)
@@ -243,10 +262,13 @@ func TestMatcher(t *testing.T) {
 			require.NoError(t, matcher.Set(context.Background(), testRulesPrefix))
 
 			t.Run("case=created", func(t *testing.T) {
-				testMatcher(t, matcher, "POST", "https://localhost:1234/foo", ProtocolHTTP, false, &testRulesPrefix[0])
-				testMatcher(t, matcher, "GET", "https://localhost:34/baz", ProtocolHTTP, false, &testRulesPrefix[1])
+				testMatcher(t, matcher, "POST", "https://localhost:1234/", ProtocolHTTP, false, &testRulesPrefix[0])
+				testMatcher(t, matcher, "POST", "https://localhost:1234/foo", ProtocolHTTP, false, &testRulesPrefix[1])
+				testMatcher(t, matcher, "POST", "https://localhost:1234/foo/something/very/long", ProtocolHTTP, false, &testRulesPrefix[2])
+				testMatcher(t, matcher, "POST", "https://localhost:1234/foo/baz/something/very/long", ProtocolHTTP, false, &testRulesPrefix[1])
+				testMatcher(t, matcher, "GET", "https://localhost:34/baz", ProtocolHTTP, false, &testRulesPrefix[3])
 				testMatcher(t, matcher, "DELETE", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
-				testMatcher(t, matcher, "POST", "grpc://bar.example.com/grpc.api/Call", ProtocolGRPC, false, &testRulesPrefix[3])
+				testMatcher(t, matcher, "POST", "grpc://bar.example.com/grpc.api/Call", ProtocolGRPC, false, &testRulesPrefix[5])
 			})
 
 			t.Run("case=cache", func(t *testing.T) {
@@ -257,10 +279,10 @@ func TestMatcher(t *testing.T) {
 				// assert.NotEmpty(t, got.matchingEngine.Checksum())
 			})
 
-			require.NoError(t, matcher.Set(context.Background(), testRulesPrefix[1:]))
+			require.NoError(t, matcher.Set(context.Background(), testRulesPrefix[3:]))
 
 			t.Run("case=updated", func(t *testing.T) {
-				testMatcher(t, matcher, "GET", "https://localhost:34/baz", ProtocolHTTP, false, &testRulesPrefix[1])
+				testMatcher(t, matcher, "GET", "https://localhost:34/baz", ProtocolHTTP, false, &testRulesPrefix[3])
 				testMatcher(t, matcher, "POST", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
 				testMatcher(t, matcher, "DELETE", "https://localhost:1234/foo", ProtocolHTTP, true, nil)
 			})

--- a/rule/repository.go
+++ b/rule/repository.go
@@ -17,5 +17,7 @@ type Repository interface {
 	Count(context.Context) (int, error)
 	MatchingStrategy(context.Context) (configuration.MatchingStrategy, error)
 	SetMatchingStrategy(context.Context, configuration.MatchingStrategy) error
+	PrefixMatching(context.Context) (bool, error)
+	SetPrefixMatching(context.Context, bool) error
 	ReadyChecker(*http.Request) error
 }

--- a/rule/repository_memory.go
+++ b/rule/repository_memory.go
@@ -140,7 +140,7 @@ func (m *RepositoryMemory) Match(ctx context.Context, method string, u *url.URL,
 		if m.trie.root == nil {
 			return nil, errors.WithStack(errors.New("prefix trie is nil"))
 		} else {
-			matchedRules := m.trie.Match(method, u)
+			matchedRules := m.trie.Match(method, u, protocol)
 			for _, r := range matchedRules {
 				rules = append(rules, &r)
 			}

--- a/rule/trie.go
+++ b/rule/trie.go
@@ -38,6 +38,14 @@ func (t *Trie) InsertRule(r Rule) error {
 		return err
 	}
 
+	// insert the protocol into the trie
+	if _, ok := node.children[string(r.Match.Protocol())]; !ok {
+		node.children[string(r.Match.Protocol())] = &TrieNode{
+			children: make(map[string]*TrieNode),
+		}
+	}
+	node = node.children[string(r.Match.Protocol())]
+
 	// insert the methods into the trie
 	for _, method := range r.Match.GetMethods() {
 		// reset the node to the root
@@ -128,8 +136,14 @@ func (t *Trie) LongestPrefix(u *url.URL) string {
 }
 
 // return the rules of the longest prefix of the url that is in the trie
-func (t *Trie) Match(method string, u *url.URL) []Rule {
+func (t *Trie) Match(method string, u *url.URL, protocol Protocol) []Rule {
 	node := t.root
+
+	// check the protocol
+	if _, ok := node.children[string(protocol)]; !ok {
+		return nil
+	}
+	node = node.children[string(protocol)]
 
 	// check the method
 	if _, ok := node.children[method]; !ok {

--- a/rule/trie.go
+++ b/rule/trie.go
@@ -48,8 +48,9 @@ func (t *Trie) InsertRule(r Rule) error {
 
 	// insert the methods into the trie
 	for _, method := range r.Match.GetMethods() {
-		// reset the node to the root
+		// reset the node to the root, followed by the protocol
 		node = t.root
+		node = node.children[string(r.Match.Protocol())]
 		if _, ok := node.children[method]; !ok {
 			node.children[method] = &TrieNode{
 				children: make(map[string]*TrieNode),

--- a/rule/trie.go
+++ b/rule/trie.go
@@ -1,0 +1,176 @@
+package rule
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// types for a trie root node
+type TrieNode struct {
+	children map[string]*TrieNode
+	rules    []*Rule
+	// isWord   bool
+}
+
+// types for a trie node
+type Trie struct {
+	root *TrieNode
+}
+
+// NewTrie creates a new trie
+func NewTrie() *Trie {
+	return &Trie{
+		root: &TrieNode{
+			children: make(map[string]*TrieNode),
+		},
+	}
+}
+
+// Insert inserts a word into the trie
+func (t *Trie) InsertString(word string) {
+	node := t.root
+	if _, ok := node.children[word]; !ok {
+		node.children[word] = &TrieNode{
+			children: make(map[string]*TrieNode),
+		}
+	}
+	node = node.children[word]
+}
+
+// Insert a url host and paths into the trie along with the rule
+func (t *Trie) InsertURL(u *url.URL, r *Rule) {
+	// TODO: should this also handle scheme?
+
+	node := t.root
+	// insert the host into the trie
+	if _, ok := node.children[u.Host]; !ok {
+		node.children[u.Host] = &TrieNode{
+			children: make(map[string]*TrieNode),
+		}
+	}
+	node = node.children[u.Host]
+
+	// remove the leading and trailing slash
+	trimmedPath := strings.Trim(u.Path, "/")
+	if len(trimmedPath) == 0 {
+		node.rules = append(node.rules, r)
+	} else {
+		// insert the paths into the trie
+		splitPaths := strings.Split(trimmedPath, "/")
+		i := 0
+		for _, path := range splitPaths {
+			i++
+			if _, ok := node.children[string(path)]; !ok {
+				node.children[string(path)] = &TrieNode{
+					children: make(map[string]*TrieNode),
+				}
+			}
+			node = node.children[string(path)]
+			if i == len(splitPaths) {
+				node.rules = append(node.rules, r)
+			}
+		}
+	}
+}
+
+// Insert a url host and paths into the trie
+func (t *Trie) InsertRule(r *Rule) {
+	node := t.root
+
+	// TODO: handle error properly
+	matchURL, err := url.Parse(r.Match.GetURL())
+	if err != nil {
+		fmt.Println("error parsing url")
+	}
+
+	// TODO: should this also handle scheme?
+
+	// insert the host into the trie
+	if _, ok := node.children[matchURL.Host]; !ok {
+		node.children[matchURL.Host] = &TrieNode{
+			children: make(map[string]*TrieNode),
+		}
+	}
+	node = node.children[matchURL.Host]
+	// remove the leading and trailing slash
+	trimmedPath := strings.Trim(matchURL.Path, "/")
+
+	if len(trimmedPath) == 0 {
+		node.rules = append(node.rules, r)
+	} else {
+
+		// insert the paths into the trie
+		splitPaths := strings.Split(trimmedPath, "/")
+		i := 0
+		for _, path := range splitPaths {
+			i++
+			if _, ok := node.children[string(path)]; !ok {
+				node.children[string(path)] = &TrieNode{
+					children: make(map[string]*TrieNode),
+				}
+			}
+			node = node.children[string(path)]
+			// if this is the last path, append the rule
+			if i == len(splitPaths) {
+				node.rules = append(node.rules, r)
+			}
+		}
+	}
+}
+
+// return the longest prefix of the url that is in the trie
+func (t *Trie) LongestPrefix(u *url.URL) string {
+	node := t.root
+	var prefix string
+	// check the host
+	if _, ok := node.children[u.Host]; !ok {
+		return prefix
+	}
+	prefix += u.Host
+	node = node.children[u.Host]
+	// check the paths
+	// remove the leading and trailing slash
+	trimmedPath := strings.Trim(u.Path, "/")
+
+	if len(trimmedPath) > 0 {
+		splitPaths := strings.Split(trimmedPath, "/")
+		for _, path := range splitPaths {
+			if _, ok := node.children[string(path)]; !ok {
+				break
+			}
+			prefix += "/" + string(path)
+			node = node.children[string(path)]
+		}
+	}
+	return prefix
+
+}
+
+// return the rules of the longest prefix of the url that is in the trie
+func (t *Trie) Match(u *url.URL) []*Rule {
+	node := t.root
+	var rules []*Rule
+	// check the host
+	if _, ok := node.children[u.Host]; !ok {
+		return rules
+	}
+	node = node.children[u.Host]
+	// remove the leading and trailing slash
+	trimmedPath := strings.Trim(u.Path, "/")
+	if len(trimmedPath) == 0 {
+		rules = node.rules
+		return rules
+	} else {
+		// check the paths
+		splitPaths := strings.Split(trimmedPath, "/")
+		for _, path := range splitPaths {
+			if _, ok := node.children[string(path)]; !ok {
+				break
+			}
+			node = node.children[string(path)]
+		}
+		rules = node.rules
+		return rules
+	}
+}

--- a/spec/config.schema.json
+++ b/spec/config.schema.json
@@ -1267,6 +1267,12 @@
           "default": "regexp",
           "enum": ["glob", "regexp"],
           "examples": ["glob"]
+        },
+        "prefix_matching_enabled": {
+          "title": "Enable prefix matching",
+          "description": "This an optional field describing if rules should be matched using path prefixes, defaults to false.",
+          "type": "boolean",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Currently rules are matched to an incoming request based on regex or glob pattern matching. Since only a single rule is allowed to match a request, the regex or glob patterns must be very precise and become increasingly complex as different paths need to be matched. While the used regex library supports negative lookahead, creating rules where requests are matched based on path prefixes is still difficult since you'd need to provide negative matches for all other rule regexes with the same base path. As glob doesn't support negative lookahead doing path prefix based routing is not possible. Even when using regex patterns with negative lookahead, the issue that arises is that the end user ends up needing to manage system with the state of all rules to then be able to create rules with the appropriate regexes including negative lookahead patterns for all other rules. Since the most common type of routing people likely would want to implement is prefixed based routing, the fact that doing so with oathkeeper is difficult and error prone is in my views its biggest drawback.

This PR introduces a system that allows for matching rules based on the longest matching path prefix between a request URL and the paths of all the rules using a Trie. With this trie, oathkeeper does not need to range over each rule when performing the matching which I expect will decrease latency.

Note, this implementation is likely incomplete and requires some further work which I would like to implement after some further discussion here. Some things that come to mind are:
- a way to be able to define multiple schemes in a single rule (currently only a single scheme per rule is possible since the URL needs to be parsable by url.Parse())
- ~allow for regex or glob matching groups since these can be used downstream in authenticators, authorisers and mutators.~

**Update:**
I've made the prefix matching a separate config from the matching strategy. This way, if multiple rules are found based on the path prefix those rules are then further filtered using the matching pattern. Matching patterns can only be used in the path of the URL and are not added into the Trie (since they would break the Trie). Thus, 2 rules with the same path prefix but different matching patterns will be added to the same node in the Trie. Then if a request comes in that matches those rules it will be matched using the pattern. Note that the intension for pattern matching combined with prefix matching is for use of the patterns in downstream handlers. It is not intended to be used for determining which rule an incoming request should match against, but it will fall back to doing so. In any case, it is much easier to create a negative lookahead for a single path section rather than all paths known to oathkeeper.

## Related issue(s)
https://github.com/ory/oathkeeper/pull/1073
https://github.com/ory/oathkeeper/issues/441
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204651423958875