### PR TITLE
fix: don't remove trailing slash when using path.Clean and path.Join

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -215,6 +215,11 @@ func ConfigureBackendURL(r *http.Request, rl *rule.Rule) error {
 	forwardURL.Host = backendHost
 	forwardURL.Path = path.Join(backendPath, proxyPath)
 
+	// path.Join removes trailing slash
+	if forwardURL.Path != "/" && strings.HasSuffix(proxyPath, "/") {
+		forwardURL.Path += "/"
+	}
+
 	if rl.Upstream.StripPath != "" {
 		forwardURL.Path = strings.Replace(forwardURL.Path, "/"+strings.Trim(rl.Upstream.StripPath, "/"), "", 1)
 	}

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/ory/herodot"
 	"github.com/ory/x/errorsx"
@@ -333,7 +334,13 @@ func (d *requestHandler) InitializeAuthnSession(r *http.Request, rl *rule.Rule) 
 	}
 
 	if r.URL.Path != "" {
+		hasSlash := strings.HasSuffix(r.URL.Path, "/")
 		r.URL.Path = path.Clean(r.URL.Path)
+
+		// path.Clean removes trailing slash
+		if r.URL.Path != "/" && hasSlash {
+			r.URL.Path += "/"
+		}
 	}
 
 	values, err := rl.ExtractRegexGroups(d.c.AccessRuleMatchingStrategy(), r.URL)

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -220,7 +220,13 @@ func (r *Rule) IsMatching(strategy configuration.MatchingStrategy, method string
 	}
 
 	if u.Path != "" {
+		hasSlash := strings.HasSuffix(u.Path, "/")
 		u.Path = path.Clean(u.Path)
+
+		// path.Clean removes trailing slash
+		if u.Path != "/" && hasSlash {
+			u.Path += "/"
+		}
 	}
 	matchAgainst := fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Path)
 	return r.matchingEngine.IsMatching(r.Match.GetURL(), matchAgainst)


### PR DESCRIPTION
`path.Join` and `path.Clean` remove trailing slashes. This is an issue when the upstream server expects them to be contained in the URL path. 

Example:
Upstream expects: `http://host/path/1/`
Client does request to  `http://host/path/1/` but Oathkeeper modifies the path to  `http://host/path/1`.

With this PR, trailing slashes are added after using the two functions, if a trailing slash existed before.

## Related issue(s)
 #1266 


## Checklist

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [ x] I have read the [security policy](../security/policy).
- [ ]x I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.com](mailto:security@ory.com)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments
Tested locally.