### PR TITLE
fix: query string included for the first collapsed path segment

### DIFF
--- a/metrics/middleware.go
+++ b/metrics/middleware.go
@@ -92,7 +92,9 @@ func (m *Middleware) getFirstPathSegment(requestURI string) string {
 	// Will split /my/example/uri in []string{"", "my", "example/uri"}
 	uriSegments := strings.SplitN(requestURI, "/", 3)
 	if len(uriSegments) > 1 {
-		return "/" + uriSegments[1]
+		// Remove any query string from the segment
+		// For example /my?query=string should return /my
+		return "/" + strings.SplitN(uriSegments[1], "?", 2)[0]
 	}
 	return "/"
 


### PR DESCRIPTION
When the first path segment of a request has a query string the metrics middleware includes the query string in a collapsed path.

For example, `/hello?uid=46cfcbdd-fd45-4fb2-a301-47bc24024b5c` produces a metric like this:

```
ory_oathkeeper_requests_total{method="GET",request="hello?uid=46cfcbdd-fd45-4fb2-a301-47bc24024b5c",service="test",status_code="200"} 1
```

If the query string contains non-static values, then a new prometheus metric will be created for each request. The number of metrics increasing over time could cause stability issues.

The expected metrics should be a collapsed path like:

```
ory_oathkeeper_requests_total{method="GET",request="hello",service="test",status_code="200"} 1
```

This PR truncates any query string when collapsing the path.

## Related issue(s)

Original metrics cardinality issue: https://github.com/ory/oathkeeper/issues/446

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

The results of this issue are also visible in standard Oathkeeper Grafana dashboard:

<img width="1251" alt="Screenshot 2024-04-11 at 11 23 43 AM" src="https://github.com/ory/oathkeeper/assets/19244661/86e943af-7a46-47c8-85ab-7c12fa64a751">