### PR TITLE
feat: ssrf allow CGNAT ip range for ipv4

### DIFF
--- a/oryx/httpx/ssrf.go
+++ b/oryx/httpx/ssrf.go
@@ -74,6 +74,7 @@ func init() {
 		ssrf.WithNetworks("tcp4", "tcp6"),
 		ssrf.WithAllowedV4Prefixes(
 			netip.MustParsePrefix("10.0.0.0/8"),     // Private-Use (RFC 1918)
+			netip.MustParsePrefix("100.64.0.0/10"),  // Shared Address Space (RFC 6598 - CGNAT)
 			netip.MustParsePrefix("127.0.0.0/8"),    // Loopback (RFC 1122, Section 3.2.1.3))
 			netip.MustParsePrefix("169.254.0.0/16"), // Link Local (RFC 3927)
 			netip.MustParsePrefix("172.16.0.0/12"),  // Private-Use (RFC 1918)
@@ -94,6 +95,7 @@ func init() {
 		ssrf.WithNetworks("tcp4"),
 		ssrf.WithAllowedV4Prefixes(
 			netip.MustParsePrefix("10.0.0.0/8"),     // Private-Use (RFC 1918)
+			netip.MustParsePrefix("100.64.0.0/10"),  // Shared Address Space (RFC 6598 - CGNAT)
 			netip.MustParsePrefix("127.0.0.0/8"),    // Loopback (RFC 1122, Section 3.2.1.3))
 			netip.MustParsePrefix("169.254.0.0/16"), // Link Local (RFC 3927)
 			netip.MustParsePrefix("172.16.0.0/12"),  // Private-Use (RFC 1918)


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
# Add CGNAT IP Range Support to SSRF Protection
## Summary
This PR adds support for the CGNAT (Carrier-Grade NAT) IP address range 100.64.0.0/10 to the SSRF protection mechanisms in the HTTP client transports. This enables Oathkeeper to work correctly in environments using Carrier-Grade NAT infrastructure.

## Background
CGNAT (Carrier-Grade NAT) uses the shared address space 100.64.0.0/10 as defined in [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598). This address space is used by ISPs and organizations for internal network infrastructure when traditional private address space (RFC 1918) is insufficient or already allocated.

The CGNAT range was missing from the allowed internal IP prefixes, causing issues when Oathkeeper needs to communicate with services in CGNAT environments.

In our case, access to one of our mutators, that resides on the same Kubernetes cluster as our Oathkeeper Pod, was declined as the `100.64.0.0/10` is used by the Calico CNI. This IP range should NOT be publicly exposed as per the RFC.

## Changes
Added 100.64.0.0/10 to the allowed IPv4 prefixes in both HTTP transport configurations:
[allowInternalAllowIPv6](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) transport (supports both IPv4 and IPv6)
IPv4-only transport configuration

## Impact
This is a non-breaking enhancement that is user transparent; thus, I do not see a need for the design document

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.com/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [n/a] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
Change is minimal, I did not see a reason to create the design document. 

Furthermore, no tests exist for this part of the code - that is why I did not add any (correct me if I am wrong).

IMO comments are telling enough. As this is not a customer-facing change I do not see where to document it better.