### PR TITLE
fix: preserve query string from X-Forwarded-Uri in decision handler

### DIFF
--- a/api/decision.go
+++ b/api/decision.go
@@ -71,7 +71,15 @@ func (h *DecisionHandler) Decisions(w http.ResponseWriter, r *http.Request) {
 	r.URL.Scheme = cmp.Or(r.Header.Get(xForwardedProto),
 		x.IfThenElseString(r.TLS != nil, "https", "http"))
 	r.URL.Host = cmp.Or(r.Header.Get(xForwardedHost), r.Host)
-	r.URL.Path = cmp.Or(strings.SplitN(r.Header.Get(xForwardedUri), "?", 2)[0], r.URL.Path[len(DecisionPath):])
+	if fwdUri := r.Header.Get(xForwardedUri); fwdUri != "" {
+		parts := strings.SplitN(fwdUri, "?", 2)
+		r.URL.Path = parts[0]
+		if len(parts) == 2 {
+			r.URL.RawQuery = parts[1]
+		}
+	} else {
+		r.URL.Path = r.URL.Path[len(DecisionPath):]
+	}
 
 	fields := map[string]interface{}{
 		"http_method":     r.Method,

--- a/api/decision_test.go
+++ b/api/decision_test.go
@@ -323,6 +323,32 @@ func TestDecisionAPI(t *testing.T) {
 			code: http.StatusOK,
 		},
 		{
+			d:   "should pass when X-Forwarded-Uri contains a query string",
+			url: ts.URL + "/decisions",
+			rulesRegexp: []rule.Rule{{
+				Match:          &rule.Match{Methods: []string{"GET"}, URL: ts.URL + "/authn-noop/<[0-9]+>"},
+				Authenticators: []rule.Handler{{Handler: "noop"}},
+				Authorizer:     rule.Handler{Handler: "allow"},
+				Mutators:       []rule.Handler{{Handler: "noop"}},
+				Upstream:       rule.Upstream{URL: ""},
+			}},
+			rulesGlob: []rule.Rule{{
+				Match:          &rule.Match{Methods: []string{"GET"}, URL: ts.URL + "/authn-noop/<[0-9]*>"},
+				Authenticators: []rule.Handler{{Handler: "noop"}},
+				Authorizer:     rule.Handler{Handler: "allow"},
+				Mutators:       []rule.Handler{{Handler: "noop"}},
+				Upstream:       rule.Upstream{URL: ""},
+			}},
+			transform: func(r *http.Request) {
+				r.Header.Set("X-Forwarded-Method", "GET")
+				r.Header.Set("X-Forwarded-Proto", "http")
+				r.Header.Set("X-Forwarded-Host", r.URL.Host)
+				r.Header.Set("X-Forwarded-Uri", "/authn-noop/1234?foo=bar")
+			},
+			code:  http.StatusOK,
+			authz: "",
+		},
+		{
 			d:   "path is empty after being stripped",
 			url: ts.URL + "/decisions",
 			rulesRegexp: []rule.Rule{{
@@ -454,7 +480,7 @@ func TestDecisionAPIHeaderUsage(t *testing.T) {
 		},
 		{
 			name:           "argument from the headers doesn't get url encoded",
-			expectedUrl:    &url.URL{Scheme: "https", Host: "test.dev", Path: "/bar"},
+			expectedUrl:    &url.URL{Scheme: "https", Host: "test.dev", Path: "/bar", RawQuery: "this=is&a=test"},
 			expectedMethod: "POST",
 			transform: func(req *http.Request) {
 				req.Header.Add("X-Forwarded-Method", "POST")


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

This PR sets the `r.URL.RawQuery` to a potential query string provided within the `X-Forwarded-Uri` header. This was dropped in an earlier version because including it in the path broke the URL matcher, but fully stripping the query string breaks authenticator that rely on query parameters.

## Related issue(s)

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.com/chat).
-->

#1264

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper handling of query parameters in forwarded URIs, ensuring they are now correctly preserved during request processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/oathkeeper/pull/1265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->