### PR TITLE
feat: consider nginx original header on decision api

### DIFF
--- a/api/decision_test.go
+++ b/api/decision_test.go
@@ -396,7 +396,7 @@ func TestDecisionAPIHeaderUsage(t *testing.T) {
 			},
 		},
 		{
-			name:           "all arguments are taken from the headers",
+			name:           "all arguments are taken from the `forwarded` headers",
 			expectedUrl:    &url.URL{Scheme: "https", Host: "test.dev", Path: "/bar"},
 			expectedMethod: "POST",
 			transform: func(req *http.Request) {
@@ -407,7 +407,16 @@ func TestDecisionAPIHeaderUsage(t *testing.T) {
 			},
 		},
 		{
-			name:           "argument from the headers doesn't get url encoded",
+			name:           "all arguments are taken from the `original` headers",
+			expectedUrl:    &url.URL{Scheme: "https", Host: "test.dev", Path: "/bar"},
+			expectedMethod: "POST",
+			transform: func(req *http.Request) {
+				req.Header.Add("X-Original-Method", "POST")
+				req.Header.Add("X-Original-Url", "https://test.dev/bar")
+			},
+		},
+		{
+			name:           "argument from the `forwarded` headers doesn't get url encoded",
 			expectedUrl:    &url.URL{Scheme: "https", Host: "test.dev", Path: "/bar"},
 			expectedMethod: "POST",
 			transform: func(req *http.Request) {
@@ -418,11 +427,29 @@ func TestDecisionAPIHeaderUsage(t *testing.T) {
 			},
 		},
 		{
+			name:           "argument from the `original` headers doesn't get url encoded",
+			expectedUrl:    &url.URL{Scheme: "https", Host: "test.dev", Path: "/bar"},
+			expectedMethod: "POST",
+			transform: func(req *http.Request) {
+				req.Header.Add("X-Original-Method", "POST")
+				req.Header.Add("X-Original-Url", "https://test.dev/bar?this=is&a=test")
+			},
+		},
+		{
 			name:           "only scheme is taken from the headers",
 			expectedUrl:    &url.URL{Scheme: "https", Host: defaultUrl.Host, Path: defaultUrl.Path},
 			expectedMethod: defaultMethod,
 			transform: func(req *http.Request) {
 				req.Header.Add("X-Forwarded-Proto", "https")
+			},
+		},
+		{
+			name:           "scheme is taken from the `forwarded` headers and url from `original` headers",
+			expectedUrl:    &url.URL{Scheme: "https", Host: defaultUrl.Host, Path: defaultUrl.Path},
+			expectedMethod: defaultMethod,
+			transform: func(req *http.Request) {
+				req.Header.Add("X-Forwarded-Proto", "https")
+				req.Header.Add("X-Original-Url", "https://test.dev/bar")
 			},
 		},
 		{


### PR DESCRIPTION
Currently, only `x-forwarded-*` headers are used for original host extraction in decision api.
Nginx defaults to `x-origin-*` deployed as ingress. This PR does also check the default nginx headers.

Locally, tests are failing because I dont have azure credentials.

## Related issue(s)

closes #521

## Checklist

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).