### PR TITLE
feat: match_json_field in remote_json authorizer (#1164)

### DIFF
--- a/spec/config.schema.json
+++ b/spec/config.schema.json
@@ -1013,6 +1013,30 @@
           "uniqueItems": true,
           "default": []
         },
+        "match_json_field": {
+          "description": "Match the JSON field in response from the remote authorizer to allow/deny access. Only applicable if it respond with HTTP 200",
+          "title": "Match JSON Response",
+          "type": "object",
+          "required": ["field"],
+          "properties": {
+            "field": {
+              "type": "string",
+              "description": "Path to field in [gjson path](https://github.com/tidwall/gjson/blob/v1.14.3/SYNTAX.md) format. If the field is not found, the request will be denied.",
+              "examples": ["allowed"]
+            },
+            "str_val": {
+              "type": "string",
+              "description": "String value to match the field against.",
+              "examples": ["true"]
+            },
+            "bool_val": {
+              "type": "boolean",
+              "description": "Boolean value to match the field against.",
+              "examples": ["true"]
+            }
+          },
+          "additionalProperties": false
+        },
         "retry": {
           "$ref": "#/definitions/retry"
         }


### PR DESCRIPTION
Implements response content match in remote_json authorizer as described in rfc #1169 

## Related issue(s)
#1169

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
