### PR TITLE
feat: add `delegate` authenticator

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -1301,6 +1301,17 @@
             }
           }
         },
+        "delegate": {
+          "title": "Delegate Operation (delegate)",
+          "description": "The [`delegate` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#delegate).",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "$ref": "#/definitions/handlerSwitch"
+            }
+          }
+        },
         "unauthorized": {
           "title": "Unauthorized",
           "description": "The [`unauthorized` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#unauthorized).",

--- a/.schemas/authenticators.delegate.schema.json
+++ b/.schemas/authenticators.delegate.schema.json
@@ -1,0 +1,9 @@
+{
+  "$id": "https://raw.githubusercontent.com/ory/oathkeeper/master/.schemas/authenticators.delegate.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Delegate Authenticator Configuration",
+  "description": "This section is optional when the authenticator is disabled.",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/.schemas/config.schema.json
+++ b/.schemas/config.schema.json
@@ -1009,6 +1009,17 @@
             }
           }
         },
+        "delegate": {
+          "title": "Delegate Operation (delegate)",
+          "description": "The [`delegate` authenticator](https://www.ory.sh/docs/oathkeeper/pipeline/authn#delegate).",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "$ref": "#/definitions/handlerSwitch"
+            }
+          }
+        },
         "unauthorized": {
           "title": "Unauthorized",
           "description": "The [`unauthorized` authenticator](https://www.ory.sh/docs/oathkeeper/pipeline/authn#unauthorized).",

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -39,6 +39,7 @@ func TestHealth(t *testing.T) {
 	conf.SetForTest(t, configuration.AuthorizerAllowIsEnabled, true)
 	conf.SetForTest(t, configuration.AuthorizerDenyIsEnabled, true)
 	conf.SetForTest(t, configuration.AuthenticatorNoopIsEnabled, true)
+	conf.SetForTest(t, configuration.AuthenticatorDelegateIsEnabled, true)
 	conf.SetForTest(t, configuration.AuthenticatorAnonymousIsEnabled, true)
 	conf.SetForTest(t, configuration.MutatorNoopIsEnabled, true)
 	conf.SetForTest(t, "mutators.header.config", map[string]interface{}{"headers": map[string]interface{}{}})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -30,6 +30,7 @@ func init() {
 	os.Setenv("SERVE_API_PORT", fmt.Sprintf("%d", apiPort))
 	os.Setenv("SERVE_PROXY_PORT", fmt.Sprintf("%d", proxyPort))
 	os.Setenv("AUTHENTICATORS_NOOP_ENABLED", "1")
+	os.Setenv("AUTHENTICATORS_DELEGATE_ENABLED", "1")
 	os.Setenv("AUTHENTICATORS_ANONYMOUS_ENABLED", "true")
 	os.Setenv("AUTHORIZERS_ALLOW_ENABLED", "true")
 	os.Setenv("MUTATORS_NOOP_ENABLED", "true")
@@ -54,6 +55,9 @@ func init() {
       },
       {
         "handler": "anonymous"
+      },
+      {
+        "handler": "delegate"
       }
     ],
     "authorizer": {

--- a/driver/configuration/config_keys.go
+++ b/driver/configuration/config_keys.go
@@ -55,6 +55,9 @@ const (
 	// noop
 	AuthenticatorNoopIsEnabled Key = "authenticators.noop.enabled"
 
+	// delegate
+	AuthenticatorDelegateIsEnabled Key = "authenticators.delegate.enabled"
+
 	// cookie session
 	AuthenticatorCookieSessionIsEnabled Key = "authenticators.cookie_session.enabled"
 

--- a/driver/configuration/provider_koanf_public_test.go
+++ b/driver/configuration/provider_koanf_public_test.go
@@ -146,6 +146,7 @@ func BenchmarkPipelineEnabled(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		p.AuthorizerIsEnabled("allow")
 		p.AuthenticatorIsEnabled("noop")
+		p.AuthenticatorIsEnabled("delegate")
 		p.MutatorIsEnabled("noop")
 	}
 }
@@ -243,6 +244,12 @@ func TestKoanfProvider(t *testing.T) {
 
 		t.Run("authenticator=noop", func(t *testing.T) {
 			a := authn.NewAuthenticatorNoOp(p)
+			assert.True(t, p.AuthenticatorIsEnabled(a.GetID()))
+			require.NoError(t, a.Validate(nil))
+		})
+
+		t.Run("authenticator=delegate", func(t *testing.T) {
+			a := authn.NewAuthenticatorDelegate(p)
 			assert.True(t, p.AuthenticatorIsEnabled(a.GetID()))
 			require.NoError(t, a.Validate(nil))
 		})

--- a/driver/registry_memory.go
+++ b/driver/registry_memory.go
@@ -361,6 +361,7 @@ func (r *RegistryMemory) prepareAuthn() {
 			authn.NewAuthenticatorBearerToken(r.c, r.trc.Provider()),
 			authn.NewAuthenticatorJWT(r.c, r),
 			authn.NewAuthenticatorNoOp(r.c),
+			authn.NewAuthenticatorDelegate(r.c),
 			authn.NewAuthenticatorOAuth2ClientCredentials(r.c, r.Logger()),
 			authn.NewAuthenticatorOAuth2Introspection(r.c, r.Logger(), r.trc.Provider()),
 			authn.NewAuthenticatorUnauthorized(r.c),

--- a/internal/config/.oathkeeper.yaml
+++ b/internal/config/.oathkeeper.yaml
@@ -179,6 +179,11 @@ authenticators:
     # Set enabled to true if the authenticator should be enabled and false to disable the authenticator. Defaults to false.
     enabled: true
 
+  # Configures the delegate authenticator
+  delegate:
+    # Set enabled to true if the authenticator should be enabled and false to disable the authenticator. Defaults to false.
+    enabled: true
+
   # Configures the oauth2_client_credentials authenticator
   oauth2_client_credentials:
     # Set enabled to true if the authenticator should be enabled and false to disable the authenticator. Defaults to false.

--- a/middleware/grpc_middleware_test.go
+++ b/middleware/grpc_middleware_test.go
@@ -98,6 +98,8 @@ func TestMiddleware(t *testing.T) {
 authenticators:
   noop:
     enabled: true
+  delegate:
+    enabled: true
   anonymous:
     enabled: true
   bearer_token:

--- a/pipeline/authn/authenticator.go
+++ b/pipeline/authn/authenticator.go
@@ -18,6 +18,7 @@ import (
 )
 
 var ErrAuthenticatorNotResponsible = errors.New("Authenticator not responsible")
+var ErrAuthenticatorDelegate = errors.New("Authentication should be delegated")
 var ErrAuthenticatorNotEnabled = herodot.DefaultError{
 	ErrorField:  "authenticator matching this route is misconfigured or disabled",
 	CodeField:   http.StatusInternalServerError,

--- a/pipeline/authn/authenticator_delegate.go
+++ b/pipeline/authn/authenticator_delegate.go
@@ -1,0 +1,39 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package authn
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/ory/oathkeeper/driver/configuration"
+	"github.com/ory/oathkeeper/pipeline"
+)
+
+type AuthenticatorDelegate struct {
+	c configuration.Provider
+}
+
+func NewAuthenticatorDelegate(c configuration.Provider) *AuthenticatorDelegate {
+	return &AuthenticatorDelegate{c: c}
+}
+
+func (a *AuthenticatorDelegate) GetID() string {
+	return "delegate"
+}
+
+func (a *AuthenticatorDelegate) Validate(config json.RawMessage) error {
+	if !a.c.AuthenticatorIsEnabled(a.GetID()) {
+		return NewErrAuthenticatorNotEnabled(a)
+	}
+
+	if err := a.c.AuthenticatorConfig(a.GetID(), config, nil); err != nil {
+		return NewErrAuthenticatorMisconfigured(a, err)
+	}
+	return nil
+}
+
+func (a *AuthenticatorDelegate) Authenticate(r *http.Request, session *AuthenticationSession, config json.RawMessage, _ pipeline.Rule) error {
+	return ErrAuthenticatorDelegate
+}

--- a/pipeline/authn/authenticator_delegate_test.go
+++ b/pipeline/authn/authenticator_delegate_test.go
@@ -1,0 +1,37 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package authn_test
+
+import (
+	"testing"
+
+	"github.com/ory/oathkeeper/driver/configuration"
+	"github.com/ory/oathkeeper/internal"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthenticatorDelegate(t *testing.T) {
+	t.Parallel()
+	conf := internal.NewConfigurationWithDefaults()
+	reg := internal.NewRegistry(conf)
+
+	a, err := reg.PipelineAuthenticator("delegate")
+	require.NoError(t, err)
+	assert.Equal(t, "delegate", a.GetID())
+
+	t.Run("method=authenticate", func(t *testing.T) {
+		err := a.Authenticate(nil, nil, nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("method=validate", func(t *testing.T) {
+		conf.SetForTest(t, configuration.AuthenticatorDelegateIsEnabled, true)
+		require.NoError(t, a.Validate(nil))
+
+		conf.SetForTest(t, configuration.AuthenticatorDelegateIsEnabled, false)
+		require.Error(t, a.Validate(nil))
+	})
+}

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -208,10 +208,10 @@ func (d *requestHandler) HandleRequest(r *http.Request, rl *rule.Rule) (session 
 			case authn.ErrAuthenticatorNotResponsible.Error():
 				// The authentication handler is not responsible for handling this request, skip to the next handler
 				break
-			// case ErrAuthenticatorBypassed.Error():
-			// The authentication handler says that no further authentication/authorization is required, and the request should
-			// be forwarded to its final destination.
-			// return nil
+			case authn.ErrAuthenticatorDelegate.Error():
+				//The authentication handler says that no further authentication/authorization is required, and the request should
+				//be forwarded to its final destination.
+				return session, nil
 			case helper.ErrUnauthorized.ErrorField:
 				d.r.Logger().Info(err)
 				return nil, err

--- a/spec/config.schema.json
+++ b/spec/config.schema.json
@@ -354,6 +354,13 @@
       },
       "additionalProperties": false
     },
+    "configAuthenticatorsDelegate": {
+      "type": "object",
+      "title": "Delegate Authenticator Configuration",
+      "description": "This section is optional when the authenticator is disabled.",
+      "properties": {},
+      "additionalProperties": false
+    },
     "configAuthenticatorsCookieSession": {
       "type": "object",
       "title": "Cookie Session Authenticator Configuration",
@@ -1321,6 +1328,17 @@
         "noop": {
           "title": "No Operation (noop)",
           "description": "The [`noop` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#noop).",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "$ref": "#/definitions/handlerSwitch"
+            }
+          }
+        },
+        "delegate": {
+          "title": "Delegate Operation (delegate)",
+          "description": "The [`delegate` authenticator](https://www.ory.sh/oathkeeper/docs/pipeline/authn#delegate).",
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/spec/pipeline/authenticators.delegate.schema.json
+++ b/spec/pipeline/authenticators.delegate.schema.json
@@ -1,0 +1,5 @@
+{
+  "$id": "/.schema/authenticators.delegate.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "/.schema/config.schema.json#/definitions/configAuthenticatorsDelegate"
+}


### PR DESCRIPTION
## Problem Summary

This merge request addresses issue !669 surrounding the behavior of the "noop" authentication method, which underwent changes in commit 6f8ab4f7d. Reverting these changes to restore the previous behavior is challenging due to the potential for breaking existing systems. To mitigate this risk, we propose implementing a new authenticator named "delegate" to replicate the original behavior of the "noop" method.

## Ideal Solution

To address this issue, our proposed solution is to implement a new authenticator named "delegate" that replicates the original behavior of the "noop" method. This approach ensures that existing systems in production remain stable and unaffected by changes, while also providing users who prefer the old behavior with an option to utilize it. By introducing the "delegate" authenticator, we mitigate the risk of breaking changes while offering flexibility to users who require the previous behavior.

## Changes Proposed

1. **New Authenticator Module**: This MR adds a new authenticator module named "delegate" to replicate the original behavior of the "noop" method.

3. **Integration Tests**: Integration tests will be added to validate the functionality of the "delegate" authenticator, ensuring compatibility and reliability.

4. **Documentation Updates**: Documentation will be updated to include details about the new "delegate" authenticator, its configuration options, and usage examples.

## Related Issues

https://github.com/ory/oathkeeper/issues/1152
https://github.com/ory/oathkeeper/issues/669

closes 1152

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
