### PR TITLE
chore: bump golang-jwt to v5

### DIFF
--- a/credentials/signer.go
+++ b/credentials/signer.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type Signer interface {

--- a/credentials/signer_default.go
+++ b/credentials/signer_default.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 
 	"github.com/go-jose/go-jose/v3"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ed25519"
 )

--- a/credentials/signer_default_integration_test.go
+++ b/credentials/signer_default_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/ory/oathkeeper/internal"
 )

--- a/credentials/signer_default_test.go
+++ b/credentials/signer_default_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 

--- a/credentials/verifier.go
+++ b/credentials/verifier.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/ory/fosite"
 )

--- a/credentials/verifier_default_test.go
+++ b/credentials/verifier_default_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/go-swagger/go-swagger v0.30.0
 	github.com/gobuffalo/httptest v1.5.2
 	github.com/gobwas/glob v0.2.3
-	github.com/golang-jwt/jwt/v4 v4.4.3
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang/gddo v0.0.0-20190904175337-72a348e765d2
 	github.com/golang/mock v1.6.0
 	github.com/google/go-replayers/httpreplay v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
-github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/gddo v0.0.0-20190904175337-72a348e765d2 h1:xisWqjiKEff2B0KfFYGpCqc3M3zdTz+OHQHRc09FeYk=
 github.com/golang/gddo v0.0.0-20190904175337-72a348e765d2/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/pipeline/authn/authenticator_jwt.go
+++ b/pipeline/authn/authenticator_jwt.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 
@@ -130,7 +130,7 @@ func (a *AuthenticatorJWT) Authenticate(r *http.Request, session *Authentication
 }
 
 func (a *AuthenticatorJWT) tryEnrichResultErr(token string, err *herodot.DefaultError) *herodot.DefaultError {
-	t, _ := jwt.ParseWithClaims(token, jwt.MapClaims{}, nil)
+	t, _ := jwt.ParseWithClaims(token, jwt.MapClaims{}, nil, jwt.WithIssuedAt())
 	if t == nil {
 		return err
 	}

--- a/pipeline/authn/authenticator_jwt_test.go
+++ b/pipeline/authn/authenticator_jwt_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/tidwall/sjson"
 
 	"github.com/ory/herodot"

--- a/pipeline/mutate/mutator_id_token.go
+++ b/pipeline/mutate/mutator_id_token.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/dgraph-io/ristretto"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"

--- a/pipeline/mutate/mutator_id_token_test.go
+++ b/pipeline/mutate/mutator_id_token_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ory/oathkeeper/x"
 	"github.com/ory/x/configx"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/ory/oathkeeper/credentials"
 	"github.com/ory/oathkeeper/driver/configuration"

--- a/test/e2e/okclient/main.go
+++ b/test/e2e/okclient/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v3"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/ory/oathkeeper/x"
 	"github.com/ory/x/cmdx"


### PR DESCRIPTION
The rationale behind this update is that we see an ever increasing memory usage on our Oathkeeper instances, until they OOM and we start a new one.

From some pprof analysis in our prod environment, seems to indicate that it's in `MutatorIDToken.Mutate` that the issue lies.
More specifically when signing the token string.
- in `MutatorIDToken.Mutate` => `signed, err := a.r.CredentialsSigner().Sign(r.Context(), jwks, claims)`
- in `Sign` => `signed, err := token.SignedString(key.Key)`
- in `SignedString` => `return strings.Join([]string{sstr, sig}, "."), nil`


![Screenshot 2024-06-25 at 17 26 37](https://github.com/ory/oathkeeper/assets/8582749/3c2313d5-a09f-4b46-ae66-cee7abfec4aa)

In golang-jwt v5, this **method does not use `strings.Join` anymore**.
See https://github.com/golang-jwt/jwt/pull/115

I'm entirely sure to understand why string joining could cause this issue, perhaps some reference that Oathkeeper is keeping and therefore leads to this memory leak 🤷 
But in any case, we believe it's a good thing to keep dependencies up-to-date and use the latest version.

Let me know what you think :) 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
