### PR TITLE
feat: add configurable header redaction for logs

### DIFF
--- a/driver/configuration/config_keys.go
+++ b/driver/configuration/config_keys.go
@@ -81,3 +81,8 @@ const (
 	ErrorsRedirectIsEnabled        Key = ErrorsHandlers + ".redirect.enabled"
 	ErrorsWWWAuthenticateIsEnabled Key = ErrorsHandlers + ".www_authenticate.enabled"
 )
+
+// Log
+const (
+	LogRedactHeaders Key = "log.redact_headers"
+)

--- a/driver/configuration/provider.go
+++ b/driver/configuration/provider.go
@@ -79,6 +79,8 @@ type Provider interface {
 
 	TLSConfig(daemon string) *TLSConfig
 
+	LogRedactHeaders() []string
+
 	SetForTest(t testing.TB, key string, value interface{})
 }
 

--- a/driver/configuration/provider_koanf.go
+++ b/driver/configuration/provider_koanf.go
@@ -435,6 +435,10 @@ func (v *KoanfProvider) TracingConfig() *otelx.Config {
 	return v.source.TracingConfig(v.TracingServiceName())
 }
 
+func (v *KoanfProvider) LogRedactHeaders() []string {
+	return v.source.StringsF(LogRedactHeaders, []string{})
+}
+
 func (v *KoanfProvider) PrometheusHideRequestPaths() bool {
 	return v.source.BoolF(PrometheusServeHideRequestPaths, false)
 }

--- a/driver/configuration/testdata/log_redact_headers_config.yaml
+++ b/driver/configuration/testdata/log_redact_headers_config.yaml
@@ -1,0 +1,4 @@
+log:
+  redact_headers:
+    - x-custom-authorization
+    - x-api-key

--- a/driver/registry_memory.go
+++ b/driver/registry_memory.go
@@ -177,7 +177,7 @@ func (r *RegistryMemory) Writer() herodot.Writer {
 
 func (r *RegistryMemory) Logger() *logrusx.Logger {
 	if r.logger == nil {
-		r.logger = logrusx.New("ORY Oathkeeper", x.Version)
+		r.logger = logrusx.New("ORY Oathkeeper", x.Version, logrusx.WithAdditionalRedactedHeaders(r.c.LogRedactHeaders()))
 	}
 	return r.logger
 }


### PR DESCRIPTION
When configuring oathkeeper to use a non standard auth header (such as `token_from` in the jwt authenticator), oathkeeper currently logs these tokens in plain text when configured at log level `INFO` or above. There is no way currently to append additional headers to the default list of redacted headers.

I considered implementing a matcher for some of these fields, but went with a more generic solution that allows the user to choose which arbitrary headers to redact from logging.

Add support for log.redact_headers configuration option to redact additional sensitive headers beyond the defaults (authorization, cookie, set-cookie, x-session-token). Headers specified in this configuration will have their values masked in log output.

Example configuration
```
log:
  redact_headers:
    - x-custom-authorization
    - x-api-key
```

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
