### PR TITLE
feat(cmd/serve): add in default-shutdown-timeout flag to increase shutdown timeout on http server shutdown

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -32,4 +32,5 @@ func init() {
 
 	serveCmd.PersistentFlags().Bool("disable-telemetry", false, "Disable anonymized telemetry reports - for more information please visit https://www.ory.sh/docs/ecosystem/sqa")
 	serveCmd.PersistentFlags().Bool("sqa-opt-out", false, "Disable anonymized telemetry reports - for more information please visit https://www.ory.sh/docs/ecosystem/sqa")
+	serveCmd.PersistentFlags().Int("default-shutdown-timeout", 5, "Set the default shutdown timeout in seconds for server shutdown when trapping SIGTERM and SIGINT")
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -251,6 +251,13 @@ func RunServe(version, build, date string) func(cmd *cobra.Command, args []strin
 		adminmw.Use(telemetry)
 		publicmw.Use(telemetry)
 
+		// Override the `graceful.DefaultShutdownTimeout` value
+		graceful.DefaultShutdownTimeout = 5 * time.Second
+		defaultShutdownTimeout, _ := cmd.Flags().GetInt("default-shutdown-timeout")
+		if defaultShutdownTimeout > 0 {
+			graceful.DefaultShutdownTimeout = time.Duration(defaultShutdownTimeout) * time.Second
+		}
+
 		prometheusRepo := metrics.NewConfigurablePrometheusRepository(d, logger)
 		var wg sync.WaitGroup
 		tasks := []func(){


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Under the hood `ory/oathkeeper` uses https://github.com/ory/graceful to shutdown the HTTP proxy. The `graceful` package provides a constant called `DefaultShutdownTimeout` which sets the timeout to be `5` seconds.

We have an application that can take up to `60` seconds to finish processing requests and we need a solution to be able to change this shutdown time in order for those requests to complete successfully.

As a result, we need a way to configure `oathkeeper` to bump up that timeout and the implementation has a flag that will be able to override the global variable set in the `graceful` package. Although this does not seem like the most **ideal** solution it provides a way for us to change that value.

Curious to hear suggestions on what may be an alternative approach to get a similar outcome & would be happy to try and make the changes needed for any feedback to help enable that.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).
