### PR TITLE
chore: remove unused cached TTL value in id_token mutator

### DIFF
--- a/pipeline/mutate/mutator_id_token.go
+++ b/pipeline/mutate/mutator_id_token.go
@@ -76,7 +76,6 @@ func (a *MutatorIDToken) SetCaching(token bool) {
 
 type idTokenCacheContainer struct {
 	ExpiresAt time.Time
-	TTL       time.Duration
 	Token     string
 }
 
@@ -115,7 +114,6 @@ func (a *MutatorIDToken) tokenToCache(config *CredentialsIDTokenConfig, session 
 	a.tokenCache.SetWithTTL(
 		key,
 		&idTokenCacheContainer{
-			TTL:       ttl,
 			ExpiresAt: expiresAt,
 			Token:     token,
 		},


### PR DESCRIPTION
It would seem that the TTL value stored in the `id_token` mutator cache is unused.

For backward compatibility, we should be fine since this is an in-memory cache. And therefore it is flushed when bumping Oathkeeper version.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
