### PR TITLE
proxy: preserve trailing slash through path.Join and strip_path

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -218,10 +218,18 @@ func ConfigureBackendURL(r *http.Request, rl *rule.Rule) error {
 	forwardURL := r.URL
 	forwardURL.Scheme = backendScheme
 	forwardURL.Host = backendHost
+	// path.Join strips a trailing slash, so remember whether the
+	// inbound request ended with one and put it back after we're done
+	// joining and stripping.
+	hadTrailingSlash := strings.HasSuffix(proxyPath, "/") && proxyPath != "/"
 	forwardURL.Path = path.Join(backendPath, proxyPath)
 
 	if rl.Upstream.StripPath != "" {
 		forwardURL.Path = strings.Replace(forwardURL.Path, "/"+strings.Trim(rl.Upstream.StripPath, "/"), "", 1)
+	}
+
+	if hadTrailingSlash && !strings.HasSuffix(forwardURL.Path, "/") {
+		forwardURL.Path += "/"
 	}
 
 	r.Host = backendHost

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -502,6 +502,20 @@ func TestConfigureBackendURL(t *testing.T) {
 			eURL:  "http://localhost:4000/users/1234",
 			eHost: "localhost:4000",
 		},
+		// #1266: trailing slash on the inbound path survives path.Join +
+		// strip_path.
+		{
+			r:     &http.Request{Host: "localhost:3000", URL: &url.URL{Path: "/some/path/", Scheme: "http"}},
+			rl:    &rule.Rule{Upstream: rule.Upstream{URL: "http://localhost:4000/", StripPath: "/some"}},
+			eURL:  "http://localhost:4000/path/",
+			eHost: "localhost:4000",
+		},
+		{
+			r:     &http.Request{Host: "localhost:3000", URL: &url.URL{Path: "/api/users/", Scheme: "http"}},
+			rl:    &rule.Rule{Upstream: rule.Upstream{URL: "http://localhost:4000/"}},
+			eURL:  "http://localhost:4000/api/users/",
+			eHost: "localhost:4000",
+		},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
 			require.NoError(t, proxy.ConfigureBackendURL(tc.r, tc.rl))


### PR DESCRIPTION
Closes #1266.

The switch to `path.Join` in `ConfigureBackendURL` drops a trailing slash from the proxied path. Combined with the existing `strip_path` `strings.Replace`, a request to `/some/path/` with `strip_path: /some` ended up at `/path` on the upstream instead of `/path/`.

Remember whether the inbound path had a trailing slash and add it back after the strip step. Two regression cases added to `TestConfigureBackendURL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where trailing slashes in request paths were not being preserved during URL forwarding.

* **Tests**
  * Added test cases to verify proper handling of trailing slash preservation in path configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/oathkeeper/pull/1272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->