### PR TITLE
fix: update regex engine to support possessive match and lookbehind syntaxes

### DIFF
--- a/rule/engine_regexp_test.go
+++ b/rule/engine_regexp_test.go
@@ -30,6 +30,24 @@ func TestFindStringSubmatch(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "bad lookbehind (wrong delimiters)",
+			args: args{
+				pattern:      `urn:foo:<(?<=foo:)foobar>`,
+				matchAgainst: "urn:foo:foobar",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "bad possessive (wrong delimiters)",
+			args: args{
+				pattern:      `urn:foo:<(?>=foo:)foobar>`,
+				matchAgainst: "urn:foo:foobar",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "one group",
 			args: args{
 				pattern:      `urn:foo:<.*>`,
@@ -55,6 +73,33 @@ func TestFindStringSubmatch(t *testing.T) {
 			},
 			want:    []string{"bar"},
 			wantErr: false,
+		},
+		{
+			name: "positive lookbehind (?<=foo)bar",
+			args: args{
+				pattern:      `urn:foo:{(?<=foo:)foobar}`,
+				matchAgainst: "urn:foo:foobar",
+			},
+			want:    []string{"foobar"},
+			wantErr: false,
+		},
+		{
+			name: "negative lookbehind (?<!boo)foobar",
+			args: args{
+				pattern:      `urn:foo:{(?<!boo:)foobar}`,
+				matchAgainst: "urn:foo:foobar",
+			},
+			want:    []string{"foobar"},
+			wantErr: false,
+		},
+		{
+			name: "negative lookbehind (?<!boo)foobar, not match",
+			args: args{
+				pattern:      `urn:foo:{(?<!boo:)foobar}`,
+				matchAgainst: "urn:boo:foobar",
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Update the regexp to conditionally (naively?) change the current start,end delimiters for the regexp from the hard-coded '<','>' to '{','}' when the compiler encounters a pattern that has syntax that includes '(?<' or '(?>' organically.

BREAKING CHANGES: None

## Related issue(s)

Relates:
#441

Fixes:
#1089

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments
