### PR TITLE
fix: noop mutator don't overwrite session headers

### DIFF
--- a/pipeline/mutate/mutator_noop.go
+++ b/pipeline/mutate/mutator_noop.go
@@ -23,7 +23,22 @@ func (a *MutatorNoop) GetID() string {
 }
 
 func (a *MutatorNoop) Mutate(r *http.Request, session *authn.AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
+	currentSessionHeaders := session.Header.Clone()
 	session.Header = r.Header
+	if session.Header == nil {
+		session.Header = make(map[string][]string)
+	}
+
+	for k, v := range currentSessionHeaders {
+		var val string
+		if len(v) == 0 {
+			val = ""
+		} else {
+			val = v[0]
+		}
+		session.SetHeader(k, val)
+	}
+
 	return nil
 }
 

--- a/pipeline/mutate/mutator_noop_test.go
+++ b/pipeline/mutate/mutator_noop_test.go
@@ -33,6 +33,16 @@ func TestMutatorNoop(t *testing.T) {
 		assert.EqualValues(t, r.Header, s.Header)
 	})
 
+	t.Run("method=mutate/case=ensure authentication session headers are kept", func(t *testing.T) {
+		r := &http.Request{Header: http.Header{"foo": {"foo"}}}
+		s := &authn.AuthenticationSession{Header: http.Header{"bar": {"bar"}}}
+		combinedHeaders := http.Header{"foo": {"foo"}}
+		combinedHeaders.Set("bar", "bar")
+		err := a.Mutate(r, s, nil, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, r.Header, combinedHeaders)
+	})
+
 	t.Run("method=validate", func(t *testing.T) {
 		conf.SetForTest(t, configuration.MutatorNoopIsEnabled, true)
 		require.NoError(t, a.Validate(nil))


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

This PR changes the `noop` mutator so that it doesn't overwrite the current session headers with the request headers.

When using the [remote_json](https://www.ory.sh/docs/oathkeeper/pipeline/authz#remote_json) authorizer, it is possible to configure headers returned by the remote authorizer that will be forwarded to upstream services with the `forward_response_headers_to_upstream` field. This effectively allows the authorizer to also act as a mutator. Since rules must contain a mutator, if no further mutations need to be performed you would specify the `noop` mutator. However, since the `noop` mutator is setting the session headers to be equal to the request headers, this effectively overwrites the headers set by the `remote_json` authorizer.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204651423958868