### PR TITLE
feat: make id_token mutator cache configurable

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -1140,6 +1140,25 @@
           "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
           "default": "15m",
           "examples": ["1h", "1m", "30s"]
+        },
+        "cache": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enabled",
+              "type": "boolean",
+              "default": true,
+              "examples": [false, true],
+              "description": "En-/disables this component."
+            },
+            "max_cost": {
+              "type": "integer",
+              "default": 33554432,
+              "title": "Maximum Cached Cost",
+              "description": "The cost of one cached JSON Web Token is the length of its string form."
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/.schemas/mutators.id_token.schema.json
+++ b/.schemas/mutators.id_token.schema.json
@@ -32,6 +32,25 @@
       "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
       "default": "1m",
       "examples": ["1h", "1m", "30s"]
+    },
+    "cache": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enabled",
+          "type": "boolean",
+          "default": true,
+          "examples": [false, true],
+          "description": "En-/disables this component."
+        },
+        "max_cost": {
+          "type": "integer",
+          "default": 33554432,
+          "title": "Maximum Cached Cost",
+          "description": "The cost of one cached JSON Web Token is the length of its string form."
+        }
+      }
     }
   },
   "additionalProperties": false

--- a/pipeline/mutate/mutator_id_token.go
+++ b/pipeline/mutate/mutator_id_token.go
@@ -38,15 +38,20 @@ type MutatorIDToken struct {
 	templates     *template.Template
 	templatesLock sync.Mutex
 
-	tokenCache        *ristretto.Cache[string, *idTokenCacheContainer]
-	tokenCacheEnabled bool
+	tokenCache *ristretto.Cache[string, *idTokenCacheContainer]
 }
 
 type CredentialsIDTokenConfig struct {
-	Claims    string `json:"claims"`
-	IssuerURL string `json:"issuer_url"`
-	JWKSURL   string `json:"jwks_url"`
-	TTL       string `json:"ttl"`
+	Claims    string             `json:"claims"`
+	IssuerURL string             `json:"issuer_url"`
+	JWKSURL   string             `json:"jwks_url"`
+	TTL       string             `json:"ttl"`
+	Cache     IdTokenCacheConfig `json:"cache"`
+}
+
+type IdTokenCacheConfig struct {
+	Enabled bool `json:"enabled"`
+	MaxCost int  `json:"max_cost"`
 }
 
 func (c *CredentialsIDTokenConfig) ClaimsTemplateID() string {
@@ -54,12 +59,7 @@ func (c *CredentialsIDTokenConfig) ClaimsTemplateID() string {
 }
 
 func NewMutatorIDToken(c configuration.Provider, r MutatorIDTokenRegistry) *MutatorIDToken {
-	cache, _ := ristretto.NewCache(&ristretto.Config[string, *idTokenCacheContainer]{
-		NumCounters: 10000,
-		MaxCost:     1 << 25,
-		BufferItems: 64,
-	})
-	return &MutatorIDToken{r: r, c: c, templates: x.NewTemplate("id_token"), tokenCache: cache, tokenCacheEnabled: true}
+	return &MutatorIDToken{r: r, c: c, templates: x.NewTemplate("id_token")}
 }
 
 func (a *MutatorIDToken) GetID() string {
@@ -68,10 +68,6 @@ func (a *MutatorIDToken) GetID() string {
 
 func (a *MutatorIDToken) WithCache(t *template.Template) {
 	a.templates = t
-}
-
-func (a *MutatorIDToken) SetCaching(token bool) {
-	a.tokenCacheEnabled = token
 }
 
 type idTokenCacheContainer struct {
@@ -86,7 +82,7 @@ func (a *MutatorIDToken) cacheKey(config *CredentialsIDTokenConfig, ttl time.Dur
 }
 
 func (a *MutatorIDToken) tokenFromCache(config *CredentialsIDTokenConfig, session *authn.AuthenticationSession, claims []byte, ttl time.Duration) (string, bool) {
-	if !a.tokenCacheEnabled {
+	if !config.Cache.Enabled {
 		return "", false
 	}
 
@@ -106,7 +102,7 @@ func (a *MutatorIDToken) tokenFromCache(config *CredentialsIDTokenConfig, sessio
 }
 
 func (a *MutatorIDToken) tokenToCache(config *CredentialsIDTokenConfig, session *authn.AuthenticationSession, claims []byte, ttl time.Duration, expiresAt time.Time, token string) {
-	if !a.tokenCacheEnabled {
+	if !config.Cache.Enabled {
 		return
 	}
 
@@ -197,13 +193,43 @@ func (a *MutatorIDToken) Validate(config json.RawMessage) error {
 }
 
 func (a *MutatorIDToken) Config(config json.RawMessage) (*CredentialsIDTokenConfig, error) {
-	var c CredentialsIDTokenConfig
+	c := CredentialsIDTokenConfig{
+		Cache: IdTokenCacheConfig{
+			Enabled: true, // default to true
+		},
+	}
 	if err := a.c.MutatorConfig(a.GetID(), config, &c); err != nil {
 		return nil, NewErrMutatorMisconfigured(a, err)
 	}
 
 	if c.TTL == "" {
 		c.TTL = "15m"
+	}
+
+	cost := int64(c.Cache.MaxCost)
+	if cost == 0 {
+		cost = 1 << 25
+	}
+
+	if a.tokenCache == nil || a.tokenCache.MaxCost() != cost {
+		// NumCounters is approx. 10× the estimated number of items.
+		// One item is approx. 1000 bytes (typical JWT length), so items should be cost/1000.
+		numCounters := cost / 1000 * 10
+		if numCounters < 1000 {
+			numCounters = 1000
+		}
+		cache, err := ristretto.NewCache(&ristretto.Config[string, *idTokenCacheContainer]{
+			NumCounters: numCounters,
+			MaxCost:     cost,
+			BufferItems: 64,
+			Cost: func(container *idTokenCacheContainer) int64 {
+				return int64(len(container.Token))
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		a.tokenCache = cache
 	}
 
 	return &c, nil

--- a/spec/config.schema.json
+++ b/spec/config.schema.json
@@ -1140,6 +1140,25 @@
           "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
           "default": "15m",
           "examples": ["1h", "1m", "30s"]
+        },
+        "cache": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enabled",
+              "type": "boolean",
+              "default": true,
+              "examples": [false, true],
+              "description": "En-/disables this component."
+            },
+            "max_cost": {
+              "type": "integer",
+              "default": 33554432,
+              "title": "Maximum Cached Cost",
+              "description": "The cost of one cached JSON Web Token is the length of its string form."
+            }
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Make the `id_token` mutator cache configurable:
- can be enabled/disabled
- can set the `max_cost`

Changes to default configuration:
Previous:
- NumCounters: 10000
- MaxCost: 1 << 25

New:
- NumCounters: maxCost * 10
- MaxCost: 1 << 25
- Cost function: JWT length

## Related issue(s)

Follow up of https://github.com/ory/oathkeeper/pull/1171 and https://github.com/ory/oathkeeper/pull/1209 (and https://github.com/ory/oathkeeper/pull/1210 too a bit).

Related docs PR: https://github.com/ory/docs/pull/1820

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

Could probably be subject to a minor version bump, since there's a behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-rule configurable caching for ID token generation.
  * Cache options include an enable/disable toggle (default: enabled) and a max_cost parameter (default: 33554432) to control memory usage.
* **Tests**
  * Tests and benchmarks updated to cover cache enabled/disabled behavior and max_cost eviction scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/oathkeeper/pull/1177)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->