### PR TITLE
fix: memory leak in id_token mutator cache

### DIFF
--- a/pipeline/mutate/mutator_id_token.go
+++ b/pipeline/mutate/mutator_id_token.go
@@ -112,11 +112,16 @@ func (a *MutatorIDToken) tokenToCache(config *CredentialsIDTokenConfig, session 
 	}
 
 	key := a.cacheKey(config, ttl, claims, session)
-	a.tokenCache.Set(key, &idTokenCacheContainer{
-		TTL:       ttl,
-		ExpiresAt: expiresAt,
-		Token:     token,
-	}, 0)
+	a.tokenCache.SetWithTTL(
+		key,
+		&idTokenCacheContainer{
+			TTL:       ttl,
+			ExpiresAt: expiresAt,
+			Token:     token,
+		},
+		0,
+		ttl,
+	)
 }
 
 func (a *MutatorIDToken) Mutate(r *http.Request, session *authn.AuthenticationSession, config json.RawMessage, rl pipeline.Rule) error {


### PR DESCRIPTION
Set a TTL on the cached JWTs in the `id_token` mutator.
It fixes a memory leak in Oathkeeper 🙌 

We are running internally a fork of Oathkeeper with this patch applied, and the resulting memory footprint:
![image](https://github.com/user-attachments/assets/bb374abb-b680-49a2-addf-54b5c8fecc9b)

Unsure how to properly test it properly in a unit test though, since the `getFromCache` logic also checks if the cached TTL value is not expired (and not only the new ristretto internal TTL).

## Related issue(s)

Split from https://github.com/ory/oathkeeper/pull/1177.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
