### PR TITLE
fix: preserve semicolon-separated query parameters in proxy requests

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -130,7 +130,7 @@ func (d *Proxy) Rewrite(r *httputil.ProxyRequest) {
 	// maintain transparency and pass through the original query parameters to allow backends
 	// to handle them according to their own validation rules.
 	r.Out.URL.RawQuery = r.In.URL.RawQuery
-	
+
 	rl, err := d.r.RuleMatcher().Match(r.Out.Context(), r.Out.Method, r.Out.URL, rule.ProtocolHTTP)
 	if err != nil {
 		*r.Out = *r.Out.WithContext(context.WithValue(r.Out.Context(), director, err))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -123,6 +123,14 @@ func (d *Proxy) Rewrite(r *httputil.ProxyRequest) {
 	}
 
 	EnrichRequestedURL(r)
+
+	// Preserve the original query string from the incoming request. Go's httputil.ReverseProxy
+	// calls cleanQueryParams which drops semicolon-separated parameters (e.g. "a=b;c=d") as
+	// they are considered invalid per RFC 3986. However, as an identity proxy, we need to
+	// maintain transparency and pass through the original query parameters to allow backends
+	// to handle them according to their own validation rules.
+	r.Out.URL.RawQuery = r.In.URL.RawQuery
+	
 	rl, err := d.r.RuleMatcher().Match(r.Out.Context(), r.Out.Method, r.Out.URL, rule.ProtocolHTTP)
 	if err != nil {
 		*r.Out = *r.Out.WithContext(context.WithValue(r.Out.Context(), director, err))

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -394,6 +394,50 @@ func TestProxy(t *testing.T) {
 				r.Header.Set("Connection", "x-arbitrary")
 			},
 		},
+		{
+			d:           "should preserve semicolons in query strings",
+			url:         ts.URL + "/authn-noop/1234?a=b;c=d",
+			rulesRegexp: []rule.Rule{ruleNoOpAuthenticator},
+			rulesGlob:   []rule.Rule{ruleNoOpAuthenticatorGlob},
+			code:        http.StatusOK,
+			messages: []string{
+				"url=/authn-noop/1234?a=b;c=d",
+				"host=" + x.ParseURLOrPanic(backend.URL).Host,
+			},
+		},
+		{
+			d:           "should preserve complex semicolon query strings",
+			url:         ts.URL + "/authn-noop/1234?param1=value1;param2=value2;param3=value3&normal=param",
+			rulesRegexp: []rule.Rule{ruleNoOpAuthenticator},
+			rulesGlob:   []rule.Rule{ruleNoOpAuthenticatorGlob},
+			code:        http.StatusOK,
+			messages: []string{
+				"url=/authn-noop/1234?param1=value1;param2=value2;param3=value3&normal=param",
+				"host=" + x.ParseURLOrPanic(backend.URL).Host,
+			},
+		},
+		{
+			d:           "should preserve trailing semicolon in query strings",
+			url:         ts.URL + "/authn-noop/1234?a=b;",
+			rulesRegexp: []rule.Rule{ruleNoOpAuthenticator},
+			rulesGlob:   []rule.Rule{ruleNoOpAuthenticatorGlob},
+			code:        http.StatusOK,
+			messages: []string{
+				"url=/authn-noop/1234?a=b;",
+				"host=" + x.ParseURLOrPanic(backend.URL).Host,
+			},
+		},
+		{
+			d:           "should preserve URL encoded semicolons in query strings",
+			url:         ts.URL + "/authn-noop/1234?data=value%3Bseparated",
+			rulesRegexp: []rule.Rule{ruleNoOpAuthenticator},
+			rulesGlob:   []rule.Rule{ruleNoOpAuthenticatorGlob},
+			code:        http.StatusOK,
+			messages: []string{
+				"url=/authn-noop/1234?data=value%3Bseparated",
+				"host=" + x.ParseURLOrPanic(backend.URL).Host,
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("description=%s", tc.d), func(t *testing.T) {
 			testFunc := func(t *testing.T, strategy configuration.MatchingStrategy, rules []rule.Rule) {


### PR DESCRIPTION
## Problem

Oathkeeper drops query parameters that use semicolon separators `(e.g., ?param1=value1;param2=value2)` when proxying requests to upstream services. This occurs because Go's `httputil.ReverseProxy` calls `cleanQueryParams(), which removes semicolon separators as they are considered invalid per RFC 3986.

This breaks compatibility with:
- Legacy(or not) systems that rely on semicolon-separated parameters
- Applications using semicolons for structured parameter encoding
- APIs that expect semicolon separators for specific functionality

## Root Cause
The issue originates in Go's standard library net/http/httputil.ReverseProxy.cleanQueryParams() function, which intentionally removes semicolon separators to enforce RFC 3986 compliance. While technically correct, this breaks transparent proxy behavior expected from an identity proxy like Oathkeeper.

## Solution
Preserve the original query string by setting `r.Out.URL.RawQuery = r.In.URL.RawQuery after Go's URL processing but before forwarding the request. This follows the pattern documented in Go's httputil.ReverseProxy.Rewrite function documentation for transparent proxies.

## Security Considerations
⚠️ Important Security Notice

As noted in [Go's httputil.ReverseProxy documentation](https://pkg.go.dev/net/http/httputil#ReverseProxy.Rewrite), preserving RawQuery "can lead to security issues if the proxy's interpretation of query parameters does not match that of the downstream server."

**Potential risks:**
- Parameter parsing differences between Oathkeeper and backend services could be exploited
- Malformed or malicious parameters might be interpreted differently by proxy vs. backend
- URL parsing inconsistencies could potentially bypass security controls

**Mitigation:**
Backend services should implement proper query parameter validation and sanitization
Operators should monitor for unusual query parameter patterns
Consider implementing additional query parameter filtering if required by your security policy

I believe this is is an inherent trade-off when operating as a transparent proxy: RFC compliance vs. real-world compatibility. The fix prioritizes transparency while requiring operators to ensure backend security.

## Related issue(s)
#1248 
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
