### PR TITLE
feat: forward request headers to remote authorizer

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -960,6 +960,16 @@
             "type": "string"
           }
         },
+        "forward_request_headers_to_remote": {
+          "description": "A list of inbound request headers to forward to the remote authorizer.",
+          "title": "Allowed Inbound HTTP Headers to Forward to the Remote",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "default": []
+        },
         "forward_response_headers_to_upstream": {
           "description": "A list of non simple headers the remote is allowed to return to mutate requests.",
           "title": "Allowed Remote HTTP Headers for his Responses",

--- a/pipeline/authz/remote.go
+++ b/pipeline/authz/remote.go
@@ -31,6 +31,7 @@ import (
 type AuthorizerRemoteConfiguration struct {
 	Remote                           string                              `json:"remote"`
 	Headers                          map[string]string                   `json:"headers"`
+	ForwardRequestHeadersToRemote    []string                            `json:"forward_request_headers_to_remote"`
 	ForwardResponseHeadersToUpstream []string                            `json:"forward_response_headers_to_upstream"`
 	Retry                            *AuthorizerRemoteRetryConfiguration `json:"retry"`
 }
@@ -85,6 +86,16 @@ func (a *AuthorizerRemote) Authorize(r *http.Request, session *authn.Authenticat
 	req, err := http.NewRequestWithContext(ctx, "POST", c.Remote, read)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+	for _, name := range c.ForwardRequestHeadersToRemote {
+		values := r.Header.Values(name)
+		if len(values) == 0 {
+			continue
+		}
+		req.Header.Del(name)
+		for _, v := range values {
+			req.Header.Add(name, v)
+		}
 	}
 	req.Header.Add("Content-Type", r.Header.Get("Content-Type"))
 	authz := r.Header.Get("Authorization")

--- a/pipeline/authz/remote_test.go
+++ b/pipeline/authz/remote_test.go
@@ -37,6 +37,7 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 		setup              func(t *testing.T) *httptest.Server
 		session            *authn.AuthenticationSession
 		sessionHeaderMatch *http.Header
+		requestHeaders     http.Header
 		body               string
 		config             json.RawMessage
 		wantErr            bool
@@ -162,6 +163,24 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 			config:             json.RawMessage(`{"forward_response_headers_to_upstream":["X-Foo"]}`),
 		},
 		{
+			name: "ok with forwarded request headers",
+			setup: func(t *testing.T) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "sig-value", r.Header.Get("X-Signature"))
+					assert.Equal(t, "ts-value", r.Header.Get("X-Timestamp"))
+					assert.Empty(t, r.Header.Get("X-Not-Forwarded"))
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			session: &authn.AuthenticationSession{},
+			requestHeaders: http.Header{
+				"X-Signature":     {"sig-value"},
+				"X-Timestamp":     {"ts-value"},
+				"X-Not-Forwarded": {"nope"},
+			},
+			config: json.RawMessage(`{"forward_request_headers_to_remote":["X-Signature","X-Timestamp"]}`),
+		},
+		{
 			name: "authentication session",
 			setup: func(t *testing.T) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -200,6 +219,9 @@ func TestAuthorizerRemoteAuthorize(t *testing.T) {
 					"Content-Type": {"text/plain"},
 					"User-Agent":   {"Fancy Browser 5.1"},
 				},
+			}
+			for name, values := range tt.requestHeaders {
+				r.Header[name] = values
 			}
 			if tt.body != "" {
 				r.Body = io.NopCloser(strings.NewReader(tt.body))

--- a/spec/config.schema.json
+++ b/spec/config.schema.json
@@ -960,6 +960,16 @@
             "type": "string"
           }
         },
+        "forward_request_headers_to_remote": {
+          "description": "A list of inbound request headers to forward to the remote authorizer.",
+          "title": "Allowed Inbound HTTP Headers to Forward to the Remote",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "default": []
+        },
         "forward_response_headers_to_upstream": {
           "description": "A list of non simple headers the remote is allowed to return to mutate requests.",
           "title": "Allowed Remote HTTP Headers for his Responses",


### PR DESCRIPTION
Adds a `forward_request_headers_to_remote` config field on the `remote` authorizer. When set, listed headers are copied from the inbound request to the outbound request to the remote endpoint.

Useful for forwarding signature, timestamp, or nonce headers to an external verifier service. Mirrors the existing `forward_response_headers_to_upstream` field, in the request direction.

## Related issue(s)

#1270 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I am following the [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security vulnerability, I confirm that I got the approval (please contact [security@ory.com](mailto:security@ory.com)) from the maintainers to push the changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support to specify which incoming request headers should be forwarded to the remote authorizer endpoint. The feature is optional and defaults to an empty list.

* **Tests**
  * Added test coverage validating header forwarding behavior and header exclusion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->