### PR TITLE
Ensure `bearer_token` Respects `token_from`

### DIFF
--- a/middleware/grpc_middleware_test.go
+++ b/middleware/grpc_middleware_test.go
@@ -50,7 +50,7 @@ func testClient(t *testing.T, l *bufconn.Listener, dialOpts ...grpc.DialOption) 
 func testTokenCheckServer(t *testing.T) *httptest.Server {
 	s := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			if r.Header.Get("authorization") != "Bearer correct token" {
+			if r.Header.Get("Authorization") != "bearer correct token" {
 				t.Logf("denied request %+v", r)
 				w.WriteHeader(http.StatusForbidden)
 				return
@@ -77,7 +77,7 @@ func writeTestConfig(t *testing.T, pattern string, content string) string {
 type testToken string
 
 func (t testToken) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
-	return map[string]string{"authorization": "Bearer " + string(t)}, nil
+	return map[string]string{"Authorization": "bearer " + string(t)}, nil
 }
 func (t testToken) RequireTransportSecurity() bool { return false }
 

--- a/pipeline/authn/authenticator_bearer_token.go
+++ b/pipeline/authn/authenticator_bearer_token.go
@@ -141,6 +141,11 @@ func (a *AuthenticatorBearerToken) Authenticate(r *http.Request, session *Authen
 		return errors.WithStack(ErrAuthenticatorNotResponsible)
 	}
 
+	if r.Header == nil {
+		r.Header = make(http.Header)
+	}
+	r.Header.Set("Authorization", "bearer "+token)
+
 	body, err := forwardRequestToSessionStore(a.client, r, cf)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## The Problem

The `bearer_token` authenticator always returns 401 when providing any `token_from` option. The reason is because the token is indeed detected, and therefore the authenticator is deemed responsible, but the token is not actually passed forward to the session store in the `Authorization` header as the instructions [here](https://www.ory.sh/docs/identities/sign-in/check-session-token-cookie-api) and [here](https://www.ory.sh/docs/reference/api#tag/frontend/operation/exchangeSessionToken) say should be done.

The only exception when it does work is when using the default `Authorization: bearer <session-token>` option (i.e, not specifying `token_from at all), because the `Authorization` header is forwarded anyways as you can see here:

https://github.com/ory/oathkeeper/blob/acb258466eba7dd9900ea37a42e8bf98ec59a591/pipeline/authn/authenticator_bearer_token.go#L124


This PR fixes that by making sure to set `Authorization: bearer <token>` for the request going to the sessions store if a token is detected.


## Is It Breaking?

No, it should not be.


## Related issue(s)

#1144 


## Checklist


- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
