### PR TITLE
fix: switch to `httputil.ReverseProxy.Rewrite`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           key: ${{ needs.sdk-generate.outputs.sdk-cache-key }}
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - run: go list -json > go.list
       - name: Run nancy
         uses: sonatype-nexus-community/nancy-github-action@v1.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           key: ${{ needs.sdk-generate.outputs.sdk-cache-key }}
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20
       - run: go list -json > go.list
       - name: Run nancy
         uses: sonatype-nexus-community/nancy-github-action@v1.0.2
@@ -70,7 +70,7 @@ jobs:
       - uses: ory/ci/checkout@master
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19"
+          go-version: "1.20"
       - uses: actions/cache@v2
         with:
           path: ~/go/bin/oathkeeper

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           GOGC: 100
         with:
           args: --timeout 10m0s
-          version: v1.47.3
+          version: v1.52.2
           skip-go-installation: true
           skip-pkg-cache: true
       - name: Run go-acc (tests)

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - run: make format
       - name: Indicate formatting issues
         run: git diff HEAD --exit-code --color

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
       - run: make format
       - name: Indicate formatting issues
         run: git diff HEAD --exit-code --color

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19"
+          go-version: "1.20"
       - uses: actions/setup-node@v2
         with:
           node-version: "18"

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -48,7 +48,7 @@ func runProxy(d driver.Driver, n *negroni.Negroni, logger *logrusx.Logger, prom 
 		proxy := d.Registry().Proxy()
 		transport := otelhttp.NewTransport(proxy, otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string { return "upstream" }))
 		proxyHandler := &httputil.ReverseProxy{
-			Director:  proxy.Director,
+			Rewrite:   proxy.Rewrite,
 			Transport: transport,
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 				switch {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.19
+go 1.20
 
 module github.com/ory/oathkeeper
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -107,7 +107,7 @@ func (d *Proxy) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 func (d *Proxy) Rewrite(r *httputil.ProxyRequest) {
-	EnrichRequestedURL(r.Out)
+	EnrichRequestedURL(r)
 	rl, err := d.r.RuleMatcher().Match(r.Out.Context(), r.Out.Method, r.Out.URL, rule.ProtocolHTTP)
 	if err != nil {
 		*r.Out = *r.Out.WithContext(context.WithValue(r.Out.Context(), director, err))
@@ -150,11 +150,11 @@ func CopyHeaders(headers http.Header, r *http.Request) {
 
 // EnrichRequestedURL sets Scheme and Host values in a URL passed down by a http server. Per default, the URL
 // does not contain host nor scheme values.
-func EnrichRequestedURL(r *http.Request) {
-	r.URL.Scheme = "http"
-	r.URL.Host = r.Host
-	if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
-		r.URL.Scheme = "https"
+func EnrichRequestedURL(r *httputil.ProxyRequest) {
+	r.Out.URL.Scheme = "http"
+	r.Out.URL.Host = r.In.Host
+	if r.In.TLS != nil || strings.EqualFold(r.In.Header.Get("X-Forwarded-Proto"), "https") {
+		r.Out.URL.Scheme = "https"
 	}
 }
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -443,25 +443,34 @@ func TestConfigureBackendURL(t *testing.T) {
 
 func TestEnrichRequestedURL(t *testing.T) {
 	for k, tc := range []struct {
-		in     *http.Request
+		req    *httputil.ProxyRequest
 		expect url.URL
 	}{
 		{
-			in:     &http.Request{Host: "test", TLS: &tls.ConnectionState{}, URL: new(url.URL)},
+			req: &httputil.ProxyRequest{
+				In:  &http.Request{Host: "test", TLS: &tls.ConnectionState{}, URL: new(url.URL)},
+				Out: &http.Request{Host: "test", TLS: &tls.ConnectionState{}, URL: new(url.URL)},
+			},
 			expect: url.URL{Scheme: "https", Host: "test"},
 		},
 		{
-			in:     &http.Request{Host: "test", URL: new(url.URL)},
+			req: &httputil.ProxyRequest{
+				In:  &http.Request{Host: "test", URL: new(url.URL)},
+				Out: &http.Request{Host: "test", URL: new(url.URL)},
+			},
 			expect: url.URL{Scheme: "http", Host: "test"},
 		},
 		{
-			in:     &http.Request{Host: "test", Header: http.Header{"X-Forwarded-Proto": {"https"}}, URL: new(url.URL)},
+			req: &httputil.ProxyRequest{
+				In:  &http.Request{Host: "test", Header: http.Header{"X-Forwarded-Proto": {"https"}}, URL: new(url.URL)},
+				Out: &http.Request{Host: "test", URL: new(url.URL)},
+			},
 			expect: url.URL{Scheme: "https", Host: "test"},
 		},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
-			proxy.EnrichRequestedURL(tc.in)
-			assert.EqualValues(t, tc.expect, *tc.in.URL)
+			proxy.EnrichRequestedURL(tc.req)
+			assert.EqualValues(t, tc.expect, *tc.req.Out.URL)
 		})
 	}
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -6,8 +6,9 @@ package proxy_test
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -30,7 +31,10 @@ func TestProxy(t *testing.T) {
 		// assert.NotEmpty(t, helper.BearerTokenFromRequest(r))
 		fmt.Fprint(w, "authorization="+r.Header.Get("Authorization")+"\n")
 		fmt.Fprint(w, "host="+r.Host+"\n")
-		fmt.Fprint(w, "url="+r.URL.String())
+		fmt.Fprint(w, "url="+r.URL.String()+"\n")
+		for k, v := range r.Header {
+			fmt.Fprint(w, "header "+k+"="+strings.Join(v, ",")+"\n")
+		}
 	}))
 	defer backend.Close()
 
@@ -38,7 +42,7 @@ func TestProxy(t *testing.T) {
 	reg := internal.NewRegistry(conf).WithBrokenPipelineMutator()
 
 	d := reg.Proxy()
-	ts := httptest.NewServer(&httputil.ReverseProxy{Director: d.Director, Transport: d})
+	ts := httptest.NewServer(&httputil.ReverseProxy{Rewrite: d.Rewrite, Transport: d})
 	defer ts.Close()
 
 	conf.SetForTest(t, configuration.AuthenticatorNoopIsEnabled, true)
@@ -47,6 +51,8 @@ func TestProxy(t *testing.T) {
 	conf.SetForTest(t, configuration.AuthorizerAllowIsEnabled, true)
 	conf.SetForTest(t, configuration.AuthorizerDenyIsEnabled, true)
 	conf.SetForTest(t, configuration.MutatorNoopIsEnabled, true)
+	conf.SetForTest(t, "mutators.header.config", map[string]interface{}{"headers": map[string]string{}})
+	conf.SetForTest(t, configuration.MutatorHeaderIsEnabled, true)
 	conf.SetForTest(t, configuration.ErrorsWWWAuthenticateIsEnabled, true)
 
 	ruleNoOpAuthenticator := rule.Rule{
@@ -83,7 +89,7 @@ func TestProxy(t *testing.T) {
 	// acceptRuleStripHostWithoutTrailing2 := rule.Rule{MatchesMethods: []string{"GET"}, MatchesURLCompiled: mustCompileRegex(t, proxy.URL+"/users/<[0-9]+>"), Mode: "pass_through_accept", Upstream: rule.Upstream{URLParsed: u, StripPath: "users", PreserveHost: true}}
 	// denyRule := rule.Rule{MatchesMethods: []string{"GET"}, MatchesURLCompiled: mustCompileRegex(t, proxy.URL+"/users/<[0-9]+>"), Mode: "pass_through_deny", Upstream: rule.Upstream{URLParsed: u}}
 
-	for k, tc := range []struct {
+	for _, tc := range []struct {
 		url         string
 		code        int
 		messages    []string
@@ -305,9 +311,34 @@ func TestProxy(t *testing.T) {
 			}},
 			code: http.StatusInternalServerError,
 		},
+		{
+			d:   "should not remove headers set by the mutator that are defined in the connection header",
+			url: ts.URL + "/",
+			rulesRegexp: []rule.Rule{{
+				Match:          &rule.Match{Methods: []string{"GET"}, URL: ts.URL + "/"},
+				Authenticators: []rule.Handler{{Handler: "noop"}},
+				Authorizer:     rule.Handler{Handler: "allow"},
+				Mutators:       []rule.Handler{{Handler: "header", Config: json.RawMessage(`{"headers":{"X-Arbitrary":"foo"}}`)}},
+				Upstream:       rule.Upstream{URL: backend.URL},
+			}},
+			rulesGlob: []rule.Rule{{
+				Match:          &rule.Match{Methods: []string{"GET"}, URL: ts.URL + "/"},
+				Authenticators: []rule.Handler{{Handler: "noop"}},
+				Authorizer:     rule.Handler{Handler: "allow"},
+				Mutators:       []rule.Handler{{Handler: "header", Config: json.RawMessage(`{"headers":{"X-Arbitrary":"foo"}}`)}},
+				Upstream:       rule.Upstream{URL: backend.URL},
+			}},
+			code: http.StatusOK,
+			messages: []string{
+				"header X-Arbitrary=foo",
+			},
+			transform: func(r *http.Request) {
+				r.Header.Set("Connection", "x-arbitrary")
+			},
+		},
 	} {
-		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
-			testFunc := func(strategy configuration.MatchingStrategy, rules []rule.Rule) {
+		t.Run(fmt.Sprintf("description=%s", tc.d), func(t *testing.T) {
+			testFunc := func(t *testing.T, strategy configuration.MatchingStrategy, rules []rule.Rule) {
 				reg.RuleRepository().(*rule.RepositoryMemory).WithRules(rules)
 				require.NoError(t, reg.RuleRepository().SetMatchingStrategy(context.Background(), strategy))
 
@@ -320,7 +351,7 @@ func TestProxy(t *testing.T) {
 				res, err := http.DefaultClient.Do(req)
 				require.NoError(t, err)
 
-				greeting, err := ioutil.ReadAll(res.Body)
+				greeting, err := io.ReadAll(res.Body)
 				require.NoError(t, res.Body.Close())
 				require.NoError(t, err)
 
@@ -335,11 +366,11 @@ backend_url=%s
 
 			}
 
-			t.Run("regexp", func(*testing.T) {
-				testFunc(configuration.Regexp, tc.rulesRegexp)
+			t.Run("regexp", func(t *testing.T) {
+				testFunc(t, configuration.Regexp, tc.rulesRegexp)
 			})
-			t.Run("glob", func(*testing.T) {
-				testFunc(configuration.Glob, tc.rulesGlob)
+			t.Run("glob", func(t *testing.T) {
+				testFunc(t, configuration.Glob, tc.rulesGlob)
 			})
 
 		})

--- a/test/forwarded-header/rules.1.json
+++ b/test/forwarded-header/rules.1.json
@@ -2,7 +2,8 @@
   {
     "id": "test-rule-http",
     "upstream": {
-      "url": "https://httpbin.org/anything/"
+      "url": "https://example.com/",
+      "strip_path": "http"
     },
     "match": {
       "url": "http://127.0.0.1:6060/http",
@@ -25,7 +26,8 @@
   {
     "id": "test-rule-https",
     "upstream": {
-      "url": "https://httpbin.org/anything/"
+      "url": "https://example.com/",
+      "strip_path": "https"
     },
     "match": {
       "url": "https://127.0.0.1:6060/https",

--- a/test/forwarded-header/run.sh
+++ b/test/forwarded-header/run.sh
@@ -18,18 +18,13 @@ waitport() {
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 
-export GO111MODULE=on
-
-[[ "$(command -v oathkeeper)" == "" ]] &&
-    (cd ../../; make install)
-
 run_oathkekeper() {
   killall oathkeeper || true
 
   export OATHKEEPER_PROXY=http://127.0.0.1:6060
   export OATHKEEPER_API=http://127.0.0.1:6061
 
-  LOG_LEVEL=debug oathkeeper --config ./config.yaml serve >> ./oathkeeper.log 2>&1 &
+  LOG_LEVEL=debug go run ../.. --config ./config.yaml serve > ./oathkeeper.log 2>&1 &
 
   waitport 6060
   waitport 6061
@@ -61,9 +56,13 @@ run_test() {
 }
 
 function finish {
+  echo ::group::Config
   cat ./config.yaml
   cat ./rules.1.json
+  echo ::endgroup::
+  echo ::group::Log
   cat ./oathkeeper.log
+  echo ::endgroup::
 }
 trap finish EXIT
 


### PR DESCRIPTION
For background info, see https://github.com/golang/go/issues/50580

Setting some internal header names in the `Connection` header caused those to be dropped even when set by the `header` mutator.